### PR TITLE
feat: add meeting summary MVP

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -77,3 +77,19 @@ Run SwiftPM build and test commands one at a time per worktree, or use separate 
 Do not parallelize SwiftPM commands that share the same `.build` directory.
 
 ---
+
+## [6] Backfill derived artifact URLs for legacy metadata
+
+**Date**: 2026-04-25
+**Category**: wrong-assumption
+
+### What went wrong
+Adding optional summary artifact URLs to `MeetingRecord` initially handled new meetings but left older decoded metadata with nil summary paths, preventing regeneration for existing completed meetings.
+
+### Correct approach
+When adding derived artifact paths to persisted metadata, assign defaults during load as well as during creation.
+
+### How to avoid
+For every optional field added for Codable compatibility, decide whether consumers need a load-time default before using it in new workflows.
+
+---

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -109,6 +109,15 @@ struct MainWindowView: View {
                     Task {
                         await viewModel.retryTranscription(for: meeting.id)
                     }
+                },
+                regenerateSummary: { meetingID in
+                    Task {
+                        do {
+                            try await viewModel.generateSummary(for: meetingID)
+                        } catch {
+                            viewModel.setRecordingStartError(error)
+                        }
+                    }
                 }
             )
         }
@@ -202,6 +211,7 @@ private struct MeetingDetailView: View {
     let exportMeetingData: (MeetingRecord) -> Void
     let exportReadinessReport: (MeetingRecord) -> Void
     let retryTranscription: (MeetingRecord) -> Void
+    let regenerateSummary: (UUID) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -271,6 +281,14 @@ private struct MeetingDetailView: View {
                     }
                 }
                 Divider()
+                Text("Summary")
+                    .font(.headline)
+                summaryView(for: meeting)
+                Button("Regenerate Summary") {
+                    regenerateSummary(meeting.id)
+                }
+                .disabled(isRecording)
+                Divider()
                 Text("Transcript")
                     .font(.headline)
                 ScrollView {
@@ -312,5 +330,55 @@ private struct MeetingDetailView: View {
         case .retryRequested:
             return "Retry requested"
         }
+    }
+
+    @ViewBuilder
+    private func summaryView(for meeting: MeetingRecord) -> some View {
+        if let summary = summary(for: meeting) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    if summary.status == .failed {
+                        Text(summary.failureReason ?? "Summary generation failed.")
+                            .foregroundStyle(.red)
+                            .textSelection(.enabled)
+                    } else {
+                        if !summary.overview.isEmpty {
+                            Text(summary.overview)
+                                .textSelection(.enabled)
+                        }
+                        summaryList(title: "Decisions", items: summary.decisions.map(\.description))
+                        summaryList(title: "Action Items", items: summary.actionItems.map(\.description))
+                        summaryList(title: "Open Questions", items: summary.openQuestions)
+                        summaryList(title: "Risks", items: summary.risks)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(minHeight: 120, maxHeight: 220)
+        } else {
+            Text("No summary generated yet.")
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func summaryList(title: String, items: [String]) -> some View {
+        let visibleItems = items.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        if !visibleItems.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.subheadline)
+                    .bold()
+                ForEach(Array(visibleItems.enumerated()), id: \.offset) { _, item in
+                    Text("- \(item)")
+                        .textSelection(.enabled)
+                }
+            }
+        }
+    }
+
+    private func summary(for meeting: MeetingRecord) -> MeetingSummary? {
+        guard let summaryJSONURL = meeting.summaryJSONURL else { return nil }
+        return try? MeetingSummaryWriter.read(from: summaryJSONURL)
     }
 }

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -152,6 +152,37 @@ public final class MeetingAgentViewModel: ObservableObject {
         statusText = "Idle"
     }
 
+    public func generateSummary(for meetingID: UUID, generatedAt: Date = Date()) async throws {
+        guard let meeting = meetings.first(where: { $0.id == meetingID }) else {
+            throw ProbeError.invalidArguments("Meeting not found")
+        }
+        guard let transcriptJSONURL = meeting.transcriptJSONURL else {
+            throw ProbeError.invalidArguments("Meeting has no structured transcript URL")
+        }
+        guard let summaryJSONURL = meeting.summaryJSONURL,
+              let summaryMarkdownURL = meeting.summaryMarkdownURL
+        else {
+            throw ProbeError.invalidArguments("Meeting has no summary output URL")
+        }
+
+        let transcript = try TranscriptFileWriter.readDocument(from: transcriptJSONURL)
+        let provider = ExtractiveMeetingSummaryProvider()
+        let summary = try provider.generateSummary(
+            input: MeetingSummaryInput(
+                meetingName: meeting.name,
+                startedAt: meeting.startedAt,
+                endedAt: meeting.endedAt,
+                language: speechLocaleIdentifier,
+                meetingGoal: nil,
+                segments: transcript.segments,
+                generatedAt: generatedAt
+            )
+        )
+        try MeetingSummaryWriter.write(summary, jsonURL: summaryJSONURL, markdownURL: summaryMarkdownURL)
+        statusText = summary.status == .succeeded ? "Summary generated" : "Summary failed"
+        objectWillChange.send()
+    }
+
     public func selectMeeting(_ id: UUID?) {
         selectedMeetingID = id
     }

--- a/Sources/MeetingAgentCore/MeetingRecord.swift
+++ b/Sources/MeetingAgentCore/MeetingRecord.swift
@@ -17,6 +17,8 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
     public var transcriptURL: URL?
     public var transcriptJSONURL: URL?
     public var summaryURL: URL?
+    public var summaryJSONURL: URL?
+    public var summaryMarkdownURL: URL?
     public var diagnosticsURL: URL?
     public var transcriptionStatus: TranscriptionStatus
     public var transcriptionFailureReason: String?
@@ -32,6 +34,8 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         transcriptURL: URL?,
         transcriptJSONURL: URL? = nil,
         summaryURL: URL? = nil,
+        summaryJSONURL: URL? = nil,
+        summaryMarkdownURL: URL? = nil,
         diagnosticsURL: URL? = nil,
         transcriptionStatus: TranscriptionStatus = .notStarted,
         transcriptionFailureReason: String? = nil,
