### PR TITLE
fix: keep CLI capture running after STT append failure

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -30,6 +30,22 @@ Never use process-global persistence directly in unit tests; inject an isolated 
 
 ---
 
+## [14] Apply patches in the active issue worktree
+
+**Date**: 2026-04-25
+**Category**: wrong-assumption
+
+### What went wrong
+The first regression test patch was applied from the original checkout after creating the issue worktree, so verification in the worktree did not compile or run the new test.
+
+### Correct approach
+Use absolute paths or verify `git status --short` in the issue worktree immediately after every patch when working outside the original checkout.
+
+### How to avoid
+After creating a worktree, apply patches with the worktree path and confirm the changed files are visible there before running tests.
+
+---
+
 ## [7] Applying patches from a linked worktree
 
 **Date**: 2026-04-25

--- a/Sources/CoreAudioTapProbe/ProbeMain.swift
+++ b/Sources/CoreAudioTapProbe/ProbeMain.swift
@@ -126,7 +126,9 @@ struct ProbeMain {
                 totalBytes += frame.pcm.count
                 peak = max(peak, frame.pcm.max() ?? 0)
                 try writer?.append(frame)
-                try transcriptionFailureIsolator?.append(frame)
+                if let transcriptionFailure = transcriptionFailureIsolator?.append(frame) {
+                    log(transcriptionFailure)
+                }
             }
 
             log("level_peak_byte=\(peak) frames=\(frames.count) bytes=\(totalBytes)")

--- a/Sources/CoreAudioTapProbe/ProbeMain.swift
+++ b/Sources/CoreAudioTapProbe/ProbeMain.swift
@@ -72,13 +72,17 @@ struct ProbeMain {
                 channelCount: UInt16(captureSession.outputChannelCount)
             )
         }
