### PR TITLE
feat: productize STT configuration and retry

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -13,3 +13,19 @@ Plain-text fallback writes must clear the structured transcript document so read
 When adding a new source-of-truth file beside a legacy cache or fallback, update or invalidate both paths in every write mode.
 
 ---
+
+## [5] STT settings persistence test isolation
+
+**Date**: 2026-04-25
+**Category**: test-mistake
+
+### What went wrong
+The first persisted STT settings implementation used the default `UserDefaults` store in view-model tests, which allowed one test's settings to affect another test.
+
+### Correct approach
+Inject a suite-scoped `UserDefaults` through `SpeechTranscriptionConfigurationStore` in tests that read or write persisted settings.
+
+### How to avoid
+Never use process-global persistence directly in unit tests; inject an isolated store.
+
+---

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -7,6 +7,17 @@ struct MainWindowView: View {
     var body: some View {
         NavigationSplitView {
             VStack(alignment: .leading, spacing: 12) {
+                Picker("STT Provider", selection: Binding(
+                    get: { viewModel.speechProvider },
+                    set: { viewModel.updateSpeechProvider($0) }
+                )) {
+                    ForEach(SpeechProvider.allCases, id: \.self) { provider in
+                        Text(provider.rawValue).tag(provider)
+                    }
+                }
+                .disabled(viewModel.isRecording)
+                .padding([.horizontal, .top], 12)
+
                 TextField(
                     "STT Locale",
                     text: Binding(
@@ -16,7 +27,34 @@ struct MainWindowView: View {
                 )
                 .textFieldStyle(.roundedBorder)
                 .disabled(viewModel.isRecording)
-                .padding([.horizontal, .top], 12)
+                .padding(.horizontal, 12)
+
+                TextField(
+                    "Whisper Binary Path",
+                    text: Binding(
+                        get: { viewModel.speechConfiguration.whisperBinaryPath ?? "" },
+                        set: { viewModel.updateWhisperBinaryPath($0) }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .disabled(viewModel.isRecording)
+                .padding(.horizontal, 12)
+
+                TextField(
+                    "Whisper Model Path",
+                    text: Binding(
+                        get: { viewModel.speechConfiguration.whisperModelPath ?? "" },
+                        set: { viewModel.updateWhisperModelPath($0) }
+                    )
+                )
+                .textFieldStyle(.roundedBorder)
+                .disabled(viewModel.isRecording)
+                .padding(.horizontal, 12)
+
+                Text(configurationStatusText)
+                    .font(.caption)
+                    .foregroundStyle(configurationStatusColor)
+                    .padding(.horizontal, 12)
 
                 List(selection: Binding(
                     get: { viewModel.selectedMeetingID },
@@ -42,6 +80,11 @@ struct MainWindowView: View {
                 isRecording: viewModel.isRecording,
                 stopRecording: {
                     viewModel.stopRecording()
+                },
+                retryTranscription: { meeting in
+                    Task {
+                        await viewModel.retryTranscription(for: meeting.id)
+                    }
                 }
             )
         }
@@ -69,6 +112,24 @@ struct MainWindowView: View {
             Text("\(target.displayName) detected. Start recording?")
         }
     }
+
+    private var configurationStatusText: String {
+        switch viewModel.speechConfigurationStatus {
+        case .available:
+            return "STT configuration available"
+        case .unavailable(let reason):
+            return reason
+        }
+    }
+
+    private var configurationStatusColor: Color {
+        switch viewModel.speechConfigurationStatus {
+        case .available:
+            return .secondary
+        case .unavailable:
+            return .red
+        }
+    }
 }
 
 private struct MeetingDetailView: View {
@@ -76,6 +137,7 @@ private struct MeetingDetailView: View {
     let statusText: String
     let isRecording: Bool
     let stopRecording: () -> Void
+    let retryTranscription: (MeetingRecord) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -89,10 +151,23 @@ private struct MeetingDetailView: View {
                     LabeledContent("Ended", value: endedAt.formatted(date: .abbreviated, time: .standard))
                 }
                 LabeledContent("Audio", value: meeting.audioURL?.path ?? "Not recorded")
+                LabeledContent("STT Provider", value: meeting.speechProvider.rawValue)
+                LabeledContent("Language", value: meeting.speechLocaleIdentifier)
+                LabeledContent("Transcription", value: transcriptionStatusText(for: meeting))
+                if let failureReason = meeting.transcriptionFailureReason {
+                    Text(failureReason)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                }
                 Button("Stop Recording") {
                     stopRecording()
                 }
                 .disabled(!isRecording)
+                Button("Retry Transcription") {
+                    retryTranscription(meeting)
+                }
+                .disabled(isRecording || meeting.audioURL == nil)
                 Divider()
                 Text("Transcript")
                     .font(.headline)
@@ -120,5 +195,20 @@ private struct MeetingDetailView: View {
             return "Transcript will appear here while recording."
         }
         return text
+    }
+
+    private func transcriptionStatusText(for meeting: MeetingRecord) -> String {
+        switch meeting.transcriptionStatus {
+        case .notStarted:
+            return "Not started"
+        case .transcribing:
+            return "Transcribing"
+        case .transcribed:
+            return "Transcribed"
+        case .failed:
+            return "Failed"
+        case .retryRequested:
+            return "Retry requested"
+        }
     }
 }

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -7,10 +7,10 @@ public final class MeetingAgentViewModel: ObservableObject {
     @Published public private(set) var selectedMeetingID: UUID?
     @Published public private(set) var pendingCandidate: AudioCaptureTarget?
     @Published public private(set) var statusText: String = "Idle"
-    @Published public private(set) var speechLocaleIdentifier: String
-    @Published public private(set) var speechProvider: SpeechProvider
+    @Published public private(set) var speechConfiguration: SpeechTranscriptionConfiguration
 
     private let store: MeetingStore
+    private let speechConfigurationStore: SpeechTranscriptionConfigurationStore
     private let recorder: MeetingRecorder
     private let processMonitor = MeetingProcessMonitor()
     private var activeTarget: AudioCaptureTarget?
@@ -19,12 +19,25 @@ public final class MeetingAgentViewModel: ObservableObject {
         store: MeetingStore = MeetingStore(),
         recorder: MeetingRecorder? = nil,
         speechLocaleIdentifier: String = Locale.current.identifier,
-        speechProvider: SpeechProvider = .whisper
+        speechProvider: SpeechProvider = .whisper,
+        speechConfiguration: SpeechTranscriptionConfiguration? = nil,
+        speechConfigurationStore: SpeechTranscriptionConfigurationStore = SpeechTranscriptionConfigurationStore()
     ) {
         self.store = store
+        self.speechConfigurationStore = speechConfigurationStore
         self.recorder = recorder ?? MeetingRecorder(store: store)
-        self.speechLocaleIdentifier = Self.normalizedSpeechLocaleIdentifier(speechLocaleIdentifier)
-        self.speechProvider = speechProvider
+        if let speechConfiguration {
+            self.speechConfiguration = speechConfiguration
+        } else if speechProvider != .whisper || speechLocaleIdentifier != Locale.current.identifier {
+            self.speechConfiguration = SpeechTranscriptionConfiguration(
+                provider: speechProvider,
+                localeIdentifier: speechLocaleIdentifier,
+                whisperBinaryPath: nil,
+                whisperModelPath: nil
+            )
+        } else {
+            self.speechConfiguration = (try? speechConfigurationStore.load()) ?? .default
+        }
     }
 
     public func loadMeetings() throws {
@@ -59,7 +72,23 @@ public final class MeetingAgentViewModel: ObservableObject {
     }
 
     public func updateSpeechLocaleIdentifier(_ localeIdentifier: String) {
-        speechLocaleIdentifier = Self.normalizedSpeechLocaleIdentifier(localeIdentifier)
+        speechConfiguration.localeIdentifier = Self.normalizedSpeechLocaleIdentifier(localeIdentifier)
+        persistSpeechConfiguration()
+    }
+
+    public func updateSpeechProvider(_ provider: SpeechProvider) {
+        speechConfiguration.provider = provider
+        persistSpeechConfiguration()
+    }
+
+    public func updateWhisperBinaryPath(_ path: String) {
+        speechConfiguration.whisperBinaryPath = SpeechTranscriptionConfiguration.normalized(path)
+        persistSpeechConfiguration()
+    }
+
+    public func updateWhisperModelPath(_ path: String) {
+        speechConfiguration.whisperModelPath = SpeechTranscriptionConfiguration.normalized(path)
+        persistSpeechConfiguration()
     }
 
     public func startRecordingForPendingCandidate(localeIdentifier: String? = nil) async throws {
@@ -73,13 +102,14 @@ public final class MeetingAgentViewModel: ObservableObject {
         selectedMeetingID = record.id
         activeTarget = candidate
         pendingCandidate = nil
-        let recordingLocaleIdentifier = localeIdentifier.map(Self.normalizedSpeechLocaleIdentifier) ?? speechLocaleIdentifier
+        let recordingLocaleIdentifier = localeIdentifier.map(Self.normalizedSpeechLocaleIdentifier) ?? speechConfiguration.localeIdentifier
+        var recordingConfiguration = speechConfiguration
+        recordingConfiguration.localeIdentifier = recordingLocaleIdentifier
         do {
             try await recorder.startRecording(
                 target: candidate,
                 record: record,
-                speechProvider: speechProvider,
-                localeIdentifier: recordingLocaleIdentifier
+                speechConfiguration: recordingConfiguration
             )
         } catch {
             if let stopped = try? recorder.stopRecording(),
@@ -113,6 +143,54 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     public func selectMeeting(_ id: UUID?) {
         selectedMeetingID = id
+    }
+
+    public func retryTranscription(for meetingID: UUID) async {
+        guard let index = meetings.firstIndex(where: { $0.id == meetingID }) else { return }
+        var record = meetings[index]
+        guard let audioURL = record.audioURL, let transcriptURL = record.transcriptURL else {
+            record.transcriptionStatus = .failed
+            record.transcriptionFailureReason = "No saved audio is available for transcription retry"
+            meetings[index] = record
+            try? store.save(record)
+            return
+        }
+
+        record.transcriptionStatus = .retryRequested
+        record.transcriptionFailureReason = nil
+        record.speechProvider = speechConfiguration.provider
+        record.speechLocaleIdentifier = speechConfiguration.localeIdentifier
+        meetings[index] = record
+        try? store.save(record)
+
+        record.transcriptionStatus = .transcribing
+        meetings[index] = record
+        try? store.save(record)
+
+        do {
+            let previousTranscript = try? String(contentsOf: transcriptURL, encoding: .utf8)
+            let provider = SpeechTranscriptionProviderFactory.provider(
+                for: speechConfiguration.provider,
+                configuration: speechConfiguration
+            )
+            try await provider.transcribeExistingAudio(context: SpeechTranscriptionContext(
+                inputAudioURL: audioURL,
+                transcriptURL: transcriptURL,
+                localeIdentifier: speechConfiguration.localeIdentifier,
+                meetingID: record.id,
+                previousTranscript: previousTranscript
+            ))
+            record.transcriptionStatus = .transcribed
+            record.transcriptionFailureReason = nil
+            statusText = "Transcript regenerated"
+        } catch {
+            record.transcriptionStatus = .failed
+            record.transcriptionFailureReason = "Speech recognition failed: \(error)"
+            statusText = "Transcription failed"
+        }
+
+        meetings[index] = record
+        try? store.save(record)
     }
 
     public func pollForMeetingCandidates() -> AudioCaptureTarget? {
@@ -157,8 +235,24 @@ public final class MeetingAgentViewModel: ObservableObject {
         meetings.first { $0.id == selectedMeetingID }
     }
 
+    public var speechLocaleIdentifier: String {
+        speechConfiguration.localeIdentifier
+    }
+
+    public var speechProvider: SpeechProvider {
+        speechConfiguration.provider
+    }
+
+    public var speechConfigurationStatus: SpeechConfigurationValidationStatus {
+        speechConfiguration.validationStatus()
+    }
+
     private static func normalizedSpeechLocaleIdentifier(_ localeIdentifier: String) -> String {
         let trimmed = localeIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "en-US" : trimmed
+    }
+
+    private func persistSpeechConfiguration() {
+        try? speechConfigurationStore.save(speechConfiguration)
     }
 }

--- a/Sources/MeetingAgentCore/MeetingRecord.swift
+++ b/Sources/MeetingAgentCore/MeetingRecord.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+public enum TranscriptionStatus: String, Codable, Equatable {
+    case notStarted
+    case transcribing
+    case transcribed
+    case failed
+    case retryRequested
+}
+
 public struct MeetingRecord: Codable, Identifiable, Equatable {
     public let id: UUID
     public var name: String
@@ -9,6 +17,10 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
     public var transcriptURL: URL?
     public var transcriptJSONURL: URL?
     public var diagnosticsURL: URL?
+    public var transcriptionStatus: TranscriptionStatus
+    public var transcriptionFailureReason: String?
+    public var speechProvider: SpeechProvider
+    public var speechLocaleIdentifier: String
 
     public init(
         id: UUID,
@@ -18,7 +30,11 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         audioURL: URL?,
         transcriptURL: URL?,
         transcriptJSONURL: URL? = nil,
-        diagnosticsURL: URL? = nil
+        diagnosticsURL: URL? = nil,
+        transcriptionStatus: TranscriptionStatus = .notStarted,
+        transcriptionFailureReason: String? = nil,
+        speechProvider: SpeechProvider = .whisper,
+        speechLocaleIdentifier: String = "en-US"
     ) {
         self.id = id
         self.name = name
@@ -28,6 +44,41 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         self.transcriptURL = transcriptURL
         self.transcriptJSONURL = transcriptJSONURL
         self.diagnosticsURL = diagnosticsURL
+        self.transcriptionStatus = transcriptionStatus
+        self.transcriptionFailureReason = transcriptionFailureReason
+        self.speechProvider = speechProvider
+        self.speechLocaleIdentifier = SpeechTranscriptionConfiguration.normalized(speechLocaleIdentifier, fallback: "en-US") ?? "en-US"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case startedAt
+        case endedAt
+        case audioURL
+        case transcriptURL
+        case transcriptJSONURL
+        case diagnosticsURL
+        case transcriptionStatus
+        case transcriptionFailureReason
+        case speechProvider
+        case speechLocaleIdentifier
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        startedAt = try container.decode(Date.self, forKey: .startedAt)
+        endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
+        audioURL = try container.decodeIfPresent(URL.self, forKey: .audioURL)
+        transcriptURL = try container.decodeIfPresent(URL.self, forKey: .transcriptURL)
+        transcriptJSONURL = try container.decodeIfPresent(URL.self, forKey: .transcriptJSONURL)
+        diagnosticsURL = try container.decodeIfPresent(URL.self, forKey: .diagnosticsURL)
+        transcriptionStatus = try container.decodeIfPresent(TranscriptionStatus.self, forKey: .transcriptionStatus) ?? .notStarted
+        transcriptionFailureReason = try container.decodeIfPresent(String.self, forKey: .transcriptionFailureReason)
+        speechProvider = try container.decodeIfPresent(SpeechProvider.self, forKey: .speechProvider) ?? .whisper
+        speechLocaleIdentifier = try container.decodeIfPresent(String.self, forKey: .speechLocaleIdentifier) ?? "en-US"
     }
 }
 

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -42,18 +42,32 @@ public final class MeetingRecorder {
         target: AudioCaptureTarget,
         record: MeetingRecord,
         speechProvider: SpeechProvider = .local,
-        localeIdentifier: String = "en-US"
+        localeIdentifier: String = "en-US",
+        speechConfiguration: SpeechTranscriptionConfiguration? = nil
     ) async throws {
         guard case .prepared(record.id) = state else {
             throw ProbeError.invalidArguments("Meeting must be prepared before recording starts")
         }
+        var updatedRecord = record
+        let effectiveConfiguration = speechConfiguration ?? SpeechTranscriptionConfiguration(
+            provider: speechProvider,
+            localeIdentifier: localeIdentifier,
+            whisperBinaryPath: nil,
+            whisperModelPath: nil
+        )
+        updatedRecord.speechProvider = effectiveConfiguration.provider
+        updatedRecord.speechLocaleIdentifier = effectiveConfiguration.localeIdentifier
+        updatedRecord.transcriptionStatus = .transcribing
+        updatedRecord.transcriptionFailureReason = nil
+        activeRecord = updatedRecord
+        try store.save(updatedRecord)
 
         let session = AudioCaptureSession()
         do {
             try session.start(target: target)
         } catch {
             diagnosticsTracker?.finish(endedReason: .captureFailed)
-            try diagnosticsTracker?.snapshot().writeIfPossible(to: record.diagnosticsURL)
+            try diagnosticsTracker?.snapshot().writeIfPossible(to: updatedRecord.diagnosticsURL)
             throw error
         }
         captureSession = session
@@ -62,7 +76,7 @@ public final class MeetingRecorder {
             channelCount: session.outputChannelCount
         )
 
-        if let audioURL = record.audioURL {
+        if let audioURL = updatedRecord.audioURL {
             writer = try WavFileWriter(
                 url: audioURL,
                 sampleRate: UInt32(session.outputSampleRate.rounded()),
@@ -70,17 +84,18 @@ public final class MeetingRecorder {
             )
         }
 
-        if let transcriptURL = record.transcriptURL {
-            let provider = SpeechTranscriptionProviderFactory.provider(for: speechProvider)
+        if let transcriptURL = updatedRecord.transcriptURL {
+            let provider = SpeechTranscriptionProviderFactory.provider(
+                for: effectiveConfiguration.provider,
+                configuration: effectiveConfiguration
+            )
             do {
                 transcriber = try await provider.start(
                     transcriptURL: transcriptURL,
-                    localeIdentifier: localeIdentifier
+                    localeIdentifier: effectiveConfiguration.localeIdentifier
                 )
             } catch {
-                let transcriptWriter = try TranscriptFileWriter(url: transcriptURL)
-                try transcriptWriter.replace(with: "Speech recognition unavailable: \(error)")
-                try transcriptWriter.close()
+                try markTranscriptionFailed("Speech recognition unavailable: \(error)")
                 transcriber = nil
             }
         }
@@ -112,7 +127,11 @@ public final class MeetingRecorder {
 
     public func stopRecording(at endedAt: Date = Date()) throws -> MeetingRecord? {
         try writer?.close()
-        transcriber?.finish()
+        let activeTranscriber = transcriber
+        activeTranscriber?.finish()
+        if let failureReason = activeTranscriber?.failureReason {
+            try markTranscriptionFailed(failureReason)
+        }
         captureSession?.stop()
         diagnosticsTracker?.finish(endedReason: .saved)
         writer = nil
@@ -128,6 +147,10 @@ public final class MeetingRecorder {
         }
 
         record.endedAt = endedAt
+        if record.transcriptionStatus == .transcribing {
+            record.transcriptionStatus = .transcribed
+            record.transcriptionFailureReason = nil
+        }
         diagnosticsTracker?.finish(endedReason: .saved)
         try diagnosticsTracker?.snapshot().writeIfPossible(to: record.diagnosticsURL)
         diagnosticsTracker = nil
@@ -142,10 +165,15 @@ public final class MeetingRecorder {
     }
 
     private func persistTranscriptionFailure(_ message: String) throws {
-        guard let transcriptURL = activeRecord?.transcriptURL else { return }
-        let transcriptWriter = try TranscriptFileWriter(url: transcriptURL)
-        try transcriptWriter.replace(with: message)
-        try transcriptWriter.close()
+        try markTranscriptionFailed(message)
+    }
+
+    private func markTranscriptionFailed(_ message: String) throws {
+        guard var record = activeRecord else { return }
+        record.transcriptionStatus = .failed
+        record.transcriptionFailureReason = message
+        activeRecord = record
+        try store.save(record)
     }
 }
 

--- a/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+public enum SpeechConfigurationValidationStatus: Equatable {
+    case available
+    case unavailable(String)
+}
+
+public struct SpeechTranscriptionConfiguration: Codable, Equatable {
+    public var provider: SpeechProvider
+    public var localeIdentifier: String
+    public var whisperBinaryPath: String?
+    public var whisperModelPath: String?
+
+    public static let `default` = SpeechTranscriptionConfiguration(
+        provider: .whisper,
+        localeIdentifier: "en-US",
+        whisperBinaryPath: nil,
+        whisperModelPath: nil
+    )
+
+    public init(
+        provider: SpeechProvider,
+        localeIdentifier: String,
+        whisperBinaryPath: String?,
+        whisperModelPath: String?
+    ) {
+        self.provider = provider
+        self.localeIdentifier = Self.normalized(localeIdentifier, fallback: "en-US") ?? "en-US"
+        self.whisperBinaryPath = Self.normalized(whisperBinaryPath)
+        self.whisperModelPath = Self.normalized(whisperModelPath)
+    }
+
+    public func validationStatus(fileManager: FileManager = .default) -> SpeechConfigurationValidationStatus {
+        guard provider == .whisper else { return .available }
+        guard let whisperBinaryPath else {
+            return .unavailable("Whisper binary path is not configured")
+        }
+        guard let whisperModelPath else {
+            return .unavailable("Whisper model path is not configured")
+        }
+
+        let binaryURL = URL(fileURLWithPath: whisperBinaryPath)
+        let modelURL = URL(fileURLWithPath: whisperModelPath)
+        guard fileManager.fileExists(atPath: binaryURL.path) else {
+            return .unavailable("Whisper binary does not exist at \(binaryURL.path)")
+        }
+        guard fileManager.isExecutableFile(atPath: binaryURL.path) else {
+            return .unavailable("Whisper binary is not executable at \(binaryURL.path)")
+        }
+        guard fileManager.fileExists(atPath: modelURL.path) else {
+            return .unavailable("Whisper model does not exist at \(modelURL.path)")
+        }
+        guard fileManager.isReadableFile(atPath: modelURL.path) else {
+            return .unavailable("Whisper model is not readable at \(modelURL.path)")
+        }
+        return .available
+    }
+
+    static func normalized(_ value: String?, fallback: String? = nil) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return fallback
+        }
+        return trimmed
+    }
+}
+
+public final class SpeechTranscriptionConfigurationStore {
+    private let userDefaults: UserDefaults
+    private let key: String
+
+    public init(
+        userDefaults: UserDefaults = .standard,
+        key: String = "SpeechTranscriptionConfiguration"
+    ) {
+        self.userDefaults = userDefaults
+        self.key = key
+    }
+
+    public func load() throws -> SpeechTranscriptionConfiguration {
+        guard let data = userDefaults.data(forKey: key) else {
+            return .default
+        }
+        return try JSONDecoder.meetingAgent.decode(SpeechTranscriptionConfiguration.self, from: data)
+    }
+
+    public func save(_ configuration: SpeechTranscriptionConfiguration) throws {
+        let data = try JSONEncoder.meetingAgent.encode(configuration)
+        userDefaults.set(data, forKey: key)
+    }
+}

--- a/Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum SpeechProvider: String, Equatable {
+public enum SpeechProvider: String, Codable, Equatable, CaseIterable {
     case local
     case whisper
 
@@ -10,13 +10,47 @@ public enum SpeechProvider: String, Equatable {
 }
 
 public protocol AudioFrameTranscriber: AnyObject {
+    var failureReason: String? { get }
     func append(_ frame: AudioFrame) throws
     func finish()
+}
+
+public extension AudioFrameTranscriber {
+    var failureReason: String? { nil }
+}
+
+public struct SpeechTranscriptionContext: Equatable {
+    public let inputAudioURL: URL?
+    public let transcriptURL: URL
+    public let localeIdentifier: String
+    public let meetingID: UUID?
+    public let previousTranscript: String?
+
+    public init(
+        inputAudioURL: URL?,
+        transcriptURL: URL,
+        localeIdentifier: String,
+        meetingID: UUID?,
+        previousTranscript: String?
+    ) {
+        self.inputAudioURL = inputAudioURL
+        self.transcriptURL = transcriptURL
+        self.localeIdentifier = localeIdentifier
+        self.meetingID = meetingID
+        self.previousTranscript = previousTranscript
+    }
 }
 
 public protocol SpeechTranscriptionProvider {
     var provider: SpeechProvider { get }
     func start(transcriptURL: URL, localeIdentifier: String) async throws -> AudioFrameTranscriber
+    func transcribeExistingAudio(context: SpeechTranscriptionContext) async throws
+}
+
+public extension SpeechTranscriptionProvider {
+    func transcribeExistingAudio(context: SpeechTranscriptionContext) async throws {
+        throw ProbeError.speechRecognition("\(provider.rawValue) does not support retrying from an existing audio file")
+    }
 }
 
 public struct LocalSpeechTranscriptionProvider: SpeechTranscriptionProvider {
@@ -33,12 +67,15 @@ public struct LocalSpeechTranscriptionProvider: SpeechTranscriptionProvider {
 }
 
 public enum SpeechTranscriptionProviderFactory {
-    public static func provider(for provider: SpeechProvider) -> SpeechTranscriptionProvider {
+    public static func provider(
+        for provider: SpeechProvider,
+        configuration: SpeechTranscriptionConfiguration = .default
+    ) -> SpeechTranscriptionProvider {
         switch provider {
         case .local:
             return LocalSpeechTranscriptionProvider()
         case .whisper:
-            return WhisperSpeechTranscriptionProvider()
+            return WhisperSpeechTranscriptionProvider(appConfiguration: configuration)
         }
     }
 }

--- a/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
@@ -4,6 +4,19 @@ struct WhisperConfiguration: Equatable {
     let binaryURL: URL
     let modelURL: URL
 
+    static func fromAppConfiguration(
+        _ configuration: SpeechTranscriptionConfiguration,
+        fileManager: FileManager = .default
+    ) throws -> WhisperConfiguration {
+        guard let binaryPath = configuration.whisperBinaryPath else {
+            throw unavailable("Whisper binary path is not configured")
+        }
+        guard let modelPath = configuration.whisperModelPath else {
+            throw unavailable("Whisper model path is not configured")
+        }
+        return try validated(binaryPath: binaryPath, modelPath: modelPath, fileManager: fileManager)
+    }
+
     static func fromEnvironment(
         _ environment: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
@@ -15,6 +28,14 @@ struct WhisperConfiguration: Equatable {
             throw unavailable("MEETING_AGENT_WHISPER_MODEL is not set")
         }
 
+        return try validated(binaryPath: binaryPath, modelPath: modelPath, fileManager: fileManager)
+    }
+
+    private static func validated(
+        binaryPath: String,
+        modelPath: String,
+        fileManager: FileManager
+    ) throws -> WhisperConfiguration {
         let binaryURL = URL(fileURLWithPath: binaryPath)
         let modelURL = URL(fileURLWithPath: modelPath)
 
@@ -138,15 +159,89 @@ struct WhisperProcessRunner: WhisperProcessRunning {
 
 struct WhisperSpeechTranscriptionProvider: SpeechTranscriptionProvider {
     let provider: SpeechProvider = .whisper
+    private let configuration: WhisperConfiguration?
+    private let processRunner: WhisperProcessRunning
+
+    init(
+        appConfiguration: SpeechTranscriptionConfiguration = .default,
+        processRunner: WhisperProcessRunning = WhisperProcessRunner()
+    ) {
+        self.configuration = try? WhisperConfiguration.fromAppConfiguration(appConfiguration)
+        self.processRunner = processRunner
+    }
+
+    init(
+        configuration: WhisperConfiguration,
+        processRunner: WhisperProcessRunning = WhisperProcessRunner()
+    ) {
+        self.configuration = configuration
+        self.processRunner = processRunner
+    }
 
     func start(transcriptURL: URL, localeIdentifier: String) async throws -> AudioFrameTranscriber {
-        let configuration = try WhisperConfiguration.fromEnvironment()
+        let configuration = try configuration ?? WhisperConfiguration.fromEnvironment()
         return try WhisperCLITranscriber.start(
             transcriptURL: transcriptURL,
             localeIdentifier: localeIdentifier,
             configuration: configuration,
-            processRunner: WhisperProcessRunner()
+            processRunner: processRunner
         )
+    }
+
+    func transcribeExistingAudio(context: SpeechTranscriptionContext) async throws {
+        guard let inputAudioURL = context.inputAudioURL else {
+            throw ProbeError.speechRecognition("Whisper transcription unavailable: no audio file is available for retry")
+        }
+        let configuration = try configuration ?? WhisperConfiguration.fromEnvironment()
+        try WhisperFileTranscriber.transcribe(
+            inputAudioURL: inputAudioURL,
+            transcriptURL: context.transcriptURL,
+            localeIdentifier: context.localeIdentifier,
+            configuration: configuration,
+            processRunner: processRunner
+        )
+    }
+}
+
+enum WhisperFileTranscriber {
+    static func transcribe(
+        inputAudioURL: URL,
+        transcriptURL: URL,
+        localeIdentifier: String,
+        configuration: WhisperConfiguration,
+        processRunner: WhisperProcessRunning,
+        workingDirectory: URL = FileManager.default.temporaryDirectory
+    ) throws {
+        let temporaryDirectory = workingDirectory.appendingPathComponent("meeting-agent-whisper-retry-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let outputBaseURL = temporaryDirectory.appendingPathComponent("transcript")
+        let outputTextURL = outputBaseURL.appendingPathExtension("txt")
+        try processRunner.run(
+            binaryURL: configuration.binaryURL,
+            modelURL: configuration.modelURL,
+            inputWavURL: inputAudioURL,
+            outputBaseURL: outputBaseURL,
+            languageCode: WhisperLanguageMapper.languageCode(for: localeIdentifier)
+        )
+        guard FileManager.default.fileExists(atPath: outputTextURL.path) else {
+            throw ProbeError.speechRecognition("Whisper transcription unavailable: expected output file was not created")
+        }
+
+        let transcript = normalizedTranscript(try String(contentsOf: outputTextURL, encoding: .utf8))
+        try TranscriptFileWriter(url: transcriptURL).replace(
+            with: transcript.isEmpty ? "" : TranscriptFormatter.render([TranscriptSegment(text: transcript)])
+        )
+    }
+
+    private static func normalizedTranscript(_ text: String) -> String {
+        text
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .filter { $0.caseInsensitiveCompare("[BLANK_AUDIO]") != .orderedSame }
+            .joined(separator: "\n")
     }
 }
 
@@ -164,6 +259,7 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
     private var chunkIndex = 0
     private var transcriptSegments: [TranscriptSegment] = []
     private var isFinished = false
+    private(set) var failureReason: String?
 
     private init(
         transcriptURL: URL,
@@ -228,7 +324,9 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
                 try transcribePendingChunk()
             }
         } catch {
-            try? TranscriptFileWriter(url: transcriptURL).replace(with: failureMessage(for: error))
+            let message = failureMessage(for: error)
+            failureReason = message
+            try? TranscriptFileWriter(url: transcriptURL).replace(with: message)
         }
 
         try? FileManager.default.removeItem(at: temporaryDirectory)

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -48,7 +48,14 @@ final class MeetingAgentViewModelTests: XCTestCase {
     }
 
     func testSpeechLocaleCanBeConfiguredForAppRecording() {
-        let viewModel = MeetingAgentViewModel(speechLocaleIdentifier: "zh-CN")
+        let viewModel = MeetingAgentViewModel(
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "zh-CN",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil
+            )
+        )
 
         XCTAssertEqual(viewModel.speechLocaleIdentifier, "zh-CN")
         XCTAssertEqual(viewModel.speechProvider, .whisper)
@@ -56,6 +63,53 @@ final class MeetingAgentViewModelTests: XCTestCase {
         viewModel.updateSpeechLocaleIdentifier(" ja-JP ")
 
         XCTAssertEqual(viewModel.speechLocaleIdentifier, "ja-JP")
+    }
+
+    func testSpeechConfigurationCanBeUpdatedForAppRecording() {
+        let suiteName = "meeting-vm-settings-\(UUID().uuidString)"
+        let userDefaults = UserDefaults(suiteName: suiteName)!
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+        let viewModel = MeetingAgentViewModel(
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "en-US",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil
+            ),
+            speechConfigurationStore: SpeechTranscriptionConfigurationStore(userDefaults: userDefaults)
+        )
+
+        viewModel.updateSpeechProvider(.local)
+        viewModel.updateSpeechLocaleIdentifier(" zh-CN ")
+        viewModel.updateWhisperBinaryPath(" /opt/homebrew/bin/whisper-cli ")
+        viewModel.updateWhisperModelPath(" /Users/allan/models/ggml-small.bin ")
+
+        XCTAssertEqual(viewModel.speechConfiguration.provider, .local)
+        XCTAssertEqual(viewModel.speechConfiguration.localeIdentifier, "zh-CN")
+        XCTAssertEqual(viewModel.speechConfiguration.whisperBinaryPath, "/opt/homebrew/bin/whisper-cli")
+        XCTAssertEqual(viewModel.speechConfiguration.whisperModelPath, "/Users/allan/models/ggml-small.bin")
+    }
+
+    func testExplicitSpeechInitializerArgumentsOverridePersistedSettings() throws {
+        let suiteName = "meeting-vm-settings-\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+        let configurationStore = SpeechTranscriptionConfigurationStore(userDefaults: userDefaults)
+        try configurationStore.save(SpeechTranscriptionConfiguration(
+            provider: .local,
+            localeIdentifier: "ja-JP",
+            whisperBinaryPath: nil,
+            whisperModelPath: nil
+        ))
+
+        let viewModel = MeetingAgentViewModel(
+            speechLocaleIdentifier: "zh-CN",
+            speechProvider: .whisper,
+            speechConfigurationStore: configurationStore
+        )
+
+        XCTAssertEqual(viewModel.speechProvider, .whisper)
+        XCTAssertEqual(viewModel.speechLocaleIdentifier, "zh-CN")
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
@@ -13,13 +13,33 @@ final class MeetingRecordTests: XCTestCase {
             endedAt: endedAt,
             audioURL: URL(fileURLWithPath: "/tmp/audio.wav"),
             transcriptURL: URL(fileURLWithPath: "/tmp/transcript.txt"),
-            transcriptJSONURL: URL(fileURLWithPath: "/tmp/transcript.json")
+            transcriptJSONURL: URL(fileURLWithPath: "/tmp/transcript.json"),
+            transcriptionStatus: .transcribed,
+            transcriptionFailureReason: nil,
+            speechProvider: .whisper,
+            speechLocaleIdentifier: "zh-CN"
         )
 
         let data = try JSONEncoder.meetingAgent.encode(record)
         let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: data)
 
         XCTAssertEqual(decoded, record)
+    }
+
+    func testNewMeetingDefaultsToNotStartedTranscription() {
+        let record = MeetingRecord(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            name: "Google Meet",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            endedAt: nil,
+            audioURL: URL(fileURLWithPath: "/tmp/audio.wav"),
+            transcriptURL: URL(fileURLWithPath: "/tmp/transcript.txt")
+        )
+
+        XCTAssertEqual(record.transcriptionStatus, .notStarted)
+        XCTAssertNil(record.transcriptionFailureReason)
+        XCTAssertEqual(record.speechProvider, .whisper)
+        XCTAssertEqual(record.speechLocaleIdentifier, "en-US")
     }
 
     func testActiveRecordHasNoEndTime() {
@@ -51,5 +71,9 @@ final class MeetingRecordTests: XCTestCase {
 
         XCTAssertNil(decoded.diagnosticsURL)
         XCTAssertNil(decoded.transcriptJSONURL)
+        XCTAssertEqual(decoded.transcriptionStatus, .notStarted)
+        XCTAssertNil(decoded.transcriptionFailureReason)
+        XCTAssertEqual(decoded.speechProvider, .whisper)
+        XCTAssertEqual(decoded.speechLocaleIdentifier, "en-US")
     }
 }

--- a/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
+++ b/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class SpeechTranscriptionConfigurationTests: XCTestCase {
+    func testWhisperValidationReportsMissingPaths() {
+        let configuration = SpeechTranscriptionConfiguration(
+            provider: .whisper,
+            localeIdentifier: "zh-CN",
+            whisperBinaryPath: "",
+            whisperModelPath: nil
+        )
+
+        XCTAssertEqual(
+            configuration.validationStatus(fileManager: .default),
+            .unavailable("Whisper binary path is not configured")
+        )
+    }
+
+    func testWhisperValidationAcceptsConfiguredBinaryAndModel() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("speech-config-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let binaryURL = directory.appendingPathComponent("whisper-cli")
+        let modelURL = directory.appendingPathComponent("ggml-small.bin")
+        FileManager.default.createFile(atPath: binaryURL.path, contents: Data())
+        FileManager.default.createFile(atPath: modelURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+
+        let configuration = SpeechTranscriptionConfiguration(
+            provider: .whisper,
+            localeIdentifier: "zh-CN",
+            whisperBinaryPath: binaryURL.path,
+            whisperModelPath: modelURL.path
+        )
+
+        XCTAssertEqual(configuration.validationStatus(fileManager: .default), .available)
+        XCTAssertEqual(try WhisperConfiguration.fromAppConfiguration(configuration, fileManager: .default).binaryURL, binaryURL)
+    }
+
+    func testLocalProviderDoesNotRequireWhisperPaths() {
+        let configuration = SpeechTranscriptionConfiguration(
+            provider: .local,
+            localeIdentifier: "en-US",
+            whisperBinaryPath: nil,
+            whisperModelPath: nil
+        )
+
+        XCTAssertEqual(configuration.validationStatus(fileManager: .default), .available)
+    }
+
+    func testConfigurationStorePersistsUserSettings() throws {
+        let suiteName = "meeting-agent-tests-\(UUID().uuidString)"
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { userDefaults.removePersistentDomain(forName: suiteName) }
+        let store = SpeechTranscriptionConfigurationStore(userDefaults: userDefaults)
+
+        try store.save(SpeechTranscriptionConfiguration(
+            provider: .local,
+            localeIdentifier: "ja-JP",
+            whisperBinaryPath: "/opt/homebrew/bin/whisper-cli",
+            whisperModelPath: "/Users/allan/models/ggml-small.bin"
+        ))
+
+        XCTAssertEqual(try store.load(), SpeechTranscriptionConfiguration(
+            provider: .local,
+            localeIdentifier: "ja-JP",
+            whisperBinaryPath: "/opt/homebrew/bin/whisper-cli",
+            whisperModelPath: "/Users/allan/models/ggml-small.bin"
+        ))
+    }
+}

--- a/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
@@ -130,9 +130,41 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
     }
 
     func testFactoryReturnsWhisperProvider() {
-        let provider = SpeechTranscriptionProviderFactory.provider(for: .whisper)
+        let provider = SpeechTranscriptionProviderFactory.provider(for: .whisper, configuration: .default)
 
         XCTAssertEqual(provider.provider, .whisper)
+    }
+
+    func testTranscribesExistingAudioFile() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-retry-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioURL = directory.appendingPathComponent("audio.wav")
+        let transcriptURL = directory.appendingPathComponent("transcript.txt")
+        FileManager.default.createFile(atPath: audioURL.path, contents: Data([0x52, 0x49, 0x46, 0x46]))
+        let configuration = WhisperConfiguration(
+            binaryURL: directory.appendingPathComponent("whisper-cli"),
+            modelURL: directory.appendingPathComponent("ggml-small.bin")
+        )
+        let runner = OutputWritingWhisperProcessRunner(outputText: "retry transcript\n")
+
+        try await WhisperSpeechTranscriptionProvider(
+            configuration: configuration,
+            processRunner: runner
+        )
+        .transcribeExistingAudio(
+            context: SpeechTranscriptionContext(
+                inputAudioURL: audioURL,
+                transcriptURL: transcriptURL,
+                localeIdentifier: "en-US",
+                meetingID: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!,
+                previousTranscript: nil
+            )
+        )
+
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "User A:\nretry transcript\n")
+        XCTAssertEqual(runner.inputWavURL, audioURL)
     }
 
     func testTranscriberRunsWhisperAndWritesTranscript() throws {
@@ -247,6 +279,7 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         transcriber.finish()
 
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "Whisper transcription unavailable: process failed\n")
+        XCTAssertEqual(transcriber.failureReason, "Whisper transcription unavailable: process failed")
     }
 
     func testTranscriberWritesFailureReasonWhenNoFramesWereCaptured() throws {
@@ -271,6 +304,7 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         transcriber.finish()
 
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "Whisper transcription unavailable: no audio frames were captured\n")
+        XCTAssertEqual(transcriber.failureReason, "Whisper transcription unavailable: no audio frames were captured")
         XCTAssertNil(runner.inputWavURL)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5

- Adds persisted app-level STT configuration for provider, locale, and Whisper paths.
- Persists per-meeting transcription status and failure reasons separately from transcript text.
- Adds Whisper retry from an existing saved audio file and exposes status/retry controls in the app.

## Changes

- Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift - adds STT settings, validation, and UserDefaults persistence.
- Sources/MeetingAgentCore/MeetingRecord.swift - adds transcription status, failure, provider, and locale metadata with backward-compatible decoding.
- Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift - extends provider context for existing-audio retry.
- Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift - supports configured app paths and retrying a saved WAV.
- Sources/MeetingAgentCore/MeetingRecorder.swift - persists transcription status/failures during recording.
- Sources/MeetingAgentCore/MeetingAgentViewModel.swift - wires configuration persistence and retry flow.
- Sources/MeetingAgentApp/MainWindowView.swift - adds STT settings, validation status, transcription status, failure reason, and retry action.
- Tests/MeetingAgentCoreTests - adds coverage for settings, metadata defaults, retry, failure reporting, and view model configuration.
- MISTAKES.md - records a reusable test-isolation lesson.

## Test plan

- [x] Build/lint: swift test passed
- [x] Unit tests: swift test passed, 77 tests
- [x] E2E/integration: skipped; no E2E convention in this Swift package for this app flow
- [x] Code review: PASS after manual Swift review
- [x] Manual verification: App and CLI targets compiled during swift test