@@ -46,6 +50,8 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         self.transcriptURL = transcriptURL
         self.transcriptJSONURL = transcriptJSONURL
         self.summaryURL = summaryURL
+        self.summaryJSONURL = summaryJSONURL
+        self.summaryMarkdownURL = summaryMarkdownURL ?? summaryURL
         self.diagnosticsURL = diagnosticsURL
         self.transcriptionStatus = transcriptionStatus
         self.transcriptionFailureReason = transcriptionFailureReason
@@ -62,6 +68,8 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         case transcriptURL
         case transcriptJSONURL
         case summaryURL
+        case summaryJSONURL
+        case summaryMarkdownURL
         case diagnosticsURL
         case transcriptionStatus
         case transcriptionFailureReason
@@ -79,6 +87,8 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         transcriptURL = try container.decodeIfPresent(URL.self, forKey: .transcriptURL)
         transcriptJSONURL = try container.decodeIfPresent(URL.self, forKey: .transcriptJSONURL)
         summaryURL = try container.decodeIfPresent(URL.self, forKey: .summaryURL)
+        summaryJSONURL = try container.decodeIfPresent(URL.self, forKey: .summaryJSONURL)
+        summaryMarkdownURL = try container.decodeIfPresent(URL.self, forKey: .summaryMarkdownURL) ?? summaryURL
         diagnosticsURL = try container.decodeIfPresent(URL.self, forKey: .diagnosticsURL)
         transcriptionStatus = try container.decodeIfPresent(TranscriptionStatus.self, forKey: .transcriptionStatus) ?? .notStarted
         transcriptionFailureReason = try container.decodeIfPresent(String.self, forKey: .transcriptionFailureReason)

--- a/Sources/MeetingAgentCore/MeetingStore.swift
+++ b/Sources/MeetingAgentCore/MeetingStore.swift
@@ -43,6 +43,8 @@ public final class MeetingStore {
             transcriptURL: directory.appendingPathComponent("transcript.txt"),
             transcriptJSONURL: directory.appendingPathComponent("transcript.json"),
             summaryURL: directory.appendingPathComponent("summary.md"),
+            summaryJSONURL: directory.appendingPathComponent("summary.json"),
+            summaryMarkdownURL: directory.appendingPathComponent("summary.md"),
             diagnosticsURL: directory.appendingPathComponent("diagnostics.json")
         )
         try save(record)
@@ -72,7 +74,17 @@ public final class MeetingStore {
             let metadataURL = directory.appendingPathComponent("metadata.json")
             guard fileManager.fileExists(atPath: metadataURL.path) else { return nil }
             let data = try Data(contentsOf: metadataURL)
-            return try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: data)
+            var record = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: data)
+            if record.summaryURL == nil {
+                record.summaryURL = directory.appendingPathComponent("summary.md")
+            }
+            if record.summaryJSONURL == nil {
+                record.summaryJSONURL = directory.appendingPathComponent("summary.json")
+            }
+            if record.summaryMarkdownURL == nil {
+                record.summaryMarkdownURL = record.summaryURL ?? directory.appendingPathComponent("summary.md")
+            }
+            return record
         }
 
         return records.sorted { $0.startedAt > $1.startedAt }

--- a/Sources/MeetingAgentCore/MeetingSummary.swift
+++ b/Sources/MeetingAgentCore/MeetingSummary.swift
@@ -91,3 +91,232 @@ public struct MeetingSummary: Codable, Equatable {
         self.failureReason = failureReason
     }
 }
