### PR TITLE
feat: add product readiness exports

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -29,3 +29,19 @@ Inject a suite-scoped `UserDefaults` through `SpeechTranscriptionConfigurationSt
 Never use process-global persistence directly in unit tests; inject an isolated store.
 
 ---
+
+## [7] Applying patches from a linked worktree
+
+**Date**: 2026-04-25
+**Category**: convention-violation
+
+### What went wrong
+The first design-document patch used relative paths while the active task was in a linked issue worktree, so the files landed in the original checkout before being moved.
+
+### Correct approach
+When editing a linked worktree with `apply_patch`, use absolute paths or otherwise verify the patch target is the issue worktree before writing files.
+
+### How to avoid
+For worktree-based issue fixes, patch absolute paths under the issue worktree.
+
+---

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import MeetingAgentCore
 import SwiftUI
 
@@ -81,6 +82,29 @@ struct MainWindowView: View {
                 stopRecording: {
                     viewModel.stopRecording()
                 },
+                copySummary: { meeting in
+                    copySummary(for: meeting)
+                },
+                exportTranscript: { meeting in
+                    export("transcript.txt", for: meeting) { destination in
+                        try viewModel.exportTranscript(for: meeting.id, to: destination)
+                    }
+                },
+                exportSummary: { meeting in
+                    export("summary.md", for: meeting) { destination in
+                        try viewModel.exportSummary(for: meeting.id, to: destination)
+                    }
+                },
+                exportMeetingData: { meeting in
+                    export("meeting.json", for: meeting) { destination in
+                        try viewModel.exportMeetingData(for: meeting.id, to: destination)
+                    }
+                },
+                exportReadinessReport: { meeting in
+                    export("readiness-report.md", for: meeting) { destination in
+                        try viewModel.exportReadinessReport(for: meeting.id, to: destination)
+                    }
+                },
                 retryTranscription: { meeting in
                     Task {
                         await viewModel.retryTranscription(for: meeting.id)
@@ -113,6 +137,41 @@ struct MainWindowView: View {
         }
     }
 
+    private func copySummary(for meeting: MeetingRecord) {
+        do {
+            let summary = try viewModel.summaryTextForClipboard(for: meeting.id)
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(summary, forType: .string)
+        } catch {
+            NSSound.beep()
+        }
+    }
+
+    private func export(_ suggestedName: String, for meeting: MeetingRecord, operation: (URL) throws -> Void) {
+        let panel = NSSavePanel()
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = "\(sanitizedFileNameComponent(meeting.name))-\(suggestedName)"
+        panel.title = "Export \(suggestedName)"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try operation(url)
+        } catch {
+            NSSound.beep()
+        }
+    }
+
+    private func sanitizedFileNameComponent(_ value: String) -> String {
+        let invalidCharacters = CharacterSet(charactersIn: "/:")
+            .union(.controlCharacters)
+            .union(.newlines)
+        let sanitized = value
+            .components(separatedBy: invalidCharacters)
+            .joined(separator: "-")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return sanitized.isEmpty ? "meeting" : sanitized
+    }
+
     private var configurationStatusText: String {
         switch viewModel.speechConfigurationStatus {
         case .available:
@@ -137,6 +196,11 @@ private struct MeetingDetailView: View {
     let statusText: String
     let isRecording: Bool
     let stopRecording: () -> Void
+    let copySummary: (MeetingRecord) -> Void
+    let exportTranscript: (MeetingRecord) -> Void
+    let exportSummary: (MeetingRecord) -> Void
+    let exportMeetingData: (MeetingRecord) -> Void
+    let exportReadinessReport: (MeetingRecord) -> Void
     let retryTranscription: (MeetingRecord) -> Void
 
     var body: some View {
@@ -168,6 +232,44 @@ private struct MeetingDetailView: View {
                     retryTranscription(meeting)
                 }
                 .disabled(isRecording || meeting.audioURL == nil)
+                Divider()
+                Text("Exports")
+                    .font(.headline)
+                HStack {
+                    Button {
+                        copySummary(meeting)
+                    } label: {
+                        Label("Copy Summary", systemImage: "doc.on.clipboard")
+                    }
+                    .disabled(isRecording || meeting.summaryURL == nil)
+
+                    Button {
+                        exportTranscript(meeting)
+                    } label: {
+                        Label("Transcript", systemImage: "doc.text")
+                    }
+                    .disabled(isRecording || meeting.transcriptURL == nil)
+
+                    Button {
+                        exportSummary(meeting)
+                    } label: {
+                        Label("Summary", systemImage: "text.badge.checkmark")
+                    }
+                    .disabled(isRecording || meeting.summaryURL == nil)
+                }
+                HStack {
+                    Button {
+                        exportMeetingData(meeting)
+                    } label: {
+                        Label("Meeting JSON", systemImage: "curlybraces")
+                    }
+
+                    Button {
+                        exportReadinessReport(meeting)
+                    } label: {
+                        Label("Readiness Report", systemImage: "checklist")
+                    }
+                }
                 Divider()
                 Text("Transcript")
                     .font(.headline)

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -12,6 +12,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     private let store: MeetingStore
     private let speechConfigurationStore: SpeechTranscriptionConfigurationStore
     private let recorder: MeetingRecorder
+    private let exportService: MeetingExportService
     private let processMonitor = MeetingProcessMonitor()
     private var activeTarget: AudioCaptureTarget?
 
@@ -21,11 +22,13 @@ public final class MeetingAgentViewModel: ObservableObject {
         speechLocaleIdentifier: String = Locale.current.identifier,
         speechProvider: SpeechProvider = .whisper,
         speechConfiguration: SpeechTranscriptionConfiguration? = nil,
-        speechConfigurationStore: SpeechTranscriptionConfigurationStore = SpeechTranscriptionConfigurationStore()
+        speechConfigurationStore: SpeechTranscriptionConfigurationStore = SpeechTranscriptionConfigurationStore(),
+        exportService: MeetingExportService = MeetingExportService()
     ) {
         self.store = store
         self.speechConfigurationStore = speechConfigurationStore
         self.recorder = recorder ?? MeetingRecorder(store: store)
+        self.exportService = exportService
         if let speechConfiguration {
             self.speechConfiguration = speechConfiguration
         } else if speechProvider != .whisper || speechLocaleIdentifier != Locale.current.identifier {
@@ -145,6 +148,46 @@ public final class MeetingAgentViewModel: ObservableObject {
         selectedMeetingID = id
     }
 
+    public func exportTranscript(for meetingID: UUID, to destinationURL: URL) throws {
+        try export("Transcript", for: meetingID) { record in
+            try exportService.exportTranscript(for: record, to: destinationURL)
+        }
+    }
+
+    public func exportSummary(for meetingID: UUID, to destinationURL: URL) throws {
+        try export("Summary", for: meetingID) { record in
+            try exportService.exportSummary(for: record, to: destinationURL)
+        }
+    }
+
+    public func exportMeetingData(for meetingID: UUID, to destinationURL: URL) throws {
+        try export("Meeting data", for: meetingID) { record in
+            try exportService.exportMeetingData(for: record, to: destinationURL)
+        }
+    }
+
+    public func exportReadinessReport(for meetingID: UUID, to destinationURL: URL) throws {
+        try export("Readiness report", for: meetingID) { record in
+            try exportService.exportReadinessReport(for: record, to: destinationURL)
+        }
+    }
+
+    public func summaryTextForClipboard(for meetingID: UUID) throws -> String {
+        guard let record = meetings.first(where: { $0.id == meetingID }) else {
+            let error = MeetingExportError.missingArtifact("meeting")
+            statusText = "Copy summary failed: \(Self.errorMessage(error))"
+            throw error
+        }
+        do {
+            let summary = try exportService.summaryText(for: record)
+            statusText = "Summary copied"
+            return summary
+        } catch {
+            statusText = "Copy summary failed: \(Self.errorMessage(error))"
+            throw error
+        }
+    }
+
     public func retryTranscription(for meetingID: UUID) async {
         guard let index = meetings.firstIndex(where: { $0.id == meetingID }) else { return }
         var record = meetings[index]
@@ -254,5 +297,29 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     private func persistSpeechConfiguration() {
         try? speechConfigurationStore.save(speechConfiguration)
+    }
+
+    private func export(_ label: String, for meetingID: UUID, operation: (MeetingRecord) throws -> Void) throws {
+        guard let record = meetings.first(where: { $0.id == meetingID }) else {
+            let error = MeetingExportError.missingArtifact("meeting")
+            statusText = "\(label) export failed: \(Self.errorMessage(error))"
+            throw error
+        }
+
+        do {
+            try operation(record)
+            statusText = "\(label) exported"
+        } catch {
+            statusText = "\(label) export failed: \(Self.errorMessage(error))"
+            throw error
+        }
+    }
+
+    private static func errorMessage(_ error: Error) -> String {
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription {
+            return description
+        }
+        return String(describing: error)
     }
 }

--- a/Sources/MeetingAgentCore/MeetingExportService.swift
+++ b/Sources/MeetingAgentCore/MeetingExportService.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+public enum MeetingExportError: Error, Equatable, LocalizedError {
+    case missingArtifact(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingArtifact(let name):
+            return "Missing \(name) artifact"
+        }
+    }
+}
+
+public struct MeetingExportService {
+    private let fileManager: FileManager
+
+    public init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    public func exportTranscript(for record: MeetingRecord, to destinationURL: URL) throws {
+        guard let transcript = TranscriptFileWriter.renderedTranscript(
+            textURL: record.transcriptURL,
+            structuredURL: record.transcriptJSONURL
+        ) else {
+            throw MeetingExportError.missingArtifact("transcript")
+        }
+        try write(transcript, to: destinationURL)
+    }
+
+    public func exportSummary(for record: MeetingRecord, to destinationURL: URL) throws {
+        try write(try summaryText(for: record), to: destinationURL)
+    }
+
+    public func exportMeetingData(for record: MeetingRecord, to destinationURL: URL) throws {
+        try createDestinationDirectory(for: destinationURL)
+        let data = try JSONEncoder.meetingAgent.encode(record)
+        try data.write(to: destinationURL, options: .atomic)
+    }
+
+    public func exportReadinessReport(for record: MeetingRecord, to destinationURL: URL) throws {
+        try write(readinessReport(for: record), to: destinationURL)
+    }
+
+    public func summaryText(for record: MeetingRecord) throws -> String {
+        guard let summaryURL = record.summaryURL,
+              fileManager.fileExists(atPath: summaryURL.path)
+        else {
+            throw MeetingExportError.missingArtifact("summary")
+        }
+
+        let summary = try String(contentsOf: summaryURL, encoding: .utf8)
+        guard !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MeetingExportError.missingArtifact("summary")
+        }
+        return summary
+    }
+
+    private func readinessReport(for record: MeetingRecord) -> String {
+        let transcript = TranscriptFileWriter.renderedTranscript(
+            textURL: record.transcriptURL,
+            structuredURL: record.transcriptJSONURL
+        )
+        let diagnostics = diagnostics(for: record)
+        let summaryAvailable = record.summaryURL.map { fileManager.fileExists(atPath: $0.path) } ?? false
+
+        var lines: [String] = [
+            "# Meeting Readiness Report",
+            "",
+            "## Meeting",
+            "",
+            "- Name: \(record.name)",
+            "- ID: \(record.id.uuidString)",
+            "- Started: \(format(record.startedAt))",
+            "- Ended: \(record.endedAt.map(format) ?? "Not ended")",
+            "- STT provider: \(record.speechProvider.rawValue)",
+            "- Language: \(record.speechLocaleIdentifier)",
+            "- Transcription: \(transcriptionLabel(for: record.transcriptionStatus))",
+            "- Failure reason: \(record.transcriptionFailureReason ?? "None")",
+            "",
+            "## Artifacts",
+            "",
+            "- Audio: \(artifactPath(record.audioURL))",
+            "- Transcript: \(artifactPath(record.transcriptURL))",
+            "- Structured transcript: \(artifactPath(record.transcriptJSONURL))",
+            "- Summary: \(summaryAvailable ? artifactPath(record.summaryURL) : "Not generated")",
+            "- Diagnostics: \(artifactPath(record.diagnosticsURL))",
+            "",
+            "## Capture Diagnostics",
+            ""
+        ]
+
+        if let diagnostics {
+            lines.append(contentsOf: [
+                "- Status: \(diagnostics.status.rawValue)",
+                "- Frames captured: \(diagnostics.framesCaptured)",
+                "- Duration seconds: \(format(diagnostics.durationSeconds))",
+                "- Average level: \(format(diagnostics.averageLevel))",
+                "- Peak level: \(format(diagnostics.peakLevel))",
+                "- Silent duration seconds: \(format(diagnostics.silentDurationSeconds))",
+                "- Dropped frames: \(diagnostics.droppedFrameCount)",
+                ""
+            ])
+        } else {
+            lines.append(contentsOf: [
+                "No diagnostics artifact is available.",
+                ""
+            ])
+        }
+
+        lines.append(contentsOf: [
+            "## Transcript Excerpt",
+            "",
+            transcriptExcerpt(from: transcript),
+            ""
+        ])
+
+        return lines.joined(separator: "\n")
+    }
+
+    private func diagnostics(for record: MeetingRecord) -> CaptureDiagnostics? {
+        guard let diagnosticsURL = record.diagnosticsURL,
+              fileManager.fileExists(atPath: diagnosticsURL.path),
+              let data = try? Data(contentsOf: diagnosticsURL)
+        else {
+            return nil
+        }
+        return try? JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
+    }
+
+    private func write(_ text: String, to destinationURL: URL) throws {
+        try createDestinationDirectory(for: destinationURL)
+        try text.write(to: destinationURL, atomically: true, encoding: .utf8)
+    }
+
+    private func createDestinationDirectory(for destinationURL: URL) throws {
+        let directory = destinationURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    private func artifactPath(_ url: URL?) -> String {
+        url?.path ?? "Not available"
+    }
+
+    private func transcriptExcerpt(from transcript: String?) -> String {
+        guard let transcript,
+              !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return "Transcript is not available."
+        }
+
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 1_000 else { return trimmed }
+        let endIndex = trimmed.index(trimmed.startIndex, offsetBy: 1_000)
+        return String(trimmed[..<endIndex]) + "..."
+    }
+
+    private func transcriptionLabel(for status: TranscriptionStatus) -> String {
+        switch status {
+        case .notStarted:
+            return "Not started"
+        case .transcribing:
+            return "Transcribing"
+        case .transcribed:
+            return "Transcribed"
+        case .failed:
+            return "Failed"
+        case .retryRequested:
+            return "Retry requested"
+        }
+    }
+
+    private func format(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
+    }
+
+    private func format(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+}

--- a/Sources/MeetingAgentCore/MeetingRecord.swift
+++ b/Sources/MeetingAgentCore/MeetingRecord.swift
@@ -16,6 +16,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
     public var audioURL: URL?
     public var transcriptURL: URL?
     public var transcriptJSONURL: URL?
+    public var summaryURL: URL?
     public var diagnosticsURL: URL?
     public var transcriptionStatus: TranscriptionStatus
     public var transcriptionFailureReason: String?
@@ -30,6 +31,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         audioURL: URL?,
         transcriptURL: URL?,
         transcriptJSONURL: URL? = nil,
+        summaryURL: URL? = nil,
         diagnosticsURL: URL? = nil,
         transcriptionStatus: TranscriptionStatus = .notStarted,
         transcriptionFailureReason: String? = nil,
@@ -43,6 +45,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         self.audioURL = audioURL
         self.transcriptURL = transcriptURL
         self.transcriptJSONURL = transcriptJSONURL
+        self.summaryURL = summaryURL
         self.diagnosticsURL = diagnosticsURL
         self.transcriptionStatus = transcriptionStatus
         self.transcriptionFailureReason = transcriptionFailureReason
@@ -58,6 +61,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         case audioURL
         case transcriptURL
         case transcriptJSONURL
+        case summaryURL
         case diagnosticsURL
         case transcriptionStatus
         case transcriptionFailureReason
@@ -74,6 +78,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         audioURL = try container.decodeIfPresent(URL.self, forKey: .audioURL)
         transcriptURL = try container.decodeIfPresent(URL.self, forKey: .transcriptURL)
         transcriptJSONURL = try container.decodeIfPresent(URL.self, forKey: .transcriptJSONURL)
+        summaryURL = try container.decodeIfPresent(URL.self, forKey: .summaryURL)
         diagnosticsURL = try container.decodeIfPresent(URL.self, forKey: .diagnosticsURL)
         transcriptionStatus = try container.decodeIfPresent(TranscriptionStatus.self, forKey: .transcriptionStatus) ?? .notStarted
         transcriptionFailureReason = try container.decodeIfPresent(String.self, forKey: .transcriptionFailureReason)

--- a/Sources/MeetingAgentCore/MeetingStore.swift
+++ b/Sources/MeetingAgentCore/MeetingStore.swift
@@ -42,6 +42,7 @@ public final class MeetingStore {
             audioURL: directory.appendingPathComponent("audio.wav"),
             transcriptURL: directory.appendingPathComponent("transcript.txt"),
             transcriptJSONURL: directory.appendingPathComponent("transcript.json"),
+            summaryURL: directory.appendingPathComponent("summary.md"),
             diagnosticsURL: directory.appendingPathComponent("diagnostics.json")
         )
         try save(record)

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -111,6 +111,34 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.speechProvider, .whisper)
         XCTAssertEqual(viewModel.speechLocaleIdentifier, "zh-CN")
     }
+
+    func testExportsSelectedMeetingTranscriptAndUpdatesStatus() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let stored = try store.createMeeting(name: "Google Meet", startedAt: Date(timeIntervalSince1970: 100))
+        try "Transcript text".write(to: XCTUnwrap(stored.record.transcriptURL), atomically: true, encoding: .utf8)
+        let viewModel = MeetingAgentViewModel(store: store)
+        try viewModel.loadMeetings()
+        let destination = root.appendingPathComponent("exported-transcript.txt")
+
+        try viewModel.exportTranscript(for: stored.record.id, to: destination)
+
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "Transcript text")
+        XCTAssertEqual(viewModel.statusText, "Transcript exported")
+    }
+
+    func testSummaryClipboardTextFailsWithClearStatusWhenSummaryMissing() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let stored = try store.createMeeting(name: "Google Meet", startedAt: Date(timeIntervalSince1970: 100))
+        let viewModel = MeetingAgentViewModel(store: store)
+        try viewModel.loadMeetings()
+
+        XCTAssertThrowsError(try viewModel.summaryTextForClipboard(for: stored.record.id))
+        XCTAssertEqual(viewModel.statusText, "Copy summary failed: Missing summary artifact")
+    }
 }
 
 final class AppRuntimeCapabilitiesTests: XCTestCase {

--- a/Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class MeetingExportServiceTests: XCTestCase {
+    func testExportsRenderedStructuredTranscript() throws {
+        let fixture = try MeetingExportFixture()
+        defer { fixture.cleanup() }
+        try fixture.writeStructuredTranscript([
+            TranscriptSegment(speaker: TranscriptSpeaker(identifier: "a", label: "Allan"), text: "Hello"),
+            TranscriptSegment(speaker: TranscriptSpeaker(identifier: "a", label: "Allan"), text: "Next step")
+        ])
+        let destination = fixture.root.appendingPathComponent("transcript-export.txt")
+
+        try MeetingExportService().exportTranscript(for: fixture.record, to: destination)
+
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "Allan:\nHello\nNext step")
+    }
+
+    func testExportsSummaryMarkdownWhenPresent() throws {
+        let fixture = try MeetingExportFixture()
+        defer { fixture.cleanup() }
+        try "# Summary\n\n- Decision made\n".write(to: fixture.record.summaryURL!, atomically: true, encoding: .utf8)
+        let destination = fixture.root.appendingPathComponent("summary-export.md")
+
+        try MeetingExportService().exportSummary(for: fixture.record, to: destination)
+
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "# Summary\n\n- Decision made\n")
+    }
+
+    func testSummaryExportFailsWhenSummaryMissing() throws {
+        let fixture = try MeetingExportFixture()
+        defer { fixture.cleanup() }
+
+        XCTAssertThrowsError(try MeetingExportService().exportSummary(
+            for: fixture.record,
+            to: fixture.root.appendingPathComponent("summary-export.md")
+        )) { error in
+            XCTAssertEqual(error as? MeetingExportError, .missingArtifact("summary"))
+        }
+    }
+
+    func testExportsMeetingDataJSON() throws {
+        let fixture = try MeetingExportFixture()
+        defer { fixture.cleanup() }
+        let destination = fixture.root.appendingPathComponent("meeting.json")
+
+        try MeetingExportService().exportMeetingData(for: fixture.record, to: destination)
+
+        let data = try Data(contentsOf: destination)
+        let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: data)
+        XCTAssertEqual(decoded.id, fixture.record.id)
+        XCTAssertEqual(decoded.summaryURL?.lastPathComponent, "summary.md")
+    }
+
+    func testExportsReadinessMarkdownReport() throws {
+        let fixture = try MeetingExportFixture()
+        defer { fixture.cleanup() }
+        try "Plain transcript text for validation.".write(to: fixture.record.transcriptURL!, atomically: true, encoding: .utf8)
+        try CaptureDiagnostics(
+            framesCaptured: 44_100,
+            durationSeconds: 1,
+            lastFrameAt: Date(timeIntervalSince1970: 1_777_000_001),
+            sampleRate: 44_100,
+            channelCount: 2,
+            averageLevel: 0.2,
+            peakLevel: 0.8,
+            silentDurationSeconds: 0,
+            bufferBacklog: 0,
+            droppedFrameCount: 0,
+            targetProcessID: 42,
+            targetDisplayName: "Google Chrome",
+            endedReason: .saved,
+            status: .recordingSaved
+        ).write(to: fixture.record.diagnosticsURL!)
+        let destination = fixture.root.appendingPathComponent("readiness.md")
+
+        try MeetingExportService().exportReadinessReport(for: fixture.record, to: destination)
+
+        let markdown = try String(contentsOf: destination, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("# Meeting Readiness Report"))
+        XCTAssertTrue(markdown.contains("Google Meet"))
+        XCTAssertTrue(markdown.contains("Transcribed"))
+        XCTAssertTrue(markdown.contains("Plain transcript text for validation."))
+        XCTAssertTrue(markdown.contains("recordingSaved"))
+    }
+}
+
+private struct MeetingExportFixture {
+    let root: URL
+    let record: MeetingRecord
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-export-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        record = MeetingRecord(
+            id: UUID(uuidString: "77777777-7777-7777-7777-777777777777")!,
+            name: "Google Meet",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            endedAt: Date(timeIntervalSince1970: 1_777_000_600),
+            audioURL: root.appendingPathComponent("audio.wav"),
+            transcriptURL: root.appendingPathComponent("transcript.txt"),
+            transcriptJSONURL: root.appendingPathComponent("transcript.json"),
+            summaryURL: root.appendingPathComponent("summary.md"),
+            diagnosticsURL: root.appendingPathComponent("diagnostics.json"),
+            transcriptionStatus: .transcribed,
+            transcriptionFailureReason: nil,
+            speechProvider: .whisper,
+            speechLocaleIdentifier: "zh-CN"
+        )
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func writeStructuredTranscript(_ segments: [TranscriptSegment]) throws {
+        let data = try JSONEncoder.meetingAgent.encode(TranscriptDocument(segments: segments))
+        try data.write(to: record.transcriptJSONURL!, options: .atomic)
+    }
+}

--- a/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
@@ -14,6 +14,7 @@ final class MeetingRecordTests: XCTestCase {
             audioURL: URL(fileURLWithPath: "/tmp/audio.wav"),
             transcriptURL: URL(fileURLWithPath: "/tmp/transcript.txt"),
             transcriptJSONURL: URL(fileURLWithPath: "/tmp/transcript.json"),
+            summaryURL: URL(fileURLWithPath: "/tmp/summary.md"),
             transcriptionStatus: .transcribed,
             transcriptionFailureReason: nil,
             speechProvider: .whisper,
@@ -75,5 +76,24 @@ final class MeetingRecordTests: XCTestCase {
         XCTAssertNil(decoded.transcriptionFailureReason)
         XCTAssertEqual(decoded.speechProvider, .whisper)
         XCTAssertEqual(decoded.speechLocaleIdentifier, "en-US")
+    }
+
+    func testDecodesMetadataWithoutSummaryURL() throws {
+        let json = """
+        {
+          "audioURL" : "file:\\/\\/\\/tmp\\/audio.wav",
+          "diagnosticsURL" : "file:\\/\\/\\/tmp\\/diagnostics.json",
+          "endedAt" : null,
+          "id" : "11111111-1111-1111-1111-111111111111",
+          "name" : "Google Meet",
+          "startedAt" : "2026-04-25T10:00:00Z",
+          "transcriptJSONURL" : "file:\\/\\/\\/tmp\\/transcript.json",
+          "transcriptURL" : "file:\\/\\/\\/tmp\\/transcript.txt"
+        }
+        """
+
+        let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: Data(json.utf8))
+
+        XCTAssertNil(decoded.summaryURL)
     }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
@@ -18,6 +18,7 @@ final class MeetingStoreTests: XCTestCase {
         XCTAssertEqual(created.record.audioURL?.lastPathComponent, "audio.wav")
         XCTAssertEqual(created.record.transcriptURL?.lastPathComponent, "transcript.txt")
         XCTAssertEqual(created.record.transcriptJSONURL?.lastPathComponent, "transcript.json")
+        XCTAssertEqual(created.record.summaryURL?.lastPathComponent, "summary.md")
         XCTAssertEqual(created.record.diagnosticsURL?.lastPathComponent, "diagnostics.json")
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.directory.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.metadataURL.path))

--- a/docs/superpowers/plans/2026-04-25-product-readiness-export.md
+++ b/docs/superpowers/plans/2026-04-25-product-readiness-export.md
@@ -1,0 +1,70 @@
+# Product Readiness Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add testable meeting export and readiness report support for Phase 1E validation.
+
+**Architecture:** Core owns artifact-aware export generation through `MeetingExportService`. `MeetingRecord` stores a backward-compatible `summaryURL`, and the SwiftUI app delegates export/copy actions through `MeetingAgentViewModel` so UI code stays thin.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, SwiftUI/AppKit on macOS.
+
+---
+
+### Task 1: Meeting Record Summary Artifact
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingRecord.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingStore.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingRecordTests.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingStoreTests.swift`
+
+- [ ] Add optional `summaryURL` to `MeetingRecord`, include it in coding keys, initialize it with a default `nil`, and decode it with `decodeIfPresent` so old metadata still loads.
+- [ ] Update `MeetingStore.createMeeting` so new records reserve `summary.md`.
+- [ ] Add tests asserting `summary.md` is assigned for new meetings and old JSON without `summaryURL` decodes with `nil`.
+
+### Task 2: Core Export Service
+
+**Files:**
+- Create: `Sources/MeetingAgentCore/MeetingExportService.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift`
+
+- [ ] Write failing tests for transcript export, summary export, metadata JSON export, readiness Markdown export, and missing summary errors.
+- [ ] Implement `MeetingExportService` with methods:
+  - `exportTranscript(for:to:)`
+  - `exportSummary(for:to:)`
+  - `exportMeetingData(for:to:)`
+  - `exportReadinessReport(for:to:)`
+  - `summaryText(for:)`
+- [ ] Use `TranscriptFileWriter.renderedTranscript` for transcript rendering so structured transcript JSON remains the preferred source of truth.
+- [ ] Keep errors explicit through a small public `MeetingExportError`.
+
+### Task 3: View Model Export Actions
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] Inject `MeetingExportService` into `MeetingAgentViewModel`.
+- [ ] Add methods for exporting transcript, summary, meeting data, readiness report, and loading summary text for clipboard use.
+- [ ] Update `statusText` with success and failure messages that include the failed operation.
+- [ ] Test export success and missing-summary failure using temporary destinations.
+
+### Task 4: App UI Hooks
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] Add an export section to `MeetingDetailView`.
+- [ ] Use `NSSavePanel` in the app target to choose export destinations.
+- [ ] Use `NSPasteboard` in the app target to copy summary text returned by the view model.
+- [ ] Disable summary copy/export when `summaryURL` is missing.
+
+### Task 5: Verify and Commit
+
+**Files:**
+- All modified files.
+
+- [ ] Run `swift test`.
+- [ ] Run `swift build --product MeetingAgentApp`.
+- [ ] Fix any failures caused by the change.
+- [ ] Commit the spec, plan, implementation, and tests with `feat: add product readiness exports (#7)`.

