### PR TITLE
fix: preserve structured transcript on retry

### DIFF
--- a/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
@@ -229,19 +229,26 @@ enum WhisperFileTranscriber {
             throw ProbeError.speechRecognition("Whisper transcription unavailable: expected output file was not created")
         }
 
-        let transcript = normalizedTranscript(try String(contentsOf: outputTextURL, encoding: .utf8))
-        try TranscriptFileWriter(url: transcriptURL).replace(
-            with: transcript.isEmpty ? "" : TranscriptFormatter.render([TranscriptSegment(text: transcript)])
-        )
+        let transcriptLines = normalizedTranscriptLines(try String(contentsOf: outputTextURL, encoding: .utf8))
+        let segments = transcriptLines.enumerated().map { lineIndex, text in
+            TranscriptSegment(
+                id: "whisper-retry-\(lineIndex)",
+                text: text,
+                language: localeIdentifier,
+                sourceProvider: "whisper",
+                isFinal: true,
+                timingSource: .unavailable
+            )
+        }
+        try TranscriptFileWriter(url: transcriptURL).replace(with: segments)
     }
 
-    private static func normalizedTranscript(_ text: String) -> String {
+    private static func normalizedTranscriptLines(_ text: String) -> [String] {
         text
             .split(whereSeparator: \.isNewline)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
             .filter { $0.caseInsensitiveCompare("[BLANK_AUDIO]") != .orderedSame }
-            .joined(separator: "\n")
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
@@ -164,6 +164,16 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         )
 
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "User A:\nretry transcript\n")
+        let document = try TranscriptFileWriter.readDocument(from: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+        XCTAssertEqual(document.segments.count, 1)
+        XCTAssertEqual(document.segments.first?.id, "whisper-retry-0")
+        XCTAssertEqual(document.segments.first?.speakerID, "speaker-1")
+        XCTAssertEqual(document.segments.first?.speakerLabel, "User A")
+        XCTAssertEqual(document.segments.first?.text, "retry transcript")
+        XCTAssertEqual(document.segments.first?.language, "en-US")
+        XCTAssertEqual(document.segments.first?.sourceProvider, "whisper")
+        XCTAssertEqual(document.segments.first?.isFinal, true)
+        XCTAssertEqual(document.segments.first?.timingSource, .unavailable)
         XCTAssertEqual(runner.inputWavURL, audioURL)
     }
 


### PR DESCRIPTION
## Summary

Fixes #13

- Writes whisper retry transcripts through structured TranscriptSegment values so transcript.json remains usable by summary generation.

## Changes

- Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift - replaces retry plain-text writer path with structured segment writes containing stable IDs, locale, provider, finality, and timing-source metadata.
- Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift - adds regression coverage that retry produces non-empty transcript.json segments.

## Test plan

- [x] Build/lint: swift build --product CoreAudioTapProbe; swift build --product MeetingAgentApp; git diff --check
- [x] Unit tests: swift test; swift test --filter WhisperTranscriptionProviderTests/testTranscribesExistingAudioFile
- [x] E2E/integration: skipped, no E2E convention and issue behavior is covered at provider/unit level
- [x] Code review: PASS
- [x] Manual verification: not applicable