+
+public struct MeetingSummaryInput: Equatable {
+    public let meetingName: String
+    public let startedAt: Date
+    public let endedAt: Date?
+    public let language: String?
+    public let meetingGoal: String?
+    public let segments: [TranscriptSegment]
+    public let generatedAt: Date
+
+    public init(
+        meetingName: String,
+        startedAt: Date,
+        endedAt: Date?,
+        language: String?,
+        meetingGoal: String?,
+        segments: [TranscriptSegment],
+        generatedAt: Date = Date()
+    ) {
+        self.meetingName = meetingName
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.language = language
+        self.meetingGoal = meetingGoal
+        self.segments = segments
+        self.generatedAt = generatedAt
+    }
+}
+
+public protocol MeetingSummaryProvider {
+    var providerName: String { get }
+    func generateSummary(input: MeetingSummaryInput) throws -> MeetingSummary
+}
+
+public struct ExtractiveMeetingSummaryProvider: MeetingSummaryProvider {
+    public let providerName = "extractive-local"
+
+    public init() {}
+
+    public func generateSummary(input: MeetingSummaryInput) throws -> MeetingSummary {
+        let usableSegments = input.segments.compactMap(SummarySegment.init(segment:))
+        guard !usableSegments.isEmpty else {
+            return MeetingSummary(
+                overview: "",
+                keyTopics: [],
+                decisions: [],
+                actionItems: [],
+                openQuestions: [],
+                risks: [],
+                followUps: [],
+                language: input.language,
+                sourceSegmentIDs: [],
+                generatedAt: input.generatedAt,
+                provider: providerName,
+                status: .failed,
+                failureReason: "No usable transcript segments were available for summary generation."
+            )
+        }
+
+        let decisions = usableSegments
+            .filter { containsAny($0.lowercasedText, keywords: Self.decisionKeywords) }
+            .map {
+                MeetingDecision(
+                    description: $0.text,
+                    participants: $0.speakerLabel.map { [$0] } ?? [],
+                    sourceSegmentIDs: [$0.id],
+                    confidence: 0.65
+                )
+            }
+
+        let actionItems = usableSegments
+            .filter { containsAny($0.lowercasedText, keywords: Self.actionKeywords) }
+            .map {
+                MeetingActionItem(
+                    description: $0.text,
+                    owner: inferredOwner(from: $0.text),
+                    dueDate: nil,
+                    sourceSegmentIDs: [$0.id],
+                    confidence: 0.6
+                )
+            }
+
+        let openQuestions = usableSegments
+            .filter { isQuestion($0.text) }
+            .map(\.text)
+
+        let risks = usableSegments
+            .filter { containsAny($0.lowercasedText, keywords: Self.riskKeywords) }
+            .map(\.text)
+
+        let overview = overview(from: usableSegments, meetingGoal: input.meetingGoal)
+        return MeetingSummary(
+            overview: overview,
+            keyTopics: keyTopics(from: usableSegments, meetingName: input.meetingName),
+            decisions: decisions,
+            actionItems: actionItems,
+            openQuestions: openQuestions,
+            risks: risks,
+            followUps: actionItems.map(\.description),
+            language: input.language ?? usableSegments.compactMap(\.language).first,
+            sourceSegmentIDs: usableSegments.map(\.id),
+            generatedAt: input.generatedAt,
+            provider: providerName,
+            status: .succeeded,
+            failureReason: nil
+        )
+    }
+
+    private static let decisionKeywords = ["decided", "decision", "approved", "agreed"]
+    private static let actionKeywords = ["action item", "todo", "follow up", "will", "need to"]
+    private static let questionKeywords = ["can ", "could ", "should ", "what ", "when ", "where ", "who ", "why ", "how "]
+    private static let riskKeywords = ["risk", "blocked", "concern", "delay", "issue"]
+
+    private func containsAny(_ text: String, keywords: [String]) -> Bool {
+        keywords.contains { text.contains($0) }
+    }
+
+    private func isQuestion(_ text: String) -> Bool {
+        let lowercased = text.lowercased()
+        return text.hasSuffix("?") || containsAny(lowercased, keywords: Self.questionKeywords)
+    }
+
+    private func overview(from segments: [SummarySegment], meetingGoal: String?) -> String {
+        if let meetingGoal, !meetingGoal.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "The meeting focused on \(meetingGoal.trimmingCharacters(in: .whitespacesAndNewlines)). \(segments[0].text)"
+        }
+        return segments.prefix(2).map(\.text).joined(separator: " ")
+    }
+
+    private func keyTopics(from segments: [SummarySegment], meetingName: String) -> [String] {
+        let name = meetingName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !name.isEmpty {
+            return [name]
+        }
+        return Array(
+            Set(segments.flatMap { words(from: $0.text).filter { $0.count > 5 } })
+        )
+        .sorted()
+        .prefix(3)
+        .map { String($0) }
+    }
+
+    private func inferredOwner(from text: String) -> String? {
+        let words = text.split(separator: " ")
+        guard let first = words.first else { return nil }
+        let candidate = String(first).trimmingCharacters(in: .punctuationCharacters)
+        guard candidate.first?.isUppercase == true else { return nil }
+        return candidate
+    }
+
+    private func words(from text: String) -> [String] {
+        text.components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+}
+
+public enum MeetingSummaryMarkdownRenderer {
+    public static func render(_ summary: MeetingSummary) -> String {
+        var lines: [String] = [
+            "# Meeting Summary",
+            "",
+            "Status: \(summary.status.rawValue)",
+            "Provider: \(summary.provider)",
+            ""
+        ]
+
+        if let failureReason = summary.failureReason {
+            lines.append("Failure reason: \(failureReason)")
+            lines.append("")
+        }
+
+        appendSection("Overview", items: [summary.overview], to: &lines)
+        appendSection("Key Topics", items: summary.keyTopics, to: &lines)
+        appendSection("Decisions", items: summary.decisions.map(\.description), to: &lines)
+        appendSection("Action Items", items: summary.actionItems.map(\.description), to: &lines)
+        appendSection("Open Questions", items: summary.openQuestions, to: &lines)
+        appendSection("Risks", items: summary.risks, to: &lines)
+        appendSection("Follow Ups", items: summary.followUps, to: &lines)
+
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func appendSection(_ title: String, items: [String], to lines: inout [String]) {
+        let visibleItems = items
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !visibleItems.isEmpty else { return }
+        lines.append("## \(title)")
+        lines.append("")
+        if visibleItems.count == 1, title == "Overview" {
+            lines.append(visibleItems[0])
+        } else {
+            lines.append(contentsOf: visibleItems.map { "- \($0)" })
+        }
+        lines.append("")
+    }
+}
+
+public enum MeetingSummaryWriter {
+    public static func write(_ summary: MeetingSummary, jsonURL: URL, markdownURL: URL) throws {
+        let data = try JSONEncoder.meetingAgent.encode(summary)
+        try data.write(to: jsonURL, options: .atomic)
+        try MeetingSummaryMarkdownRenderer.render(summary).write(to: markdownURL, atomically: true, encoding: .utf8)
+    }
+
+    public static func read(from url: URL) throws -> MeetingSummary {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder.meetingAgent.decode(MeetingSummary.self, from: data)
+    }
+}
+
+private struct SummarySegment {
+    let id: String
+    let text: String
+    let lowercasedText: String
+    let speakerLabel: String?
+    let language: String?
+
+    init?(segment: TranscriptSegment) {
+        let text = segment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return nil }
+        self.id = segment.id
+        self.text = text
+        self.lowercasedText = text.lowercased()
+        self.speakerLabel = segment.speakerLabel
+        self.language = segment.language
+    }
+}