--- a/docs/superpowers/specs/2026-04-25-product-readiness-export-design.md
+++ b/docs/superpowers/specs/2026-04-25-product-readiness-export-design.md
@@ -1,0 +1,49 @@
+# Phase 1E Product Readiness Export Design
+
+## Intent
+
+Issue #7 asks for Phase 1 product readiness validation under real meeting conditions. The current prototype cannot automate live Zoom, Teams, Google Meet, Safari, and language validation reliably from unit tests, but it can make each recorded meeting easier to validate, retry, inspect, and export.
+
+This design implements the product-readiness slice that belongs in the app today: meeting artifacts remain associated with the meeting record, users can export the important artifacts, and the app can produce a Markdown readiness report for manual validation runs.
+
+## Requirements
+
+- Every new meeting record should reserve stable artifact paths for audio, transcript text, structured transcript JSON, diagnostics JSON, and summary Markdown.
+- Core code should export:
+  - rendered transcript text,
+  - structured meeting metadata JSON,
+  - summary Markdown when a summary artifact exists,
+  - a Markdown readiness report containing meeting metadata, artifact paths, transcription status, failure reason, transcript excerpt, and diagnostics status.
+- The app should expose export actions in the meeting detail view.
+- The app should support copying the summary artifact to the clipboard when it exists.
+- Export failures should surface as clear app status text.
+- Tests should cover the core export behavior without depending on live meeting apps, Core Audio, Speech, or the clipboard.
+
+## Non-Requirements
+
+- Do not automate real Zoom, Teams, Meet, Slack, or browser validation in this issue.
+- Do not add an AI summary generation backend.
+- Do not add summary retry behavior until summary generation exists.
+- Do not alter existing audio capture, STT provider, or transcript retry flow except where export status reads those artifacts.
+
+## Approach
+
+Add a focused `MeetingExportService` to `MeetingAgentCore`. It reads existing meeting artifact URLs, writes exports to caller-provided destination URLs, and creates a Markdown report suitable for the validation matrix in the issue. `MeetingRecord` gains an optional `summaryURL` with backward-compatible decoding.
+
+The SwiftUI app will keep the detail view simple by routing export and copy commands through `MeetingAgentViewModel`. AppKit-specific clipboard and save-panel work remains in the app target; export file generation remains in core for testability.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/MeetingRecord.swift`
+- `Sources/MeetingAgentCore/MeetingStore.swift`
+- `Sources/MeetingAgentCore/MeetingExportService.swift`
+- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+- `Tests/MeetingAgentCoreTests/MeetingStoreTests.swift`
+- `Tests/MeetingAgentCoreTests/MeetingRecordTests.swift`
+- `Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift`
+- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+## Testing
+
+Unit tests create temporary meeting directories with transcript, summary, metadata, and diagnostics fixtures. Tests assert exported content, missing-artifact error messages, backward-compatible record decoding, and view-model status behavior. Full local verification runs `swift test` and `swift build --product MeetingAgentApp`.


### PR DESCRIPTION
## Summary

Fixes #7

- Add artifact-aware meeting exports for transcript, summary, meeting JSON, and readiness Markdown reports.
- Associate new meetings with a stable summary artifact path.
- Add app detail-view export and copy-summary actions.

## Changes

- `Sources/MeetingAgentCore/MeetingExportService.swift` - adds core export and readiness-report generation.
- `Sources/MeetingAgentCore/MeetingRecord.swift` and `MeetingStore.swift` - add backward-compatible `summaryURL` support.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - routes export operations and status messages.
- `Sources/MeetingAgentApp/MainWindowView.swift` - adds save-panel export controls and pasteboard summary copy.
- `Tests/MeetingAgentCoreTests/*` - covers export behavior, summary artifact decoding, and view-model status updates.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test` passed, 88 tests
- [x] E2E/integration: skipped; no E2E convention and this is covered at core/view-model layer
- [x] Code review: PASS after manual Swift review and fix
- [x] Manual verification: app target compiled with export controls