-        let transcriber: AudioFrameTranscriber?
+        let transcriptionFailureIsolator: TranscriptionFailureIsolator?
         if let recordingOutput {
             do {
                 let speechProvider = SpeechTranscriptionProviderFactory.provider(for: options.speechProvider)
-                transcriber = try await speechProvider.start(
+                let transcriber = try await speechProvider.start(
                     transcriptURL: recordingOutput.transcriptURL,
                     localeIdentifier: options.speechLocaleIdentifier
+                )
+                transcriptionFailureIsolator = TranscriptionFailureIsolator(
+                    transcriber: transcriber,
+                    transcriptURL: recordingOutput.transcriptURL
                 )
                 log("Speech recognition provider: \(options.speechProvider.rawValue)")
                 log("Speech recognition locale: \(options.speechLocaleIdentifier)")
@@ -87,10 +91,10 @@ struct ProbeMain {
                 try transcriptWriter.replace(with: "Speech recognition unavailable: \(error)")
                 try transcriptWriter.close()
                 log("Speech recognition unavailable: \(error)")
-                transcriber = nil
+                transcriptionFailureIsolator = nil
             }
         } else {
-            transcriber = nil
+            transcriptionFailureIsolator = nil
         }
 
         if let recordingOutput {
@@ -122,14 +126,14 @@ struct ProbeMain {
                 totalBytes += frame.pcm.count
                 peak = max(peak, frame.pcm.max() ?? 0)
                 try writer?.append(frame)
-                try transcriber?.append(frame)
+                try transcriptionFailureIsolator?.append(frame)
             }
 
             log("level_peak_byte=\(peak) frames=\(frames.count) bytes=\(totalBytes)")
         }
 
         try writer?.close()
-        transcriber?.finish()
+        transcriptionFailureIsolator?.finish()
         diagnosticsTracker.finish(endedReason: .saved)
         let diagnostics = diagnosticsTracker.snapshot()
         if let recordingOutput {

--- a/Sources/MeetingAgentCore/TranscriptionFailureIsolator.swift
+++ b/Sources/MeetingAgentCore/TranscriptionFailureIsolator.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public final class TranscriptionFailureIsolator {
+    private var transcriber: AudioFrameTranscriber?
+    private let transcriptURL: URL
+
+    public var isActive: Bool {
+        transcriber != nil
+    }
+
+    public var failureReason: String? {
+        transcriber?.failureReason
+    }
+
+    public init(transcriber: AudioFrameTranscriber?, transcriptURL: URL) {
+        self.transcriber = transcriber
+        self.transcriptURL = transcriptURL
+    }
+
+    public func append(_ frame: AudioFrame) throws {
+        guard let transcriber else { return }
+
+        do {
+            try transcriber.append(frame)
+        } catch {
+            transcriber.finish()
+            try TranscriptFileWriter(url: transcriptURL).replace(with: "Speech recognition failed: \(error)")
+            self.transcriber = nil
+        }
+    }
+
+    public func finish() {
+        transcriber?.finish()
+        transcriber = nil
+    }
+}

--- a/Sources/MeetingAgentCore/TranscriptionFailureIsolator.swift
+++ b/Sources/MeetingAgentCore/TranscriptionFailureIsolator.swift
@@ -17,15 +17,19 @@ public final class TranscriptionFailureIsolator {
         self.transcriptURL = transcriptURL
     }
 
-    public func append(_ frame: AudioFrame) throws {
-        guard let transcriber else { return }
+    @discardableResult
+    public func append(_ frame: AudioFrame) -> String? {
+        guard let transcriber else { return nil }
 
         do {
             try transcriber.append(frame)
+            return nil
         } catch {
+            let message = "Speech recognition failed: \(error)"
             transcriber.finish()
-            try TranscriptFileWriter(url: transcriptURL).replace(with: "Speech recognition failed: \(error)")
             self.transcriber = nil
+            try? TranscriptFileWriter(url: transcriptURL).replace(with: message)
+            return message
         }
     }
 

--- a/Tests/MeetingAgentCoreTests/TranscriptionFailureIsolatorTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptionFailureIsolatorTests.swift
@@ -24,10 +24,12 @@ final class TranscriptionFailureIsolatorTests: XCTestCase {
             timestampNanos: 1
         )
 
-        try isolator.append(frame)
-        try isolator.append(frame)
+        let failureMessage = isolator.append(frame)
+        let repeatedFailureMessage = isolator.append(frame)
 
         XCTAssertFalse(isolator.isActive)
+        XCTAssertEqual(failureMessage, "Speech recognition failed: Speech recognition error: chunk failed")
+        XCTAssertNil(repeatedFailureMessage)
         XCTAssertEqual(transcriber.appendCount, 1)
         XCTAssertEqual(transcriber.finishCount, 1)
         XCTAssertEqual(

--- a/Tests/MeetingAgentCoreTests/TranscriptionFailureIsolatorTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptionFailureIsolatorTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class TranscriptionFailureIsolatorTests: XCTestCase {
+    func testAppendFailureWritesTranscriptFailureAndDisablesTranscriber() throws {
+        let transcriptURL = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
+        let transcriptJSONURL = transcriptURL.deletingPathExtension().appendingPathExtension("json")
+        defer {
+            try? FileManager.default.removeItem(at: transcriptURL)
+            try? FileManager.default.removeItem(at: transcriptJSONURL)
+        }
+        try TranscriptFileWriter(url: transcriptURL).replace(with: [
+            TranscriptSegment(id: "stale", text: "stale structured text")
+        ])
+        let transcriber = FailingAppendTranscriber()
+        let isolator = TranscriptionFailureIsolator(
+            transcriber: transcriber,
+            transcriptURL: transcriptURL
+        )
+        let frame = AudioFrame(
+            pcm: Data([0x01, 0x00]),
+            sampleRate: 16_000,
+            channelCount: 1,
+            timestampNanos: 1
+        )
+
+        try isolator.append(frame)
+        try isolator.append(frame)
+
+        XCTAssertFalse(isolator.isActive)
+        XCTAssertEqual(transcriber.appendCount, 1)
+        XCTAssertEqual(transcriber.finishCount, 1)
+        XCTAssertEqual(
+            try String(contentsOf: transcriptURL, encoding: .utf8),
+            "Speech recognition failed: Speech recognition error: chunk failed\n"
+        )
+        XCTAssertEqual(try TranscriptFileWriter.readDocument(from: transcriptJSONURL), TranscriptDocument())
+    }
+}
+
+private final class FailingAppendTranscriber: AudioFrameTranscriber {
+    private(set) var appendCount = 0
+    private(set) var finishCount = 0
+
+    func append(_ frame: AudioFrame) throws {
+        appendCount += 1
+        throw ProbeError.speechRecognition("chunk failed")
+    }
+
+    func finish() {
+        finishCount += 1
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #14

- Isolates CLI transcriber append failures so WAV writing and diagnostics continue.
- Writes and logs a clear STT failure message, finishes the failed transcriber, and disables repeated appends.
- Adds focused unit coverage for failure persistence and stale structured transcript clearing.

## Changes

- `Sources/CoreAudioTapProbe/ProbeMain.swift` - routes CLI frame transcription through the failure isolator and logs isolated failures.
- `Sources/MeetingAgentCore/TranscriptionFailureIsolator.swift` - adds the testable failure-isolation boundary.
- `Tests/MeetingAgentCoreTests/TranscriptionFailureIsolatorTests.swift` - covers append failure handling, finishing, disabling, and transcript replacement.
- `MISTAKES.md` - records the worktree patching lesson from this fix.

## Test plan

- [x] Build/lint: `swift build --product CoreAudioTapProbe` passed; `swift build --product MeetingAgentApp` passed; no separate Swift lint configured.
- [x] Unit tests: `swift test --filter TranscriptionFailureIsolatorTests` passed; `swift test` passed with 89 tests.
- [x] E2E/integration: skipped; no E2E convention for this Core Audio CLI failure-isolation path.
- [x] Code review: PASS after hardening review fix.
- [x] Manual verification: reviewed CLI drain loop diff and ensured only WAV append remains throwing in the per-frame path.