--- a/Sources/MeetingAgentCore/MeetingSummary.swift
+++ b/Sources/MeetingAgentCore/MeetingSummary.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public enum MeetingSummaryStatus: String, Codable, Equatable {
+    case succeeded
+    case failed
+}
+
+public struct MeetingActionItem: Codable, Equatable {
+    public let description: String
+    public let owner: String?
+    public let dueDate: String?
+    public let sourceSegmentIDs: [String]
+    public let confidence: Double
+
+    public init(
+        description: String,
+        owner: String?,
+        dueDate: String?,
+        sourceSegmentIDs: [String],
+        confidence: Double
+    ) {
+        self.description = description
+        self.owner = owner
+        self.dueDate = dueDate
+        self.sourceSegmentIDs = sourceSegmentIDs
+        self.confidence = confidence
+    }
+}
+
+public struct MeetingDecision: Codable, Equatable {
+    public let description: String
+    public let participants: [String]
+    public let sourceSegmentIDs: [String]
+    public let confidence: Double
+
+    public init(
+        description: String,
+        participants: [String],
+        sourceSegmentIDs: [String],
+        confidence: Double
+    ) {
+        self.description = description
+        self.participants = participants
+        self.sourceSegmentIDs = sourceSegmentIDs
+        self.confidence = confidence
+    }
+}
+
+public struct MeetingSummary: Codable, Equatable {
+    public let overview: String
+    public let keyTopics: [String]
+    public let decisions: [MeetingDecision]
+    public let actionItems: [MeetingActionItem]
+    public let openQuestions: [String]
+    public let risks: [String]
+    public let followUps: [String]
+    public let language: String?
+    public let sourceSegmentIDs: [String]
+    public let generatedAt: Date
+    public let provider: String
+    public let status: MeetingSummaryStatus
+    public let failureReason: String?
+
+    public init(
+        overview: String,
+        keyTopics: [String],
+        decisions: [MeetingDecision],
+        actionItems: [MeetingActionItem],
+        openQuestions: [String],
+        risks: [String],
+        followUps: [String],
+        language: String?,
+        sourceSegmentIDs: [String],
+        generatedAt: Date,
+        provider: String,
+        status: MeetingSummaryStatus,
+        failureReason: String?
+    ) {
+        self.overview = overview
+        self.keyTopics = keyTopics
+        self.decisions = decisions
+        self.actionItems = actionItems
+        self.openQuestions = openQuestions
+        self.risks = risks
+        self.followUps = followUps
+        self.language = language
+        self.sourceSegmentIDs = sourceSegmentIDs
+        self.generatedAt = generatedAt
+        self.provider = provider
+        self.status = status
+        self.failureReason = failureReason
+    }
+}

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -166,6 +166,39 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertThrowsError(try viewModel.summaryTextForClipboard(for: stored.record.id))
         XCTAssertEqual(viewModel.statusText, "Copy summary failed: Missing summary artifact")
     }
+
+    func testGenerateSummaryWritesArtifacts() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        var stored = try store.createMeeting(
+            id: UUID(uuidString: "77777777-7777-7777-7777-777777777777")!,
+            name: "Launch Review",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000)
+        )
+        stored.record.endedAt = Date(timeIntervalSince1970: 1_777_000_600)
+        try store.save(stored.record)
+        let transcriptWriter = try TranscriptFileWriter(url: stored.record.transcriptURL!)
+        try transcriptWriter.replace(with: [
+            TranscriptSegment(id: "segment-1", text: "We decided to launch on May 1.", language: "en-US"),
+            TranscriptSegment(id: "segment-2", text: "Alex will follow up with legal.", language: "en-US")
+        ])
+        try transcriptWriter.close()
+        let viewModel = MeetingAgentViewModel(store: store, speechLocaleIdentifier: "en-US")
+        try viewModel.loadMeetings()
+
+        try await viewModel.generateSummary(
+            for: stored.record.id,
+            generatedAt: Date(timeIntervalSince1970: 1_777_000_700)
+        )
+
+        let summary = try MeetingSummaryWriter.read(from: stored.record.summaryJSONURL!)
+        XCTAssertEqual(summary.status, .succeeded)
+        XCTAssertEqual(summary.decisions.first?.sourceSegmentIDs, ["segment-1"])
+        XCTAssertEqual(summary.actionItems.first?.sourceSegmentIDs, ["segment-2"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: stored.record.summaryMarkdownURL!.path))
+        XCTAssertEqual(viewModel.statusText, "Summary generated")
+    }
 }
 
 final class AppRuntimeCapabilitiesTests: XCTestCase {

--- a/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
@@ -15,6 +15,8 @@ final class MeetingRecordTests: XCTestCase {
             transcriptURL: URL(fileURLWithPath: "/tmp/transcript.txt"),
             transcriptJSONURL: URL(fileURLWithPath: "/tmp/transcript.json"),
             summaryURL: URL(fileURLWithPath: "/tmp/summary.md"),
+            summaryJSONURL: URL(fileURLWithPath: "/tmp/summary.json"),
+            summaryMarkdownURL: URL(fileURLWithPath: "/tmp/summary.md"),
             transcriptionStatus: .transcribed,
             transcriptionFailureReason: nil,
             speechProvider: .whisper,
@@ -95,5 +97,7 @@ final class MeetingRecordTests: XCTestCase {
         let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: Data(json.utf8))
 
         XCTAssertNil(decoded.summaryURL)
+        XCTAssertNil(decoded.summaryJSONURL)
+        XCTAssertNil(decoded.summaryMarkdownURL)
     }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
@@ -19,6 +19,8 @@ final class MeetingStoreTests: XCTestCase {
         XCTAssertEqual(created.record.transcriptURL?.lastPathComponent, "transcript.txt")
         XCTAssertEqual(created.record.transcriptJSONURL?.lastPathComponent, "transcript.json")
         XCTAssertEqual(created.record.summaryURL?.lastPathComponent, "summary.md")
+        XCTAssertEqual(created.record.summaryJSONURL?.lastPathComponent, "summary.json")
+        XCTAssertEqual(created.record.summaryMarkdownURL?.lastPathComponent, "summary.md")
         XCTAssertEqual(created.record.diagnosticsURL?.lastPathComponent, "diagnostics.json")
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.directory.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.metadataURL.path))

--- a/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
@@ -63,4 +63,32 @@ final class MeetingStoreTests: XCTestCase {
 
         XCTAssertEqual(loaded.first?.endedAt, Date(timeIntervalSince1970: 300))
     }
