### PR TITLE
feat: add capture diagnostics

### DIFF
--- a/Sources/CoreAudioTapProbe/ProbeMain.swift
+++ b/Sources/CoreAudioTapProbe/ProbeMain.swift
@@ -43,11 +43,22 @@ struct ProbeMain {
 
         let captureSession = AudioCaptureSession()
         let frameBuffer = captureSession.frameBuffer
+        let diagnosticsTracker = CaptureDiagnosticsTracker(target: target)
         defer {
             captureSession.stop()
         }
 
-        try captureSession.start(target: target)
+        do {
+            try captureSession.start(target: target)
+        } catch {
+            diagnosticsTracker.finish(endedReason: .captureFailed)
+            logDiagnostics(diagnosticsTracker.snapshot())
+            throw error
+        }
+        diagnosticsTracker.markRecording(
+            sampleRate: captureSession.outputSampleRate,
+            channelCount: captureSession.outputChannelCount
+        )
 
         log("Capture started target=\(target.displayName)")
 
@@ -85,12 +96,20 @@ struct ProbeMain {
         if let recordingOutput {
             log("Recording audio to \(recordingOutput.wavURL.path)")
             log("Recording transcript to \(recordingOutput.transcriptURL.path)")
+            log("Recording diagnostics to \(recordingOutput.diagnosticsURL.path)")
         }
 
         let end = Date().addingTimeInterval(TimeInterval(options.seconds))
         while Date() < end {
             try await Task.sleep(nanoseconds: 250_000_000)
+            let bufferBacklog = frameBuffer.count
+            let droppedFrameCount = frameBuffer.droppedFrameCount
             let frames = frameBuffer.drain()
+            diagnosticsTracker.record(
+                frames: frames,
+                bufferBacklog: bufferBacklog,
+                droppedFrameCount: droppedFrameCount
+            )
             if frames.isEmpty {
                 log("level=idle frames=0")
                 continue
@@ -110,6 +129,12 @@ struct ProbeMain {
 
         try writer?.close()
         transcriber?.finish()
+        diagnosticsTracker.finish(endedReason: .saved)
+        let diagnostics = diagnosticsTracker.snapshot()
+        if let recordingOutput {
+            try diagnostics.write(to: recordingOutput.diagnosticsURL)
+        }
+        logDiagnostics(diagnostics)
         log("Capture stopped")
     }
 
@@ -131,5 +156,16 @@ struct ProbeMain {
     private static func log(_ message: String) {
         print(message)
         fflush(stdout)
+    }
+
+    private static func logDiagnostics(_ diagnostics: CaptureDiagnostics) {
+        log(
+            "diagnostics status=\(diagnostics.status.rawValue) " +
+                "framesCaptured=\(diagnostics.framesCaptured) " +
+                "durationSeconds=\(String(format: "%.3f", diagnostics.durationSeconds)) " +
+                "averageLevel=\(String(format: "%.4f", diagnostics.averageLevel)) " +
+                "peakLevel=\(String(format: "%.4f", diagnostics.peakLevel)) " +
+                "droppedFrameCount=\(diagnostics.droppedFrameCount)"
+        )
     }
 }

--- a/Sources/MeetingAgentCore/AudioFrameRingBuffer.swift
+++ b/Sources/MeetingAgentCore/AudioFrameRingBuffer.swift
@@ -4,6 +4,7 @@ public final class AudioFrameRingBuffer {
     private let lock = NSLock()
     private let capacity: Int
     private var frames: [AudioFrame] = []
+    private var droppedFrames = 0
 
     public init(capacity: Int) {
         self.capacity = max(1, capacity)
@@ -15,7 +16,9 @@ public final class AudioFrameRingBuffer {
 
         frames.append(frame)
         if frames.count > capacity {
-            frames.removeFirst(frames.count - capacity)
+            let overflow = frames.count - capacity
+            frames.removeFirst(overflow)
+            droppedFrames += overflow
         }
     }
 
@@ -26,5 +29,19 @@ public final class AudioFrameRingBuffer {
         let drained = frames
         frames.removeAll(keepingCapacity: true)
         return drained
+    }
+
+    public var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return frames.count
+    }
+
+    public var droppedFrameCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+
+        return droppedFrames
     }
 }

--- a/Sources/MeetingAgentCore/CaptureDiagnostics.swift
+++ b/Sources/MeetingAgentCore/CaptureDiagnostics.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+public enum CaptureEndedReason: String, Codable, Equatable {
+    case saved
+    case captureFailed
+    case targetProcessEnded
+}
+
+public enum CaptureStatus: String, Codable, Equatable {
+    case preparingCapture
+    case recording
+    case recordingNoAudioDetected
+    case recordingSilentAudio
+    case targetProcessEnded
+    case captureFailed
+    case recordingSaved
+}
+
+public struct CaptureDiagnostics: Codable, Equatable {
+    public let framesCaptured: Int
+    public let durationSeconds: Double
+    public let lastFrameAt: Date?
+    public let sampleRate: Double
+    public let channelCount: Int
+    public let averageLevel: Double
+    public let peakLevel: Double
+    public let silentDurationSeconds: Double
+    public let bufferBacklog: Int
+    public let droppedFrameCount: Int
+    public let targetProcessID: pid_t
+    public let targetDisplayName: String
+    public let endedReason: CaptureEndedReason?
+    public let status: CaptureStatus
+
+    public init(
+        framesCaptured: Int,
+        durationSeconds: Double,
+        lastFrameAt: Date?,
+        sampleRate: Double,
+        channelCount: Int,
+        averageLevel: Double,
+        peakLevel: Double,
+        silentDurationSeconds: Double,
+        bufferBacklog: Int,
+        droppedFrameCount: Int,
+        targetProcessID: pid_t,
+        targetDisplayName: String,
+        endedReason: CaptureEndedReason?,
+        status: CaptureStatus
+    ) {
+        self.framesCaptured = framesCaptured
+        self.durationSeconds = durationSeconds
+        self.lastFrameAt = lastFrameAt
+        self.sampleRate = sampleRate
+        self.channelCount = channelCount
+        self.averageLevel = averageLevel
+        self.peakLevel = peakLevel
+        self.silentDurationSeconds = silentDurationSeconds
+        self.bufferBacklog = bufferBacklog
+        self.droppedFrameCount = droppedFrameCount
+        self.targetProcessID = targetProcessID
+        self.targetDisplayName = targetDisplayName
+        self.endedReason = endedReason
+        self.status = status
+    }
+
+    public func write(to url: URL) throws {
+        let data = try JSONEncoder.meetingAgent.encode(self)
+        try data.write(to: url, options: .atomic)
+    }
+}
+
+public final class CaptureDiagnosticsTracker {
+    private static let silenceThreshold = 0.01
+
+    private let target: AudioCaptureTarget
+    private var framesCaptured = 0
+    private var durationSeconds = 0.0
+    private var lastFrameAt: Date?
+    private var sampleRate = 0.0
+    private var channelCount = 0
+    private var absoluteLevelSum = 0.0
+    private var sampleCount = 0
+    private var peakLevel = 0.0
+    private var silentDurationSeconds = 0.0
+    private var bufferBacklog = 0
+    private var droppedFrameCount = 0
+    private var endedReason: CaptureEndedReason?
+    private var status: CaptureStatus = .preparingCapture
+
+    public init(target: AudioCaptureTarget) {
+        self.target = target
+    }
+
+    public func markRecording(sampleRate: Double, channelCount: Int) {
+        self.sampleRate = sampleRate
+        self.channelCount = channelCount
+        status = .recording
+    }
+
+    public func record(
+        frames: [AudioFrame],
+        bufferBacklog: Int = 0,
+        droppedFrameCount: Int = 0
+    ) {
+        self.bufferBacklog = bufferBacklog
+        self.droppedFrameCount = droppedFrameCount
+
+        for frame in frames {
+            sampleRate = frame.sampleRate
+            channelCount = frame.channelCount
+            lastFrameAt = Date(timeIntervalSince1970: TimeInterval(frame.timestampNanos) / 1_000_000_000)
+
+            let levels = Self.levels(for: frame.pcm)
+            guard levels.sampleCount > 0, frame.sampleRate > 0 else { continue }
+
+            let sampleFrames = levels.sampleCount / max(1, frame.channelCount)
+            framesCaptured += sampleFrames
+            sampleCount += levels.sampleCount
+            absoluteLevelSum += levels.absoluteLevelSum
+            peakLevel = max(peakLevel, levels.peakLevel)
+
+            let frameDuration = Double(sampleFrames) / frame.sampleRate
+            durationSeconds += frameDuration
+            if levels.peakLevel <= Self.silenceThreshold {
+                silentDurationSeconds += frameDuration
+            }
+        }
+
+        if status == .preparingCapture {
+            status = .recording
+        }
+    }
+
+    public func finish(endedReason: CaptureEndedReason) {
+        guard self.endedReason == nil else { return }
+        self.endedReason = endedReason
+        switch endedReason {
+        case .captureFailed:
+            status = .captureFailed
+        case .targetProcessEnded:
+            status = .targetProcessEnded
+        case .saved:
+            if framesCaptured == 0 {
+                status = .recordingNoAudioDetected
+            } else if peakLevel <= Self.silenceThreshold {
+                status = .recordingSilentAudio
+            } else {
+                status = .recordingSaved
+            }
+        }
+    }
+
+    public func snapshot() -> CaptureDiagnostics {
+        CaptureDiagnostics(
+            framesCaptured: framesCaptured,
+            durationSeconds: durationSeconds,
+            lastFrameAt: lastFrameAt,
+            sampleRate: sampleRate,
+            channelCount: channelCount,
+            averageLevel: sampleCount == 0 ? 0 : absoluteLevelSum / Double(sampleCount),
+            peakLevel: peakLevel,
+            silentDurationSeconds: silentDurationSeconds,
+            bufferBacklog: bufferBacklog,
+            droppedFrameCount: droppedFrameCount,
+            targetProcessID: target.processID,
+            targetDisplayName: target.displayName,
+            endedReason: endedReason,
+            status: status
+        )
+    }
+
+    public var liveStatus: CaptureStatus {
+        if status == .recording, framesCaptured == 0 {
+            return .recordingNoAudioDetected
+        }
+        if status == .recording, framesCaptured > 0, peakLevel <= Self.silenceThreshold {
+            return .recordingSilentAudio
+        }
+        return status
+    }
+
+    private static func levels(for pcm: Data) -> (sampleCount: Int, absoluteLevelSum: Double, peakLevel: Double) {
+        let sampleCount = pcm.count / MemoryLayout<Int16>.size
+        guard sampleCount > 0 else {
+            return (0, 0, 0)
+        }
+
+        var absoluteLevelSum = 0.0
+        var peakLevel = 0.0
+        for index in 0..<sampleCount {
+            let byteOffset = index * MemoryLayout<Int16>.size
+            let value = pcm.withUnsafeBytes { rawBuffer in
+                rawBuffer.loadUnaligned(fromByteOffset: byteOffset, as: Int16.self)
+            }
+            let sample = Int16(littleEndian: value)
+            let level = min(1.0, Double(abs(Int(sample))) / 32_768.0)
+            absoluteLevelSum += level
+            peakLevel = max(peakLevel, level)
+        }
+
+        return (sampleCount, absoluteLevelSum, peakLevel)
+    }
+}

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -98,6 +98,7 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     public func drainRecordingFrames() {
         try? recorder.drainFrames()
+        updateRecordingStatus()
         objectWillChange.send()
     }
 
@@ -130,6 +131,26 @@ public final class MeetingAgentViewModel: ObservableObject {
         if case .recording = recorder.state { return true }
         if case .prepared = recorder.state { return true }
         return false
+    }
+
+    private func updateRecordingStatus() {
+        guard let activeTarget, let status = recorder.currentCaptureStatus else { return }
+        switch status {
+        case .preparingCapture:
+            statusText = "Preparing capture for \(activeTarget.displayName)"
+        case .recording:
+            statusText = "Recording \(activeTarget.displayName)"
+        case .recordingNoAudioDetected:
+            statusText = "Recording \(activeTarget.displayName), but no audio detected"
+        case .recordingSilentAudio:
+            statusText = "Recording silent audio from \(activeTarget.displayName)"
+        case .targetProcessEnded:
+            statusText = "Target process ended: \(activeTarget.displayName)"
+        case .captureFailed:
+            statusText = "Capture failed: \(activeTarget.displayName)"
+        case .recordingSaved:
+            statusText = "Recording saved: \(activeTarget.displayName)"
+        }
     }
 
     public var selectedMeeting: MeetingRecord? {

--- a/Sources/MeetingAgentCore/MeetingRecord.swift
+++ b/Sources/MeetingAgentCore/MeetingRecord.swift
@@ -7,6 +7,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
     public var endedAt: Date?
     public var audioURL: URL?
     public var transcriptURL: URL?
+    public var diagnosticsURL: URL?
 
     public init(
         id: UUID,
@@ -14,7 +15,8 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         startedAt: Date,
         endedAt: Date?,
         audioURL: URL?,
-        transcriptURL: URL?
+        transcriptURL: URL?,
+        diagnosticsURL: URL? = nil
     ) {
         self.id = id
         self.name = name
@@ -22,6 +24,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         self.endedAt = endedAt
         self.audioURL = audioURL
         self.transcriptURL = transcriptURL
+        self.diagnosticsURL = diagnosticsURL
     }
 }
 

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -12,6 +12,7 @@ public final class MeetingRecorder {
     private var captureSession: AudioCaptureSession?
     private var writer: WavFileWriter?
     private var transcriber: AudioFrameTranscriber?
+    private var diagnosticsTracker: CaptureDiagnosticsTracker?
 
     public private(set) var state: MeetingRecorderState = .idle
 
@@ -32,6 +33,7 @@ public final class MeetingRecorder {
             startedAt: startedAt
         )
         activeRecord = stored.record
+        diagnosticsTracker = CaptureDiagnosticsTracker(target: target)
         state = .prepared(stored.record.id)
         return stored.record
     }
@@ -47,8 +49,18 @@ public final class MeetingRecorder {
         }
 
         let session = AudioCaptureSession()
-        try session.start(target: target)
+        do {
+            try session.start(target: target)
+        } catch {
+            diagnosticsTracker?.finish(endedReason: .captureFailed)
+            try diagnosticsTracker?.snapshot().writeIfPossible(to: record.diagnosticsURL)
+            throw error
+        }
         captureSession = session
+        diagnosticsTracker?.markRecording(
+            sampleRate: session.outputSampleRate,
+            channelCount: session.outputChannelCount
+        )
 
         if let audioURL = record.audioURL {
             writer = try WavFileWriter(
@@ -60,10 +72,17 @@ public final class MeetingRecorder {
 
         if let transcriptURL = record.transcriptURL {
             let provider = SpeechTranscriptionProviderFactory.provider(for: speechProvider)
-            transcriber = try await provider.start(
-                transcriptURL: transcriptURL,
-                localeIdentifier: localeIdentifier
-            )
+            do {
+                transcriber = try await provider.start(
+                    transcriptURL: transcriptURL,
+                    localeIdentifier: localeIdentifier
+                )
+            } catch {
+                let transcriptWriter = try TranscriptFileWriter(url: transcriptURL)
+                try transcriptWriter.replace(with: "Speech recognition unavailable: \(error)")
+                try transcriptWriter.close()
+                transcriber = nil
+            }
         }
 
         state = .recording(record.id)
@@ -71,10 +90,23 @@ public final class MeetingRecorder {
 
     public func drainFrames() throws {
         guard let session = captureSession else { return }
+        let bufferBacklog = session.frameBuffer.count
+        let droppedFrameCount = session.frameBuffer.droppedFrameCount
         let frames = session.frameBuffer.drain()
+        diagnosticsTracker?.record(
+            frames: frames,
+            bufferBacklog: bufferBacklog,
+            droppedFrameCount: droppedFrameCount
+        )
         for frame in frames {
             try writer?.append(frame)
-            try transcriber?.append(frame)
+            do {
+                try transcriber?.append(frame)
+            } catch {
+                try persistTranscriptionFailure("Speech recognition failed: \(error)")
+                transcriber?.finish()
+                transcriber = nil
+            }
         }
     }
 
@@ -82,6 +114,7 @@ public final class MeetingRecorder {
         try writer?.close()
         transcriber?.finish()
         captureSession?.stop()
+        diagnosticsTracker?.finish(endedReason: .saved)
         writer = nil
         transcriber = nil
         captureSession = nil
@@ -95,9 +128,30 @@ public final class MeetingRecorder {
         }
 
         record.endedAt = endedAt
+        diagnosticsTracker?.finish(endedReason: .saved)
+        try diagnosticsTracker?.snapshot().writeIfPossible(to: record.diagnosticsURL)
+        diagnosticsTracker = nil
         try store.save(record)
         activeRecord = nil
         state = .idle
         return record
+    }
+
+    public var currentCaptureStatus: CaptureStatus? {
+        diagnosticsTracker?.liveStatus
+    }
+
+    private func persistTranscriptionFailure(_ message: String) throws {
+        guard let transcriptURL = activeRecord?.transcriptURL else { return }
+        let transcriptWriter = try TranscriptFileWriter(url: transcriptURL)
+        try transcriptWriter.replace(with: message)
+        try transcriptWriter.close()
+    }
+}
+
+private extension CaptureDiagnostics {
+    func writeIfPossible(to url: URL?) throws {
+        guard let url else { return }
+        try write(to: url)
     }
 }

--- a/Sources/MeetingAgentCore/MeetingStore.swift
+++ b/Sources/MeetingAgentCore/MeetingStore.swift
@@ -40,7 +40,8 @@ public final class MeetingStore {
             startedAt: startedAt,
             endedAt: nil,
             audioURL: directory.appendingPathComponent("audio.wav"),
-            transcriptURL: directory.appendingPathComponent("transcript.txt")
+            transcriptURL: directory.appendingPathComponent("transcript.txt"),
+            diagnosticsURL: directory.appendingPathComponent("diagnostics.json")
         )
         try save(record)
         return StoredMeeting(

--- a/Sources/MeetingAgentCore/RecordingOutput.swift
+++ b/Sources/MeetingAgentCore/RecordingOutput.swift
@@ -4,6 +4,7 @@ public struct RecordingOutput {
     public let directory: URL
     public let wavURL: URL
     public let transcriptURL: URL
+    public let diagnosticsURL: URL
 
     public static func defaultOutput(
         forRequestedWavPath wavPath: String,
@@ -21,10 +22,16 @@ public struct RecordingOutput {
         }
         let wavURL = directory.appendingPathComponent(wavName)
         let transcriptURL = wavURL.deletingPathExtension().appendingPathExtension("txt")
+        let diagnosticsURL = directory.appendingPathComponent("diagnostics.json")
 
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
 
-        return RecordingOutput(directory: directory, wavURL: wavURL, transcriptURL: transcriptURL)
+        return RecordingOutput(
+            directory: directory,
+            wavURL: wavURL,
+            transcriptURL: transcriptURL,
+            diagnosticsURL: diagnosticsURL
+        )
     }
 
     private static func timestampedWavName(timestamp: Date, timeZone: TimeZone) -> String {

--- a/Tests/MeetingAgentCoreTests/AudioFrameRingBufferTests.swift
+++ b/Tests/MeetingAgentCoreTests/AudioFrameRingBufferTests.swift
@@ -23,4 +23,18 @@ final class AudioFrameRingBufferTests: XCTestCase {
 
         XCTAssertEqual(buffer.drain().map(\.pcm), [Data([2]), Data([3])])
     }
+
+    func testReportsBacklogAndDroppedFrameCount() {
+        let buffer = AudioFrameRingBuffer(capacity: 2)
+
+        buffer.push(AudioFrame(pcm: Data([1]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1))
+        buffer.push(AudioFrame(pcm: Data([2]), sampleRate: 16_000, channelCount: 1, timestampNanos: 2))
+        buffer.push(AudioFrame(pcm: Data([3]), sampleRate: 16_000, channelCount: 1, timestampNanos: 3))
+
+        XCTAssertEqual(buffer.count, 2)
+        XCTAssertEqual(buffer.droppedFrameCount, 1)
+        _ = buffer.drain()
+        XCTAssertEqual(buffer.count, 0)
+        XCTAssertEqual(buffer.droppedFrameCount, 1)
+    }
 }

--- a/Tests/MeetingAgentCoreTests/CaptureDiagnosticsTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptureDiagnosticsTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class CaptureDiagnosticsTests: XCTestCase {
+    func testDiagnosticsSummarizeAudibleFrames() throws {
+        let tracker = CaptureDiagnosticsTracker(
+            target: AudioCaptureTarget(
+                processID: 42,
+                displayName: "Google Chrome",
+                bundleIdentifier: "com.google.Chrome"
+            )
+        )
+        let frame = AudioFrame(
+            pcm: int16PCM([-16_384, 0, 16_384]),
+            sampleRate: 48_000,
+            channelCount: 1,
+            timestampNanos: 1_000_000_000
+        )
+
+        tracker.record(frames: [frame], bufferBacklog: 3, droppedFrameCount: 2)
+        tracker.finish(endedReason: .saved)
+
+        let diagnostics = tracker.snapshot()
+        XCTAssertEqual(diagnostics.framesCaptured, 3)
+        XCTAssertEqual(diagnostics.durationSeconds, 3.0 / 48_000.0, accuracy: 0.000001)
+        XCTAssertEqual(diagnostics.lastFrameAt, Date(timeIntervalSince1970: 1))
+        XCTAssertEqual(diagnostics.sampleRate, 48_000)
+        XCTAssertEqual(diagnostics.channelCount, 1)
+        XCTAssertEqual(diagnostics.averageLevel, 1.0 / 3.0, accuracy: 0.0001)
+        XCTAssertEqual(diagnostics.peakLevel, 0.5, accuracy: 0.0001)
+        XCTAssertEqual(diagnostics.silentDurationSeconds, 0)
+        XCTAssertEqual(diagnostics.bufferBacklog, 3)
+        XCTAssertEqual(diagnostics.droppedFrameCount, 2)
+        XCTAssertEqual(diagnostics.targetProcessID, 42)
+        XCTAssertEqual(diagnostics.targetDisplayName, "Google Chrome")
+        XCTAssertEqual(diagnostics.endedReason, .saved)
+        XCTAssertEqual(diagnostics.status, .recordingSaved)
+    }
+
+    func testDiagnosticsMarkSilentCapturedAudio() {
+        let tracker = CaptureDiagnosticsTracker(
+            target: AudioCaptureTarget(
+                processID: 10,
+                displayName: "zoom.us",
+                bundleIdentifier: "us.zoom.xos"
+            )
+        )
+        let frame = AudioFrame(
+            pcm: int16PCM([0, 0, 0, 0]),
+            sampleRate: 8_000,
+            channelCount: 1,
+            timestampNanos: 2_000_000_000
+        )
+
+        tracker.record(frames: [frame])
+        tracker.finish(endedReason: .saved)
+
+        let diagnostics = tracker.snapshot()
+        XCTAssertEqual(diagnostics.framesCaptured, 4)
+        XCTAssertEqual(diagnostics.averageLevel, 0)
+        XCTAssertEqual(diagnostics.peakLevel, 0)
+        XCTAssertEqual(diagnostics.silentDurationSeconds, 4.0 / 8_000.0, accuracy: 0.000001)
+        XCTAssertEqual(diagnostics.status, .recordingSilentAudio)
+    }
+
+    func testDiagnosticsCountSampleFramesForStereoAudio() {
+        let tracker = CaptureDiagnosticsTracker(
+            target: AudioCaptureTarget(
+                processID: 12,
+                displayName: "FaceTime",
+                bundleIdentifier: "com.apple.FaceTime"
+            )
+        )
+        let frame = AudioFrame(
+            pcm: int16PCM([1_000, -1_000, 1_000, -1_000]),
+            sampleRate: 8_000,
+            channelCount: 2,
+            timestampNanos: 3_000_000_000
+        )
+
+        tracker.record(frames: [frame])
+
+        let diagnostics = tracker.snapshot()
+        XCTAssertEqual(diagnostics.framesCaptured, 2)
+        XCTAssertEqual(diagnostics.durationSeconds, 2.0 / 8_000.0, accuracy: 0.000001)
+    }
+
+
+    func testDiagnosticsMarkNoAudioDetectedWhenNoFramesArrive() {
+        let tracker = CaptureDiagnosticsTracker(
+            target: AudioCaptureTarget(
+                processID: 11,
+                displayName: "Microsoft Teams",
+                bundleIdentifier: "com.microsoft.teams2"
+            )
+        )
+
+        tracker.finish(endedReason: .saved)
+
+        let diagnostics = tracker.snapshot()
+        XCTAssertEqual(diagnostics.framesCaptured, 0)
+        XCTAssertEqual(diagnostics.durationSeconds, 0)
+        XCTAssertNil(diagnostics.lastFrameAt)
+        XCTAssertEqual(diagnostics.status, .recordingNoAudioDetected)
+    }
+
+    func testDiagnosticsCanBeSavedAsJSON() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("diagnostics-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let diagnostics = CaptureDiagnostics(
+            framesCaptured: 10,
+            durationSeconds: 0.1,
+            lastFrameAt: Date(timeIntervalSince1970: 3),
+            sampleRate: 48_000,
+            channelCount: 2,
+            averageLevel: 0.2,
+            peakLevel: 0.8,
+            silentDurationSeconds: 0,
+            bufferBacklog: 1,
+            droppedFrameCount: 0,
+            targetProcessID: 99,
+            targetDisplayName: "Google Chrome",
+            endedReason: .saved,
+            status: .recordingSaved
+        )
+
+        try diagnostics.write(to: url)
+
+        let data = try Data(contentsOf: url)
+        let decoded = try JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
+        XCTAssertEqual(decoded, diagnostics)
+    }
+
+    private func int16PCM(_ samples: [Int16]) -> Data {
+        var data = Data()
+        for sample in samples {
+            var littleEndian = sample.littleEndian
+            data.append(Data(bytes: &littleEndian, count: MemoryLayout<Int16>.size))
+        }
+        return data
+    }
+}

--- a/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
@@ -33,4 +33,21 @@ final class MeetingRecordTests: XCTestCase {
 
         XCTAssertNil(record.endedAt)
     }
+
+    func testDecodesMetadataWithoutDiagnosticsURL() throws {
+        let json = """
+        {
+          "audioURL" : "file:\\/\\/\\/tmp\\/audio.wav",
+          "endedAt" : null,
+          "id" : "11111111-1111-1111-1111-111111111111",
+          "name" : "Google Meet",
+          "startedAt" : "2026-04-25T10:00:00Z",
+          "transcriptURL" : "file:\\/\\/\\/tmp\\/transcript.txt"
+        }
+        """
+
+        let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: Data(json.utf8))
+
+        XCTAssertNil(decoded.diagnosticsURL)
+    }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
@@ -17,6 +17,7 @@ final class MeetingStoreTests: XCTestCase {
         XCTAssertEqual(created.record.name, "Google Chrome")
         XCTAssertEqual(created.record.audioURL?.lastPathComponent, "audio.wav")
         XCTAssertEqual(created.record.transcriptURL?.lastPathComponent, "transcript.txt")
+        XCTAssertEqual(created.record.diagnosticsURL?.lastPathComponent, "diagnostics.json")
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.directory.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.metadataURL.path))
     }

--- a/Tests/MeetingAgentCoreTests/RecordingOutputTests.swift
+++ b/Tests/MeetingAgentCoreTests/RecordingOutputTests.swift
@@ -20,8 +20,10 @@ final class RecordingOutputTests: XCTestCase {
         XCTAssertEqual(output.directory.path, expectedDirectory.path)
         XCTAssertEqual(output.wavURL.lastPathComponent, "capture.wav")
         XCTAssertEqual(output.transcriptURL.lastPathComponent, "capture.txt")
+        XCTAssertEqual(output.diagnosticsURL.lastPathComponent, "diagnostics.json")
         XCTAssertEqual(output.wavURL.deletingLastPathComponent(), output.directory)
         XCTAssertEqual(output.transcriptURL.deletingLastPathComponent(), output.directory)
+        XCTAssertEqual(output.diagnosticsURL.deletingLastPathComponent(), output.directory)
     }
 
     func testDefaultRecordingOutputUsesTimestampWhenWavPathIsEmpty() throws {
@@ -47,6 +49,7 @@ final class RecordingOutputTests: XCTestCase {
 
         XCTAssertEqual(output.wavURL.lastPathComponent, "20260425-132530.wav")
         XCTAssertEqual(output.transcriptURL.lastPathComponent, "20260425-132530.txt")
+        XCTAssertEqual(output.diagnosticsURL.lastPathComponent, "diagnostics.json")
     }
 
     func testWavFlagWithoutValueEnablesTimestampedRecording() throws {


### PR DESCRIPTION
## Summary

Fixes #3

- Adds a capture diagnostics model and JSON persistence beside app and CLI recordings.
- Tracks captured sample frames, duration, levels, silence, backlog, dropped frames, target metadata, and ended reason.
- Keeps STT startup/append failures separate from WAV capture so audio recording can continue.

## Changes

- Sources/MeetingAgentCore/CaptureDiagnostics.swift - new diagnostics model, status values, level tracking, and JSON writer.
- Sources/MeetingAgentCore/MeetingRecorder.swift - records diagnostics during app capture and persists them on stop/failure.
- Sources/CoreAudioTapProbe/ProbeMain.swift - prints diagnostics and writes .record/diagnostics.json for CLI captures.
- Sources/MeetingAgentCore/AudioFrameRingBuffer.swift - exposes backlog and dropped-frame counts.
- Sources/MeetingAgentCore/MeetingRecord.swift and MeetingStore.swift - add meeting diagnostics artifact URL.
- Tests/MeetingAgentCoreTests - adds regression coverage for diagnostics, ring-buffer counters, metadata compatibility, and output paths.

## Test plan

- [x] Build/lint: git diff --check
- [x] Unit tests: swift test (64 tests, 0 failures)
- [x] Product build: swift build --product MeetingAgentApp
- [x] Product build: swift build --product CoreAudioTapProbe
- [x] E2E/integration: skipped; no E2E convention and live Core Audio capture requires local meeting process/permissions
- [x] Code review: PASS manual Swift review against AGENTS.md
- [ ] Manual verification: run a live capture with --wav and inspect audio.wav/transcript.txt/diagnostics.json