### PR TITLE
feat: add structured transcript output

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -1,0 +1,15 @@
+## [4] Clear stale structured transcript data on plain-text fallback
+
+**Date**: 2026-04-25
+**Category**: logic-error
+
+### What went wrong
+Introducing `transcript.json` as the preferred source of truth initially left old structured segments in place when a failure path wrote plain text to `transcript.txt`.
+
+### Correct approach
+Plain-text fallback writes must clear the structured transcript document so readers do not prefer stale JSON over the current fallback message.
+
+### How to avoid
+When adding a new source-of-truth file beside a legacy cache or fallback, update or invalidate both paths in every write mode.
+
+---

--- a/Sources/CoreAudioTapProbe/ProbeMain.swift
+++ b/Sources/CoreAudioTapProbe/ProbeMain.swift
@@ -96,6 +96,7 @@ struct ProbeMain {
         if let recordingOutput {
             log("Recording audio to \(recordingOutput.wavURL.path)")
             log("Recording transcript to \(recordingOutput.transcriptURL.path)")
+            log("Recording structured transcript to \(recordingOutput.transcriptJSONURL.path)")
             log("Recording diagnostics to \(recordingOutput.diagnosticsURL.path)")
         }
 

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -113,10 +113,10 @@ private struct MeetingDetailView: View {
     }
 
     private func transcriptText(for meeting: MeetingRecord) -> String {
-        guard let transcriptURL = meeting.transcriptURL,
-              let text = try? String(contentsOf: transcriptURL, encoding: .utf8),
-              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
+        guard let text = TranscriptFileWriter.renderedTranscript(
+            textURL: meeting.transcriptURL,
+            structuredURL: meeting.transcriptJSONURL
+        ) else {
             return "Transcript will appear here while recording."
         }
         return text

--- a/Sources/MeetingAgentCore/MeetingRecord.swift
+++ b/Sources/MeetingAgentCore/MeetingRecord.swift
@@ -7,6 +7,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
     public var endedAt: Date?
     public var audioURL: URL?
     public var transcriptURL: URL?
+    public var transcriptJSONURL: URL?
     public var diagnosticsURL: URL?
 
     public init(
@@ -16,6 +17,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         endedAt: Date?,
         audioURL: URL?,
         transcriptURL: URL?,
+        transcriptJSONURL: URL? = nil,
         diagnosticsURL: URL? = nil
     ) {
         self.id = id
@@ -24,6 +26,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         self.endedAt = endedAt
         self.audioURL = audioURL
         self.transcriptURL = transcriptURL
+        self.transcriptJSONURL = transcriptJSONURL
         self.diagnosticsURL = diagnosticsURL
     }
 }

--- a/Sources/MeetingAgentCore/MeetingStore.swift
+++ b/Sources/MeetingAgentCore/MeetingStore.swift
@@ -41,6 +41,7 @@ public final class MeetingStore {
             endedAt: nil,
             audioURL: directory.appendingPathComponent("audio.wav"),
             transcriptURL: directory.appendingPathComponent("transcript.txt"),
+            transcriptJSONURL: directory.appendingPathComponent("transcript.json"),
             diagnosticsURL: directory.appendingPathComponent("diagnostics.json")
         )
         try save(record)

--- a/Sources/MeetingAgentCore/RecordingOutput.swift
+++ b/Sources/MeetingAgentCore/RecordingOutput.swift
@@ -4,6 +4,7 @@ public struct RecordingOutput {
     public let directory: URL
     public let wavURL: URL
     public let transcriptURL: URL
+    public let transcriptJSONURL: URL
     public let diagnosticsURL: URL
 
     public static func defaultOutput(
@@ -22,6 +23,7 @@ public struct RecordingOutput {
         }
         let wavURL = directory.appendingPathComponent(wavName)
         let transcriptURL = wavURL.deletingPathExtension().appendingPathExtension("txt")
+        let transcriptJSONURL = wavURL.deletingPathExtension().appendingPathExtension("json")
         let diagnosticsURL = directory.appendingPathComponent("diagnostics.json")
 
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -30,6 +32,7 @@ public struct RecordingOutput {
             directory: directory,
             wavURL: wavURL,
             transcriptURL: transcriptURL,
+            transcriptJSONURL: transcriptJSONURL,
             diagnosticsURL: diagnosticsURL
         )
     }
@@ -45,19 +48,110 @@ public struct RecordingOutput {
 
 public final class TranscriptFileWriter {
     private let url: URL
+    private let structuredURL: URL
     private var isClosed = false
 
-    public init(url: URL) throws {
+    public init(url: URL, structuredURL: URL? = nil) throws {
         self.url = url
+        self.structuredURL = structuredURL ?? url.deletingPathExtension().appendingPathExtension("json")
         FileManager.default.createFile(atPath: url.path, contents: Data())
+        if !FileManager.default.fileExists(atPath: self.structuredURL.path) {
+            try writeDocument(TranscriptDocument())
+        }
     }
 
     public func replace(with text: String) throws {
         guard !isClosed else { return }
+        try writeDocument(TranscriptDocument())
         try (text + "\n").write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    public func replace(with segments: [TranscriptSegment]) throws {
+        guard !isClosed else { return }
+        let labeledSegments = Self.assignSpeakerLabels(to: segments)
+        try writeDocument(TranscriptDocument(segments: labeledSegments))
+        try (TranscriptFormatter.render(labeledSegments) + "\n").write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    public func append(_ segment: TranscriptSegment) throws {
+        guard !isClosed else { return }
+        var document = try Self.readDocument(from: structuredURL)
+        document.segments.append(segment)
+        try replace(with: document.segments)
     }
 
     public func close() throws {
         isClosed = true
+    }
+
+    public static func readDocument(from url: URL) throws -> TranscriptDocument {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return TranscriptDocument()
+        }
+        let data = try Data(contentsOf: url)
+        guard !data.isEmpty else {
+            return TranscriptDocument()
+        }
+        return try JSONDecoder.meetingAgent.decode(TranscriptDocument.self, from: data)
+    }
+
+    public static func renderedTranscript(
+        textURL: URL?,
+        structuredURL: URL?
+    ) -> String? {
+        if let structuredURL,
+           let document = try? readDocument(from: structuredURL),
+           !document.segments.isEmpty {
+            let text = TranscriptFormatter.render(document.segments)
+            if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return text
+            }
+        }
+
+        guard let textURL,
+              let text = try? String(contentsOf: textURL, encoding: .utf8),
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return nil
+        }
+        return text
+    }
+
+    private func writeDocument(_ document: TranscriptDocument) throws {
+        let data = try JSONEncoder.meetingAgent.encode(document)
+        try data.write(to: structuredURL, options: .atomic)
+    }
+
+    private static func assignSpeakerLabels(to segments: [TranscriptSegment]) -> [TranscriptSegment] {
+        var mapper = SpeakerLabelMapper()
+        var generatedIDsBySpeaker: [TranscriptSpeaker: String] = [:]
+        var nextSpeakerIndex = 1
+        return segments.map { segment in
+            let speaker = segment.speaker
+            let label = mapper.label(for: speaker)
+            let speakerID: String
+            if let existingID = speaker.identifier {
+                speakerID = existingID
+            } else if let generatedID = generatedIDsBySpeaker[speaker] {
+                speakerID = generatedID
+            } else {
+                speakerID = "speaker-\(nextSpeakerIndex)"
+                generatedIDsBySpeaker[speaker] = speakerID
+                nextSpeakerIndex += 1
+            }
+            return TranscriptSegment(
+                id: segment.id,
+                speaker: TranscriptSpeaker(identifier: speakerID, label: segment.speakerLabel ?? label),
+                startTimeSeconds: segment.startTimeSeconds,
+                endTimeSeconds: segment.endTimeSeconds,
+                text: segment.text,
+                language: segment.language,
+                sourceProvider: segment.sourceProvider,
+                isFinal: segment.isFinal,
+                confidence: segment.confidence,
+                createdAt: segment.createdAt,
+                timingSource: segment.timingSource
+            )
+        }
     }
 }

--- a/Sources/MeetingAgentCore/SystemSpeechTranscriber.swift
+++ b/Sources/MeetingAgentCore/SystemSpeechTranscriber.swift
@@ -71,13 +71,22 @@ final class SystemSpeechTranscriber: AudioFrameTranscriber {
         request.taskHint = .dictation
 
         let writer = try TranscriptFileWriter(url: transcriptURL)
-        let transcriber = SystemSpeechTranscriber(request: request, writer: writer)
+        let transcriber = SystemSpeechTranscriber(
+            request: request,
+            writer: writer
+        )
         transcriber.task = recognizer.recognitionTask(with: request) { result, error in
             if let result {
-                let transcript = TranscriptFormatter.render([
-                    TranscriptSegment(text: result.bestTranscription.formattedString)
+                try? writer.replace(with: [
+                    TranscriptSegment(
+                        id: "local-current",
+                        text: result.bestTranscription.formattedString,
+                        language: localeIdentifier,
+                        sourceProvider: "local",
+                        isFinal: result.isFinal,
+                        timingSource: .unavailable
+                    )
                 ])
-                try? writer.replace(with: transcript)
             }
             if error != nil {
                 try? writer.close()

--- a/Sources/MeetingAgentCore/TranscriptSegment.swift
+++ b/Sources/MeetingAgentCore/TranscriptSegment.swift
@@ -4,20 +4,75 @@ public struct TranscriptSpeaker: Equatable, Hashable {
     public static let `default` = TranscriptSpeaker(identifier: nil)
 
     public let identifier: String?
+    public let label: String?
 
-    public init(identifier: String?) {
+    public init(identifier: String?, label: String? = nil) {
         let trimmed = identifier?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.identifier = trimmed.flatMap { $0.isEmpty ? nil : $0 }
+        let trimmedLabel = label?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.label = trimmedLabel.flatMap { $0.isEmpty ? nil : $0 }
     }
 }
 
-public struct TranscriptSegment: Equatable {
-    public let speaker: TranscriptSpeaker
-    public let text: String
+public enum TranscriptTimingSource: String, Codable, Equatable {
+    case precise
+    case approximate
+    case unavailable
+}
 
-    public init(speaker: TranscriptSpeaker = .default, text: String) {
-        self.speaker = speaker
+public struct TranscriptSegment: Codable, Equatable, Identifiable {
+    public let id: String
+    public let speakerID: String?
+    public let speakerLabel: String?
+    public let startTimeSeconds: Double?
+    public let endTimeSeconds: Double?
+    public let text: String
+    public let language: String?
+    public let sourceProvider: String
+    public let isFinal: Bool
+    public let confidence: Double?
+    public let createdAt: Date
+    public let timingSource: TranscriptTimingSource
+
+    public var speaker: TranscriptSpeaker {
+        TranscriptSpeaker(identifier: speakerID, label: speakerLabel)
+    }
+
+    public init(
+        id: String = UUID().uuidString,
+        speaker: TranscriptSpeaker = .default,
+        startTimeSeconds: Double? = nil,
+        endTimeSeconds: Double? = nil,
+        text: String,
+        language: String? = nil,
+        sourceProvider: String = "unknown",
+        isFinal: Bool = true,
+        confidence: Double? = nil,
+        createdAt: Date = Date(),
+        timingSource: TranscriptTimingSource = .unavailable
+    ) {
+        self.id = id
+        self.speakerID = speaker.identifier
+        self.speakerLabel = speaker.label
+        self.startTimeSeconds = startTimeSeconds
+        self.endTimeSeconds = endTimeSeconds
         self.text = text
+        self.language = language
+        self.sourceProvider = sourceProvider
+        self.isFinal = isFinal
+        self.confidence = confidence
+        self.createdAt = createdAt
+        self.timingSource = timingSource
+    }
+}
+
+public struct TranscriptDocument: Codable, Equatable {
+    public let version: Int
+    public var segments: [TranscriptSegment]
+
+    public init(version: Int = 1, segments: [TranscriptSegment] = []) {
+        self.version = version
+        self.segments = segments
     }
 }
 
@@ -56,6 +111,9 @@ struct SpeakerLabelMapper {
     private var nextIndex = 0
 
     mutating func label(for speaker: TranscriptSpeaker) -> String {
+        if let label = speaker.label {
+            return label
+        }
         if let existing = labelsBySpeaker[speaker] {
             return existing
         }

--- a/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
@@ -155,10 +155,12 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
     private let temporaryDirectory: URL
     private let configuration: WhisperConfiguration
     private let processRunner: WhisperProcessRunning
+    private let localeIdentifier: String
     private let languageCode: String?
     private let chunkDurationSeconds: Double
     private var chunkFrames: [AudioFrame] = []
     private var pendingChunkDurationSeconds = 0.0
+    private var transcribedDurationSeconds = 0.0
     private var chunkIndex = 0
     private var transcriptSegments: [TranscriptSegment] = []
     private var isFinished = false
@@ -168,6 +170,7 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
         temporaryDirectory: URL,
         configuration: WhisperConfiguration,
         processRunner: WhisperProcessRunning,
+        localeIdentifier: String,
         languageCode: String?,
         chunkDurationSeconds: Double
     ) {
@@ -175,6 +178,7 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
         self.temporaryDirectory = temporaryDirectory
         self.configuration = configuration
         self.processRunner = processRunner
+        self.localeIdentifier = localeIdentifier
         self.languageCode = languageCode
         self.chunkDurationSeconds = max(0.001, chunkDurationSeconds)
     }
@@ -195,6 +199,7 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
             temporaryDirectory: temporaryDirectory,
             configuration: configuration,
             processRunner: processRunner,
+            localeIdentifier: localeIdentifier,
             languageCode: WhisperLanguageMapper.languageCode(for: localeIdentifier),
             chunkDurationSeconds: chunkDurationSeconds
         )
@@ -274,15 +279,29 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
             throw ProbeError.speechRecognition("Whisper transcription unavailable: expected output file was not created")
         }
 
-        let transcript = normalizedTranscript(
+        let transcriptLines = normalizedTranscriptLines(
             try String(contentsOf: outputTextURL, encoding: .utf8)
         )
-        if !transcript.isEmpty {
-            transcriptSegments.append(TranscriptSegment(text: transcript))
-            try TranscriptFileWriter(url: transcriptURL).replace(with: TranscriptFormatter.render(transcriptSegments))
+        let chunkStartTime = transcribedDurationSeconds
+        let chunkEndTime = chunkStartTime + pendingChunkDurationSeconds
+        if !transcriptLines.isEmpty {
+            transcriptSegments += transcriptLines.enumerated().map { lineIndex, text in
+                TranscriptSegment(
+                    id: "whisper-\(chunkID)-\(lineIndex)",
+                    startTimeSeconds: chunkStartTime,
+                    endTimeSeconds: chunkEndTime,
+                    text: text,
+                    language: localeIdentifier,
+                    sourceProvider: "whisper",
+                    isFinal: true,
+                    timingSource: .approximate
+                )
+            }
+            try TranscriptFileWriter(url: transcriptURL).replace(with: transcriptSegments)
         }
 
         chunkFrames.removeAll(keepingCapacity: true)
+        transcribedDurationSeconds = chunkEndTime
         pendingChunkDurationSeconds = 0
         try? FileManager.default.removeItem(at: inputWavURL)
         try? FileManager.default.removeItem(at: outputTextURL)
@@ -295,12 +314,11 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
         return Double(frameCount) / frame.sampleRate
     }
 
-    private func normalizedTranscript(_ text: String) -> String {
+    private func normalizedTranscriptLines(_ text: String) -> [String] {
         text
             .split(whereSeparator: \.isNewline)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
             .filter { $0.caseInsensitiveCompare("[BLANK_AUDIO]") != .orderedSame }
-            .joined(separator: "\n")
     }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
@@ -12,7 +12,8 @@ final class MeetingRecordTests: XCTestCase {
             startedAt: startedAt,
             endedAt: endedAt,
             audioURL: URL(fileURLWithPath: "/tmp/audio.wav"),
-            transcriptURL: URL(fileURLWithPath: "/tmp/transcript.txt")
+            transcriptURL: URL(fileURLWithPath: "/tmp/transcript.txt"),
+            transcriptJSONURL: URL(fileURLWithPath: "/tmp/transcript.json")
         )
 
         let data = try JSONEncoder.meetingAgent.encode(record)
@@ -49,5 +50,6 @@ final class MeetingRecordTests: XCTestCase {
         let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: Data(json.utf8))
 
         XCTAssertNil(decoded.diagnosticsURL)
+        XCTAssertNil(decoded.transcriptJSONURL)
     }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
@@ -17,6 +17,7 @@ final class MeetingStoreTests: XCTestCase {
         XCTAssertEqual(created.record.name, "Google Chrome")
         XCTAssertEqual(created.record.audioURL?.lastPathComponent, "audio.wav")
         XCTAssertEqual(created.record.transcriptURL?.lastPathComponent, "transcript.txt")
+        XCTAssertEqual(created.record.transcriptJSONURL?.lastPathComponent, "transcript.json")
         XCTAssertEqual(created.record.diagnosticsURL?.lastPathComponent, "diagnostics.json")
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.directory.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.metadataURL.path))

--- a/Tests/MeetingAgentCoreTests/RecordingOutputTests.swift
+++ b/Tests/MeetingAgentCoreTests/RecordingOutputTests.swift
@@ -20,9 +20,11 @@ final class RecordingOutputTests: XCTestCase {
         XCTAssertEqual(output.directory.path, expectedDirectory.path)
         XCTAssertEqual(output.wavURL.lastPathComponent, "capture.wav")
         XCTAssertEqual(output.transcriptURL.lastPathComponent, "capture.txt")
+        XCTAssertEqual(output.transcriptJSONURL.lastPathComponent, "capture.json")
         XCTAssertEqual(output.diagnosticsURL.lastPathComponent, "diagnostics.json")
         XCTAssertEqual(output.wavURL.deletingLastPathComponent(), output.directory)
         XCTAssertEqual(output.transcriptURL.deletingLastPathComponent(), output.directory)
+        XCTAssertEqual(output.transcriptJSONURL.deletingLastPathComponent(), output.directory)
         XCTAssertEqual(output.diagnosticsURL.deletingLastPathComponent(), output.directory)
     }
 
@@ -49,6 +51,7 @@ final class RecordingOutputTests: XCTestCase {
 
         XCTAssertEqual(output.wavURL.lastPathComponent, "20260425-132530.wav")
         XCTAssertEqual(output.transcriptURL.lastPathComponent, "20260425-132530.txt")
+        XCTAssertEqual(output.transcriptJSONURL.lastPathComponent, "20260425-132530.json")
         XCTAssertEqual(output.diagnosticsURL.lastPathComponent, "diagnostics.json")
     }
 
@@ -106,7 +109,11 @@ final class RecordingOutputTests: XCTestCase {
 
     func testTranscriptWriterReplacesPartialTextWithLatestText() throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
-        defer { try? FileManager.default.removeItem(at: url) }
+        let jsonURL = url.deletingPathExtension().appendingPathExtension("json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: jsonURL)
+        }
 
         let writer = try TranscriptFileWriter(url: url)
         try writer.replace(with: "hello")
@@ -114,5 +121,79 @@ final class RecordingOutputTests: XCTestCase {
         try writer.close()
 
         XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "hello world\n")
+        XCTAssertEqual(try TranscriptFileWriter.readDocument(from: jsonURL), TranscriptDocument())
+    }
+
+    func testTranscriptWriterPlainTextReplaceClearsStructuredSegments() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
+        let jsonURL = url.deletingPathExtension().appendingPathExtension("json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: jsonURL)
+        }
+
+        let writer = try TranscriptFileWriter(url: url)
+        try writer.replace(with: [TranscriptSegment(id: "segment-1", text: "structured text")])
+        try writer.replace(with: "Speech recognition unavailable")
+
+        XCTAssertEqual(TranscriptFileWriter.renderedTranscript(textURL: url, structuredURL: jsonURL), "Speech recognition unavailable\n")
+        XCTAssertEqual(try TranscriptFileWriter.readDocument(from: jsonURL), TranscriptDocument())
+    }
+
+    func testTranscriptWriterRendersTextFromStructuredSegments() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
+        let jsonURL = url.deletingPathExtension().appendingPathExtension("json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: jsonURL)
+        }
+
+        let writer = try TranscriptFileWriter(url: url)
+        try writer.replace(with: [
+            TranscriptSegment(
+                id: "segment-1",
+                startTimeSeconds: 0,
+                endTimeSeconds: 1.25,
+                text: "hello",
+                language: "en-US",
+                sourceProvider: "whisper",
+                isFinal: true,
+                confidence: 0.87,
+                createdAt: Date(timeIntervalSince1970: 1_777_000_000),
+                timingSource: .approximate
+            )
+        ])
+        try writer.close()
+
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "User A:\nhello\n")
+        let document = try TranscriptFileWriter.readDocument(from: jsonURL)
+        XCTAssertEqual(document.version, 1)
+        XCTAssertEqual(document.segments.first?.id, "segment-1")
+        XCTAssertEqual(document.segments.first?.speakerID, "speaker-1")
+        XCTAssertEqual(document.segments.first?.speakerLabel, "User A")
+        XCTAssertEqual(document.segments.first?.startTimeSeconds, 0)
+        XCTAssertEqual(document.segments.first?.endTimeSeconds, 1.25)
+        XCTAssertEqual(document.segments.first?.language, "en-US")
+        XCTAssertEqual(document.segments.first?.sourceProvider, "whisper")
+        XCTAssertEqual(document.segments.first?.isFinal, true)
+        XCTAssertEqual(document.segments.first?.confidence, 0.87)
+        XCTAssertEqual(document.segments.first?.timingSource, .approximate)
+    }
+
+    func testRenderedTranscriptPrefersStructuredSegmentsAndFallsBackToPlainText() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
+        let jsonURL = url.deletingPathExtension().appendingPathExtension("json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: jsonURL)
+        }
+
+        try "legacy text\n".write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertEqual(TranscriptFileWriter.renderedTranscript(textURL: url, structuredURL: jsonURL), "legacy text\n")
+
+        let writer = try TranscriptFileWriter(url: url)
+        try writer.replace(with: [TranscriptSegment(id: "segment-1", text: "structured text")])
+
+        XCTAssertEqual(TranscriptFileWriter.renderedTranscript(textURL: url, structuredURL: jsonURL), "User A:\nstructured text")
     }
 }

--- a/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
@@ -158,6 +158,16 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         transcriber.finish()
 
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "User A:\nhello from whisper\n")
+        let document = try TranscriptFileWriter.readDocument(from: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+        XCTAssertEqual(document.segments.count, 1)
+        XCTAssertEqual(document.segments.first?.id, "whisper-0-0")
+        XCTAssertEqual(document.segments.first?.speakerID, "speaker-1")
+        XCTAssertEqual(document.segments.first?.speakerLabel, "User A")
+        XCTAssertEqual(document.segments.first?.startTimeSeconds, 0)
+        XCTAssertEqual(document.segments.first?.endTimeSeconds, 0.000125)
+        XCTAssertEqual(document.segments.first?.language, "en-US")
+        XCTAssertEqual(document.segments.first?.sourceProvider, "whisper")
+        XCTAssertEqual(document.segments.first?.timingSource, .approximate)
         XCTAssertEqual(runner.languageCode, "en")
         XCTAssertNotNil(runner.inputWavURL)
     }


### PR DESCRIPTION
## Summary

Fixes #4

- Adds JSON-backed transcript documents alongside rendered transcript text.
- Keeps historical plain-text transcript display working as a fallback.

## Changes

- `Sources/MeetingAgentCore/TranscriptSegment.swift` - promotes transcript segments to codable structured records with IDs, speaker placeholders, timing metadata, language, provider, finality, confidence, and creation time.
- `Sources/MeetingAgentCore/RecordingOutput.swift` - adds transcript JSON paths and a writer that renders text from structured segments.
- `Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift` - writes Whisper chunks as structured segments with approximate timing and blank-audio filtering.
- `Sources/MeetingAgentCore/SystemSpeechTranscriber.swift` - writes local Speech partial/final state through the segment model.
- `Sources/MeetingAgentApp/MainWindowView.swift` - renders from structured transcripts when available, falling back to historical text.
- `Sources/CoreAudioTapProbe/ProbeMain.swift` - logs the structured transcript output path.
- `Tests/MeetingAgentCoreTests/*` - covers JSON output, fallback behavior, metadata, and Whisper segment metadata.

## Test plan

- [x] Build/lint: `git diff --check HEAD~1 HEAD` passed; no separate Swift lint command exists in this package.
- [x] Unit tests: `swift test` passed, 72 tests.
- [x] E2E/integration: skipped; no E2E convention exists for this Swift package behavior.
- [x] Code review: errors-fixed; stale structured JSON on plain-text fallback was fixed and covered by a regression test.
- [x] Manual verification: `swift build --product MeetingAgentApp` and `swift build --product CoreAudioTapProbe` passed.