+
+    func testLoadsLegacyMeetingMetadataWithDefaultSummaryURLs() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-store-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let id = UUID(uuidString: "88888888-8888-8888-8888-888888888888")!
+        let directory = store.meetingsDirectory.appendingPathComponent(id.uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let metadata = """
+        {
+          "audioURL" : "\(directory.appendingPathComponent("audio.wav").absoluteString)",
+          "endedAt" : "2026-04-25T10:10:00Z",
+          "id" : "\(id.uuidString)",
+          "name" : "Legacy Meeting",
+          "startedAt" : "2026-04-25T10:00:00Z",
+          "transcriptJSONURL" : "\(directory.appendingPathComponent("transcript.json").absoluteString)",
+          "transcriptURL" : "\(directory.appendingPathComponent("transcript.txt").absoluteString)"
+        }
+        """
+        try metadata.write(to: directory.appendingPathComponent("metadata.json"), atomically: true, encoding: .utf8)
+
+        let loaded = try store.loadMeetings()
+
+        XCTAssertEqual(loaded.first?.summaryJSONURL?.lastPathComponent, "summary.json")
+        XCTAssertEqual(loaded.first?.summaryMarkdownURL?.lastPathComponent, "summary.md")
+        XCTAssertEqual(loaded.first?.summaryJSONURL?.deletingLastPathComponent().lastPathComponent, id.uuidString)
+        XCTAssertEqual(loaded.first?.summaryMarkdownURL?.deletingLastPathComponent().lastPathComponent, id.uuidString)
+    }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift
@@ -1,0 +1,127 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class MeetingSummaryProviderTests: XCTestCase {
+    func testExtractiveProviderSeparatesSummarySectionsWithSourceIDs() throws {
+        let provider = ExtractiveMeetingSummaryProvider()
+        let summary = try provider.generateSummary(
+            input: MeetingSummaryInput(
+                meetingName: "Launch Review",
+                startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+                endedAt: Date(timeIntervalSince1970: 1_777_000_600),
+                language: "en-US",
+                meetingGoal: nil,
+                segments: [
+                    TranscriptSegment(id: "segment-1", text: "We decided to launch on May 1.", language: "en-US"),
+                    TranscriptSegment(id: "segment-2", text: "Alex will follow up with legal.", language: "en-US"),
+                    TranscriptSegment(id: "segment-3", text: "Can support staff the launch?", language: "en-US"),
+                    TranscriptSegment(id: "segment-4", text: "The main risk is legal review delay.", language: "en-US")
+                ],
+                generatedAt: Date(timeIntervalSince1970: 1_777_000_700)
+            )
+        )
+
+        XCTAssertEqual(summary.status, .succeeded)
+        XCTAssertEqual(summary.language, "en-US")
+        XCTAssertEqual(summary.provider, "extractive-local")
+        XCTAssertEqual(summary.sourceSegmentIDs, ["segment-1", "segment-2", "segment-3", "segment-4"])
+        XCTAssertEqual(summary.decisions.first?.description, "We decided to launch on May 1.")
+        XCTAssertEqual(summary.decisions.first?.sourceSegmentIDs, ["segment-1"])
+        XCTAssertEqual(summary.actionItems.first?.description, "Alex will follow up with legal.")
+        XCTAssertEqual(summary.actionItems.first?.sourceSegmentIDs, ["segment-2"])
+        XCTAssertEqual(summary.openQuestions, ["Can support staff the launch?"])
+        XCTAssertEqual(summary.risks, ["The main risk is legal review delay."])
+        XCTAssertEqual(summary.followUps, ["Alex will follow up with legal."])
+    }
+
+    func testExtractiveProviderFailsForEmptyTranscript() throws {
+        let provider = ExtractiveMeetingSummaryProvider()
+
+        let summary = try provider.generateSummary(
+            input: MeetingSummaryInput(
+                meetingName: "Empty Meeting",
+                startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+                endedAt: nil,
+                language: "en-US",
+                meetingGoal: nil,
+                segments: [TranscriptSegment(id: "blank", text: "   ")],
+                generatedAt: Date(timeIntervalSince1970: 1_777_000_100)
+            )
+        )
+
+        XCTAssertEqual(summary.status, .failed)
+        XCTAssertEqual(summary.failureReason, "No usable transcript segments were available for summary generation.")
+        XCTAssertEqual(summary.sourceSegmentIDs, [])
+    }
+
+    func testSummaryWriterWritesJSONAndMarkdownTogether() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("summary-writer-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let jsonURL = directory.appendingPathComponent("summary.json")
+        let markdownURL = directory.appendingPathComponent("summary.md")
+        let summary = MeetingSummary(
+            overview: "The team aligned on launch scope.",
+            keyTopics: ["Launch"],
+            decisions: [
+                MeetingDecision(
+                    description: "Approved the launch date.",
+                    participants: ["User A"],
+                    sourceSegmentIDs: ["segment-1"],
+                    confidence: 0.8
+                )
+            ],
+            actionItems: [
+                MeetingActionItem(
+                    description: "Follow up with legal.",
+                    owner: "User B",
+                    dueDate: nil,
+                    sourceSegmentIDs: ["segment-2"],
+                    confidence: 0.7
+                )
+            ],
+            openQuestions: ["Can support staff the launch?"],
+            risks: ["Legal review may delay launch."],
+            followUps: ["Schedule launch review."],
+            language: "en-US",
+            sourceSegmentIDs: ["segment-1", "segment-2"],
+            generatedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            provider: "extractive-local",
+            status: .succeeded,
+            failureReason: nil
+        )
+
+        try MeetingSummaryWriter.write(summary, jsonURL: jsonURL, markdownURL: markdownURL)
+
+        XCTAssertEqual(try MeetingSummaryWriter.read(from: jsonURL), summary)
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("# Meeting Summary"))
+        XCTAssertTrue(markdown.contains("The team aligned on launch scope."))
+        XCTAssertTrue(markdown.contains("Approved the launch date."))
+        XCTAssertTrue(markdown.contains("Follow up with legal."))
+        XCTAssertTrue(markdown.contains("Can support staff the launch?"))
+    }
+
+    func testMarkdownRendererIncludesFailureReason() {
+        let summary = MeetingSummary(
+            overview: "",
+            keyTopics: [],
+            decisions: [],
+            actionItems: [],
+            openQuestions: [],
+            risks: [],
+            followUps: [],
+            language: "en-US",
+            sourceSegmentIDs: [],
+            generatedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            provider: "extractive-local",
+            status: .failed,
+            failureReason: "No transcript was available."
+        )
+
+        let markdown = MeetingSummaryMarkdownRenderer.render(summary)
+
+        XCTAssertTrue(markdown.contains("Status: failed"))
+        XCTAssertTrue(markdown.contains("No transcript was available."))
+    }
+}

--- a/Tests/MeetingAgentCoreTests/MeetingSummaryTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingSummaryTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class MeetingSummaryTests: XCTestCase {
+    func testMeetingSummaryEncodesAndDecodes() throws {
+        let summary = MeetingSummary(
+            overview: "The team aligned on launch scope.",
+            keyTopics: ["Launch"],
+            decisions: [
+                MeetingDecision(
+                    description: "Approved the launch date.",
+                    participants: ["User A"],
+                    sourceSegmentIDs: ["segment-1"],
+                    confidence: 0.8
+                )
+            ],
+            actionItems: [
+                MeetingActionItem(
+                    description: "Follow up with legal.",
+                    owner: "User B",
+                    dueDate: nil,
+                    sourceSegmentIDs: ["segment-2"],
+                    confidence: 0.7
+                )
+            ],
+            openQuestions: ["Can support staff the launch?"],
+            risks: ["Legal review may delay launch."],
+            followUps: ["Schedule launch review."],
+            language: "en-US",
+            sourceSegmentIDs: ["segment-1", "segment-2"],
+            generatedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            provider: "extractive-local",
+            status: .succeeded,
+            failureReason: nil
+        )
+
+        let data = try JSONEncoder.meetingAgent.encode(summary)
+        let decoded = try JSONDecoder.meetingAgent.decode(MeetingSummary.self, from: data)
+
+        XCTAssertEqual(decoded, summary)
+    }
+}

--- a/docs/superpowers/plans/2026-04-25-meeting-summary-mvp.md
+++ b/docs/superpowers/plans/2026-04-25-meeting-summary-mvp.md
@@ -1,0 +1,289 @@
+# Meeting Summary MVP Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a first post-meeting summary flow that reads structured transcript segments, writes `summary.json` and `summary.md`, and renders/regenerates the summary in the macOS app.
+
+**Architecture:** Add summary models, a deterministic extractive provider behind `MeetingSummaryProvider`, and a writer that persists JSON and Markdown together. Extend meeting metadata with summary artifact URLs and add a view model method that regenerates summaries from `transcript.json`.
+
+**Tech Stack:** Swift 5.9, Foundation, SwiftUI, XCTest, existing `JSONEncoder.meetingAgent` and `TranscriptFileWriter` conventions.
+
+---
+
+### Task 1: Summary Models And Meeting Metadata
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingRecord.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingStore.swift`
+- Create: `Sources/MeetingAgentCore/MeetingSummary.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingRecordTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingStoreTests.swift`
+- Create: `Tests/MeetingAgentCoreTests/MeetingSummaryTests.swift`
+
+- [ ] **Step 1: Write failing metadata and model tests**
+
+Add summary URL assertions to `MeetingStoreTests.testCreatesMeetingDirectoryAndMetadata`:
+
+```swift
+XCTAssertEqual(created.record.summaryJSONURL?.lastPathComponent, "summary.json")
+XCTAssertEqual(created.record.summaryMarkdownURL?.lastPathComponent, "summary.md")
+```
+
+Update `MeetingRecordTests.testMeetingRecordEncodesAndDecodes` to pass summary URLs:
+
+```swift
+summaryJSONURL: URL(fileURLWithPath: "/tmp/summary.json"),
+summaryMarkdownURL: URL(fileURLWithPath: "/tmp/summary.md")
+```
+
+Update `testDecodesMetadataWithoutDiagnosticsURL` assertions:
+
+```swift
+XCTAssertNil(decoded.summaryJSONURL)
+XCTAssertNil(decoded.summaryMarkdownURL)
+```
+
+Create `Tests/MeetingAgentCoreTests/MeetingSummaryTests.swift` with:
+
+```swift
+import XCTest
+@testable import MeetingAgentCore
+
+final class MeetingSummaryTests: XCTestCase {
+    func testMeetingSummaryEncodesAndDecodes() throws {
+        let summary = MeetingSummary(
+            overview: "The team aligned on launch scope.",
+            keyTopics: ["Launch"],
+            decisions: [
+                MeetingDecision(
+                    description: "Approved the launch date.",
+                    participants: ["User A"],
+                    sourceSegmentIDs: ["segment-1"],
+                    confidence: 0.8
+                )
+            ],
+            actionItems: [
+                MeetingActionItem(
+                    description: "Follow up with legal.",
+                    owner: "User B",
+                    dueDate: nil,
+                    sourceSegmentIDs: ["segment-2"],
+                    confidence: 0.7
+                )
+            ],
+            openQuestions: ["Can support staff the launch?"],
+            risks: ["Legal review may delay launch."],
+            followUps: ["Schedule launch review."],
+            language: "en-US",
+            sourceSegmentIDs: ["segment-1", "segment-2"],
+            generatedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            provider: "extractive-local",
+            status: .succeeded,
+            failureReason: nil
+        )
+
+        let data = try JSONEncoder.meetingAgent.encode(summary)
+        let decoded = try JSONDecoder.meetingAgent.decode(MeetingSummary.self, from: data)
+
+        XCTAssertEqual(decoded, summary)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `swift test --filter MeetingSummaryTests`
+
+Expected: FAIL because summary model types do not exist.
+
+- [ ] **Step 3: Implement models and metadata URLs**
+
+Create `Sources/MeetingAgentCore/MeetingSummary.swift`:
+
+```swift
+import Foundation
+
+public enum MeetingSummaryStatus: String, Codable, Equatable {
+    case succeeded
+    case failed
+}
+
+public struct MeetingActionItem: Codable, Equatable {
+    public let description: String
+    public let owner: String?
+    public let dueDate: String?
+    public let sourceSegmentIDs: [String]
+    public let confidence: Double
+}
+
+public struct MeetingDecision: Codable, Equatable {
+    public let description: String
+    public let participants: [String]
+    public let sourceSegmentIDs: [String]
+    public let confidence: Double
+}
+
+public struct MeetingSummary: Codable, Equatable {
+    public let overview: String
+    public let keyTopics: [String]
+    public let decisions: [MeetingDecision]
+    public let actionItems: [MeetingActionItem]
+    public let openQuestions: [String]
+    public let risks: [String]
+    public let followUps: [String]
+    public let language: String?
+    public let sourceSegmentIDs: [String]
+    public let generatedAt: Date
+    public let provider: String
+    public let status: MeetingSummaryStatus
+    public let failureReason: String?
+}
+```
+
+Add `summaryJSONURL` and `summaryMarkdownURL` optional properties and initializer parameters to `MeetingRecord`. In `MeetingStore.createMeeting`, set them to `summary.json` and `summary.md`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `swift test --filter MeetingSummaryTests && swift test --filter MeetingStoreTests && swift test --filter MeetingRecordTests`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/MeetingRecord.swift Sources/MeetingAgentCore/MeetingStore.swift Sources/MeetingAgentCore/MeetingSummary.swift Tests/MeetingAgentCoreTests/MeetingRecordTests.swift Tests/MeetingAgentCoreTests/MeetingStoreTests.swift Tests/MeetingAgentCoreTests/MeetingSummaryTests.swift
+git commit -m "feat: add meeting summary metadata models (#6)"
+```
+
+### Task 2: Summary Provider And Persistence
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingSummary.swift`
+- Create: `Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift`
+
+- [ ] **Step 1: Write failing provider and writer tests**
+
+Create tests that instantiate `ExtractiveMeetingSummaryProvider`, verify decision/action/question/risk extraction from segments, verify empty transcript returns `status == .failed`, and verify `MeetingSummaryWriter.write` persists matching JSON and Markdown files.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `swift test --filter MeetingSummaryProviderTests`
+
+Expected: FAIL because provider and writer types do not exist.
+
+- [ ] **Step 3: Implement provider, renderer, and writer**
+
+Add to `MeetingSummary.swift`:
+
+- `MeetingSummaryInput`
+- `MeetingSummaryProvider`
+- `ExtractiveMeetingSummaryProvider`
+- `MeetingSummaryMarkdownRenderer`
+- `MeetingSummaryWriter`
+
+Use deterministic keyword extraction from the spec. `MeetingSummaryWriter.write` must encode JSON with `JSONEncoder.meetingAgent` and render Markdown from the same `MeetingSummary`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `swift test --filter MeetingSummaryProviderTests && swift test --filter MeetingSummaryTests`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/MeetingSummary.swift Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift
+git commit -m "feat: add extractive meeting summary provider (#6)"
+```
+
+### Task 3: View Model Summary Regeneration
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Write failing view model test**
+
+Add a test that creates a stored meeting, writes `transcript.json` with decision/action segments, calls `await viewModel.generateSummary(for:)`, then reads `summary.json` and asserts `status == .succeeded`.
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `swift test --filter MeetingAgentViewModelTests/testGenerateSummaryWritesArtifacts`
+
+Expected: FAIL because `generateSummary` does not exist.
+
+- [ ] **Step 3: Implement view model method**
+
+Add `generateSummary(for meetingID: UUID, generatedAt: Date = Date()) async` to `MeetingAgentViewModel`. It should read `TranscriptDocument` from the selected meeting's `transcriptJSONURL`, build `MeetingSummaryInput`, call `ExtractiveMeetingSummaryProvider`, write summary artifacts through `MeetingSummaryWriter`, and update `statusText`.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `swift test --filter MeetingAgentViewModelTests`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/MeetingAgentViewModel.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+git commit -m "feat: regenerate summaries from view model (#6)"
+```
+
+### Task 4: App Summary UI
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Implement summary section**
+
+Pass a `regenerateSummary` closure from `MainWindowView` to `MeetingDetailView`. Add a Summary section above Transcript that reads `summary.json`, shows overview, decisions, action items, open questions, risks, failure reason, and a disabled-while-recording regenerate button.
+
+- [ ] **Step 2: Build app**
+
+Run: `swift build --product MeetingAgentApp`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift
+git commit -m "feat: show meeting summaries in app (#6)"
+```
+
+### Task 5: Final Verification
+
+**Files:**
+- No source changes expected.
+
+- [ ] **Step 1: Run full unit test suite**
+
+Run: `swift test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run app build**
+
+Run: `swift build --product MeetingAgentApp`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run CLI build**
+
+Run: `swift build --product CoreAudioTapProbe`
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect diff and status**
+
+Run: `git status --short` and `git log --oneline -5`
+
+Expected: clean worktree with issue #6 commits on `feat/issue-6-summary-mvp`.

--- a/docs/superpowers/specs/2026-04-25-meeting-summary-mvp-design.md
+++ b/docs/superpowers/specs/2026-04-25-meeting-summary-mvp-design.md
@@ -1,0 +1,153 @@
+# Meeting Summary MVP Design
+
+## Context
+
+Issue #6 asks for a first post-meeting summary experience. The current app records meeting audio, writes a plain-text transcript, and writes a structured transcript document at `transcript.json`. Managers need a shorter artifact that extracts outcomes from the transcript without replacing or corrupting the source transcript and audio files.
+
+This MVP should produce `summary.json` as the source of truth for app display and future integrations, plus `summary.md` as a human-readable export. It should keep the summary implementation behind a provider boundary so local and hosted providers can be added later.
+
+## User Intent And Success Criteria
+
+The user wants a completed meeting with structured transcript data to generate a useful post-meeting summary. The summary must separate overview text from decisions and action items, preserve traceability to transcript segment IDs where practical, and fail without damaging existing transcript or audio artifacts.
+
+Success criteria:
+
+- Completed meetings with transcript segments can generate a summary.
+- Summary output is saved to both `summary.json` and `summary.md`.
+- Decisions and action items are represented as separate structured arrays.
+- Summary generation failures are represented in `summary.json` and visible in the app.
+- Summary output can be regenerated from the current transcript.
+- Decisions, action items, and other extracted claims include source segment IDs when available.
+
+## Non-Requirements
+
+- No hosted LLM provider is introduced in this phase.
+- No privacy, consent, account, or API-key settings are introduced in this phase.
+- No chunked long-meeting summarization pipeline is implemented yet.
+- No automatic summary generation is required while a meeting is still recording.
+
+## Selected Approach
+
+Build a deterministic local extractive provider first. The provider consumes structured transcript segments and meeting metadata, then emits a schema-compatible summary based on lightweight heuristics. This is intentionally conservative: it keeps the app useful and testable while preserving a provider boundary for future LLM-backed summarizers.
+
+Alternative approaches considered:
+
+- Hosted LLM provider now: likely higher quality, but introduces privacy, configuration, cost, retry, and external failure concerns before product policy is settled.
+- Schema-only implementation: lower risk, but does not satisfy the acceptance criterion that completed meetings can generate a useful summary.
+
+## Data Model
+
+Add summary artifact URLs to `MeetingRecord`:
+
+- `summaryJSONURL`
+- `summaryMarkdownURL`
+
+`MeetingStore.createMeeting` will assign these paths inside the meeting directory:
+
+- `summary.json`
+- `summary.md`
+
+Add a `MeetingSummary` model with:
+
+- `overview`
+- `keyTopics`
+- `decisions`
+- `actionItems`
+- `openQuestions`
+- `risks`
+- `followUps`
+- `language`
+- `sourceSegmentIDs`
+- `generatedAt`
+- `provider`
+- `status`
+- `failureReason`
+
+Action items include:
+
+- `description`
+- `owner`
+- `dueDate`
+- `sourceSegmentIDs`
+- `confidence`
+
+Decisions include:
+
+- `description`
+- `participants`
+- `sourceSegmentIDs`
+- `confidence`
+
+`status` is an enum with `succeeded` and `failed`. `failureReason` is set only for failed summaries.
+
+## Provider Boundary
+
+Introduce:
+
+- `MeetingSummaryProvider`
+- `MeetingSummaryInput`
+- `ExtractiveMeetingSummaryProvider`
+
+`MeetingSummaryInput` includes meeting name, started and ended timestamps, locale or language, optional meeting goal or agenda, and structured transcript segments.
+
+The provider returns a complete `MeetingSummary`. The initial extractive provider will:
+
+- Trim empty transcript segments.
+- Fail with status `failed` when no usable transcript segments exist.
+- Use the first meaningful transcript text as a compact overview seed.
+- Extract decisions from segments containing phrases such as `decided`, `decision`, `approved`, or `agreed`.
+- Extract action items from segments containing phrases such as `action item`, `todo`, `follow up`, `will`, or `need to`.
+- Extract open questions from text ending in `?` or containing question phrases.
+- Extract risks from text containing `risk`, `blocked`, `concern`, `delay`, or `issue`.
+- Use source segment IDs from the segments that produced each claim.
+
+The heuristic provider is not expected to be semantically perfect. It is a deterministic MVP that exercises the full product flow and can be replaced by an LLM provider later.
+
+## Persistence
+
+Add `MeetingSummaryWriter` for writing and reading summary artifacts. It will write `summary.json` atomically and render `summary.md` from the same in-memory summary to avoid drift.
+
+The issue #4 lesson applies here: `summary.json` and `summary.md` must be updated together on success and failure so the app never prefers stale structured data over current fallback text.
+
+## App Experience
+
+The meeting detail view will show a Summary section above the Transcript section when a meeting is selected.
+
+The Summary section includes:
+
+- Overview.
+- Decisions.
+- Action items.
+- Open questions.
+- Risks.
+- A regenerate summary button.
+- A failure reason when the latest summary failed.
+
+The regenerate action is disabled while recording. If no summary exists yet, the section shows a short empty state and still offers generation for completed meetings with transcript data.
+
+## Error Handling
+
+Summary generation failures must not modify audio or transcript artifacts. Failures are represented by a failed `MeetingSummary` written to both summary artifacts, including a failure reason and the provider name.
+
+Expected failure cases:
+
+- No structured transcript file.
+- Structured transcript file exists but contains no usable segments.
+- Summary artifact write failure.
+
+Read failures in the app should show the absence of a summary rather than crashing the view.
+
+## Testing
+
+Unit tests cover:
+
+- `MeetingRecord` Codable compatibility with optional summary URLs.
+- `MeetingStore` creates summary artifact URLs.
+- `MeetingSummary` JSON round trip.
+- `MeetingSummaryMarkdownRenderer` renders overview, decisions, action items, open questions, and failure reason.
+- `ExtractiveMeetingSummaryProvider` produces separate decisions and action items with source segment IDs.
+- `ExtractiveMeetingSummaryProvider` returns a failed summary for empty transcript input.
+- `MeetingSummaryWriter` writes JSON and Markdown together.
+- `MeetingAgentViewModel` regenerates a summary for a completed meeting with structured transcript segments.
+
+No E2E test convention exists in the repository. Integration-style behavior is covered through core and view model XCTest coverage.


### PR DESCRIPTION
## Summary

Fixes #6

- Adds summary metadata, schema, deterministic extractive summary provider, and JSON/Markdown summary persistence.
- Adds view model regeneration and a macOS app Summary section with failure display.
- Backfills summary artifact paths for legacy meeting metadata.

## Changes

- `Sources/MeetingAgentCore/MeetingSummary.swift` - summary schema, provider boundary, extractive provider, Markdown renderer, writer.
- `Sources/MeetingAgentCore/MeetingRecord.swift` and `Sources/MeetingAgentCore/MeetingStore.swift` - summary artifact URLs for new and legacy meetings.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - regenerate summaries from structured transcript segments.
- `Sources/MeetingAgentApp/MainWindowView.swift` - show summary sections and regenerate action.
- `Tests/MeetingAgentCoreTests/*Summary*` and related tests - coverage for schema, provider, writer, store, and view model.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed; `swift build --product CoreAudioTapProbe` passed
- [x] Unit tests: `swift test` passed, 79 tests
- [x] E2E/integration: skipped; no E2E convention exists in this Swift package
- [x] Code review: PASS after one review fix for legacy metadata backfill
- [x] Manual verification: app target compiles with Summary section