### PR TITLE
feat: detect target process ended during capture

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -61,3 +61,19 @@ When editing a linked worktree with `apply_patch`, use absolute paths or otherwi
 For worktree-based issue fixes, patch absolute paths under the issue worktree.
 
 ---
+
+## [15] Parallel SwiftPM commands in one worktree
+
+**Date**: 2026-04-25
+**Category**: test-mistake
+
+### What went wrong
+Focused `swift test --filter ...` commands were launched in parallel in the same worktree, causing SwiftPM to serialize on the shared `.build` directory and produce noisy waiting output.
+
+### Correct approach
+Run SwiftPM build and test commands one at a time per worktree, or use separate worktrees when true parallel SwiftPM verification is needed.
+
+### How to avoid
+Do not parallelize SwiftPM commands that share the same `.build` directory.
+
+---

--- a/Sources/CoreAudioTapProbe/ProbeMain.swift
+++ b/Sources/CoreAudioTapProbe/ProbeMain.swift
@@ -105,8 +105,15 @@ struct ProbeMain {
         }
 
         let end = Date().addingTimeInterval(TimeInterval(options.seconds))
+        let processMonitor = MeetingProcessMonitor()
+        var endedReason = CaptureEndedReason.saved
         while Date() < end {
             try await Task.sleep(nanoseconds: 250_000_000)
+            let currentTargets = RunningProcessDiscovery.currentTargets()
+            let targetProcessEnded = processMonitor.hasProcessEnded(processID: target.processID, in: currentTargets)
+            if targetProcessEnded {
+                endedReason = .targetProcessEnded
+            }
             let bufferBacklog = frameBuffer.count
             let droppedFrameCount = frameBuffer.droppedFrameCount
             let frames = frameBuffer.drain()
@@ -117,6 +124,10 @@ struct ProbeMain {
             )
             if frames.isEmpty {
                 log("level=idle frames=0")
+                if targetProcessEnded {
+                    log("Target process ended: \(target.displayName) pid=\(target.processID)")
+                    break
+                }
                 continue
             }
 
@@ -132,11 +143,15 @@ struct ProbeMain {
             }
 
             log("level_peak_byte=\(peak) frames=\(frames.count) bytes=\(totalBytes)")
+            if targetProcessEnded {
+                log("Target process ended: \(target.displayName) pid=\(target.processID)")
+                break
+            }
         }
 
         try writer?.close()
         transcriptionFailureIsolator?.finish()
-        diagnosticsTracker.finish(endedReason: .saved)
+        diagnosticsTracker.finish(endedReason: endedReason)
         let diagnostics = diagnosticsTracker.snapshot()
         if let recordingOutput {
             try diagnostics.write(to: recordingOutput.diagnosticsURL)

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -13,6 +13,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     private let speechConfigurationStore: SpeechTranscriptionConfigurationStore
     private let recorder: MeetingRecorder
     private let exportService: MeetingExportService
+    private let processTargetsProvider: () -> [AudioCaptureTarget]
     private let processMonitor = MeetingProcessMonitor()
     private var activeTarget: AudioCaptureTarget?
 
@@ -23,12 +24,14 @@ public final class MeetingAgentViewModel: ObservableObject {
         speechProvider: SpeechProvider = .whisper,
         speechConfiguration: SpeechTranscriptionConfiguration? = nil,
         speechConfigurationStore: SpeechTranscriptionConfigurationStore = SpeechTranscriptionConfigurationStore(),
-        exportService: MeetingExportService = MeetingExportService()
+        exportService: MeetingExportService = MeetingExportService(),
+        processTargetsProvider: @escaping () -> [AudioCaptureTarget] = RunningProcessDiscovery.currentTargets
     ) {
         self.store = store
         self.speechConfigurationStore = speechConfigurationStore
         self.recorder = recorder ?? MeetingRecorder(store: store)
         self.exportService = exportService
+        self.processTargetsProvider = processTargetsProvider
         if let speechConfiguration {
             self.speechConfiguration = speechConfiguration
         } else if speechProvider != .whisper || speechLocaleIdentifier != Locale.current.identifier {
@@ -71,6 +74,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         meetings.insert(record, at: 0)
         selectedMeetingID = record.id
         pendingCandidate = nil
+        activeTarget = candidate
         statusText = "Recording \(record.name)"
     }
 
@@ -129,8 +133,12 @@ public final class MeetingAgentViewModel: ObservableObject {
         statusText = "Recording failed: \(error)"
     }
 
-    public func drainRecordingFrames() {
+    public func drainRecordingFrames(endedAt: Date = Date()) {
         try? recorder.drainFrames()
+        if stopRecordingIfTargetProcessEnded(at: endedAt) {
+            objectWillChange.send()
+            return
+        }
         updateRecordingStatus()
         objectWillChange.send()
     }
@@ -237,7 +245,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     }
 
     public func pollForMeetingCandidates() -> AudioCaptureTarget? {
-        let targets = RunningProcessDiscovery.currentTargets()
+        let targets = processTargetsProvider()
         processMonitor.reconcileRunningProcessIDs(Set(targets.map(\.processID)))
         let candidates = processMonitor.detectNewCandidates(
             in: targets,
@@ -272,6 +280,21 @@ public final class MeetingAgentViewModel: ObservableObject {
         case .recordingSaved:
             statusText = "Recording saved: \(activeTarget.displayName)"
         }
+    }
+
+    private func stopRecordingIfTargetProcessEnded(at endedAt: Date = Date()) -> Bool {
+        guard let activeTarget else { return false }
+        let targets = processTargetsProvider()
+        guard processMonitor.hasProcessEnded(processID: activeTarget.processID, in: targets) else {
+            return false
+        }
+        if let stopped = try? recorder.stopRecording(at: endedAt, endedReason: .targetProcessEnded),
+           let index = meetings.firstIndex(where: { $0.id == stopped.id }) {
+            meetings[index] = stopped
+        }
+        statusText = "Target process ended: \(activeTarget.displayName)"
+        self.activeTarget = nil
+        return true
     }
 
     public var selectedMeeting: MeetingRecord? {

--- a/Sources/MeetingAgentCore/MeetingProcessMonitor.swift
+++ b/Sources/MeetingAgentCore/MeetingProcessMonitor.swift
@@ -36,4 +36,12 @@ public final class MeetingProcessMonitor {
         promptedProcessIDs = promptedProcessIDs.intersection(runningProcessIDs)
         ignoredProcessIDs = ignoredProcessIDs.intersection(runningProcessIDs)
     }
+
+    public func isProcessRunning(processID: pid_t, in targets: [AudioCaptureTarget]) -> Bool {
+        targets.contains { $0.processID == processID }
+    }
+
+    public func hasProcessEnded(processID: pid_t, in targets: [AudioCaptureTarget]) -> Bool {
+        !isProcessRunning(processID: processID, in: targets)
+    }
 }

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -125,7 +125,10 @@ public final class MeetingRecorder {
         }
     }
 
-    public func stopRecording(at endedAt: Date = Date()) throws -> MeetingRecord? {
+    public func stopRecording(
+        at endedAt: Date = Date(),
+        endedReason: CaptureEndedReason = .saved
+    ) throws -> MeetingRecord? {
         try writer?.close()
         let activeTranscriber = transcriber
         activeTranscriber?.finish()
@@ -133,14 +136,17 @@ public final class MeetingRecorder {
             try markTranscriptionFailed(failureReason)
         }
         captureSession?.stop()
-        diagnosticsTracker?.finish(endedReason: .saved)
+        diagnosticsTracker?.finish(endedReason: endedReason)
         writer = nil
         transcriber = nil
         captureSession = nil
-        return try markStopped(at: endedAt)
+        return try markStopped(at: endedAt, endedReason: endedReason)
     }
 
-    public func markStopped(at endedAt: Date = Date()) throws -> MeetingRecord? {
+    public func markStopped(
+        at endedAt: Date = Date(),
+        endedReason: CaptureEndedReason = .saved
+    ) throws -> MeetingRecord? {
         guard var record = activeRecord else {
             state = .idle
             return nil
@@ -151,7 +157,7 @@ public final class MeetingRecorder {
             record.transcriptionStatus = .transcribed
             record.transcriptionFailureReason = nil
         }
-        diagnosticsTracker?.finish(endedReason: .saved)
+        diagnosticsTracker?.finish(endedReason: endedReason)
         try diagnosticsTracker?.snapshot().writeIfPossible(to: record.diagnosticsURL)
         diagnosticsTracker = nil
         try store.save(record)

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -47,6 +47,33 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isRecording)
     }
 
+    func testDrainRecordingFramesStopsWhenTargetProcessEnds() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let targets: [AudioCaptureTarget] = []
+        let endedAt = Date(timeIntervalSince1970: 200)
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: store,
+            processTargetsProvider: { targets }
+        )
+
+        viewModel.setPendingCandidate(target)
+        try viewModel.acceptPendingCandidate(startedAt: Date(timeIntervalSince1970: 100))
+
+        viewModel.drainRecordingFrames(endedAt: endedAt)
+
+        XCTAssertEqual(viewModel.meetings.first?.endedAt, endedAt)
+        XCTAssertEqual(viewModel.statusText, "Target process ended: zoom.us")
+        XCTAssertFalse(viewModel.isRecording)
+
+        let data = try Data(contentsOf: XCTUnwrap(viewModel.meetings.first?.diagnosticsURL))
+        let diagnostics = try JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
+        XCTAssertEqual(diagnostics.endedReason, .targetProcessEnded)
+        XCTAssertEqual(diagnostics.status, .targetProcessEnded)
+    }
+
     func testSpeechLocaleCanBeConfiguredForAppRecording() {
         let viewModel = MeetingAgentViewModel(
             speechConfiguration: SpeechTranscriptionConfiguration(

--- a/Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift
@@ -66,4 +66,21 @@ final class MeetingProcessMonitorTests: XCTestCase {
         XCTAssertEqual(inactive, [])
         XCTAssertEqual(active, [activeChrome])
     }
+
+    func testDetectsRunningProcessIDFromTargets() {
+        let monitor = MeetingProcessMonitor()
+        let zoom = AudioCaptureTarget(processID: 123, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let chrome = AudioCaptureTarget(processID: 456, displayName: "Google Chrome", bundleIdentifier: "com.google.Chrome")
+
+        XCTAssertTrue(monitor.isProcessRunning(processID: 123, in: [zoom, chrome]))
+        XCTAssertFalse(monitor.isProcessRunning(processID: 789, in: [zoom, chrome]))
+    }
+
+    func testDetectsEndedProcessIDFromTargets() {
+        let monitor = MeetingProcessMonitor()
+        let zoom = AudioCaptureTarget(processID: 123, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+
+        XCTAssertFalse(monitor.hasProcessEnded(processID: 123, in: [zoom]))
+        XCTAssertTrue(monitor.hasProcessEnded(processID: 456, in: [zoom]))
+    }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
@@ -29,4 +29,20 @@ final class MeetingRecorderTests: XCTestCase {
 
         XCTAssertThrowsError(try recorder.prepareRecord(for: target, startedAt: Date(timeIntervalSince1970: 101)))
     }
+
+    func testRecorderPersistsTargetProcessEndedReason() throws {
+        let storeRoot = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-recorder-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: storeRoot) }
+        let store = MeetingStore(baseDirectory: storeRoot)
+        let recorder = MeetingRecorder(store: store)
+        let target = AudioCaptureTarget(processID: 1, displayName: "Google Chrome", bundleIdentifier: "com.google.Chrome")
+
+        let record = try recorder.prepareRecord(for: target, startedAt: Date(timeIntervalSince1970: 100))
+        _ = try recorder.markStopped(at: Date(timeIntervalSince1970: 200), endedReason: .targetProcessEnded)
+
+        let data = try Data(contentsOf: XCTUnwrap(record.diagnosticsURL))
+        let diagnostics = try JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
+        XCTAssertEqual(diagnostics.endedReason, .targetProcessEnded)
+        XCTAssertEqual(diagnostics.status, .targetProcessEnded)
+    }
 }

--- a/docs/superpowers/plans/2026-04-25-target-process-ended.md
+++ b/docs/superpowers/plans/2026-04-25-target-process-ended.md
@@ -1,0 +1,372 @@
+# Target Process Ended Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect active capture target process termination in the app and CLI, then persist capture diagnostics with `endedReason: targetProcessEnded`.
+
+**Architecture:** Add testable PID liveness helpers to `MeetingProcessMonitor`, inject the target list provider into `MeetingAgentViewModel`, and let `MeetingRecorder.stopRecording` accept the final capture ended reason. The CLI will use the same liveness helper in its existing capture loop.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, macOS Core Audio Process Tap prototype.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentCore/MeetingProcessMonitor.swift` to expose PID liveness helpers.
+- Modify `Sources/MeetingAgentCore/MeetingRecorder.swift` to accept and persist a caller-provided `CaptureEndedReason`.
+- Modify `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` to inject a process target provider and stop active recordings when the PID disappears.
+- Modify `Sources/CoreAudioTapProbe/ProbeMain.swift` to stop early with `.targetProcessEnded` when the target PID disappears.
+- Modify `Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift` for liveness helper coverage.
+- Modify `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift` for target-ended diagnostics persistence.
+- Modify `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` for app state transition coverage.
+
+### Task 1: Process Liveness Helper
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingProcessMonitor.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift`
+
+- [ ] **Step 1: Write failing liveness tests**
+
+Add these tests to `MeetingProcessMonitorTests`:
+
+```swift
+func testDetectsRunningProcessIDFromTargets() {
+    let monitor = MeetingProcessMonitor()
+    let zoom = AudioCaptureTarget(processID: 123, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+    let chrome = AudioCaptureTarget(processID: 456, displayName: "Google Chrome", bundleIdentifier: "com.google.Chrome")
+
+    XCTAssertTrue(monitor.isProcessRunning(processID: 123, in: [zoom, chrome]))
+    XCTAssertFalse(monitor.isProcessRunning(processID: 789, in: [zoom, chrome]))
+}
+
+func testDetectsEndedProcessIDFromTargets() {
+    let monitor = MeetingProcessMonitor()
+    let zoom = AudioCaptureTarget(processID: 123, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+
+    XCTAssertFalse(monitor.hasProcessEnded(processID: 123, in: [zoom]))
+    XCTAssertTrue(monitor.hasProcessEnded(processID: 456, in: [zoom]))
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `swift test --filter MeetingProcessMonitorTests`
+
+Expected: FAIL because `isProcessRunning(processID:in:)` and `hasProcessEnded(processID:in:)` do not exist.
+
+- [ ] **Step 3: Implement liveness helper**
+
+Add these methods to `MeetingProcessMonitor`:
+
+```swift
+public func isProcessRunning(processID: pid_t, in targets: [AudioCaptureTarget]) -> Bool {
+    targets.contains { $0.processID == processID }
+}
+
+public func hasProcessEnded(processID: pid_t, in targets: [AudioCaptureTarget]) -> Bool {
+    !isProcessRunning(processID: processID, in: targets)
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `swift test --filter MeetingProcessMonitorTests`
+
+Expected: PASS.
+
+### Task 2: Recorder Ended Reason
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingRecorder.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift`
+
+- [ ] **Step 1: Write failing recorder diagnostics test**
+
+Add this test to `MeetingRecorderTests`:
+
+```swift
+func testRecorderPersistsTargetProcessEndedReason() throws {
+    let storeRoot = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-recorder-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: storeRoot) }
+    let store = MeetingStore(baseDirectory: storeRoot)
+    let recorder = MeetingRecorder(store: store)
+    let target = AudioCaptureTarget(processID: 1, displayName: "Google Chrome", bundleIdentifier: "com.google.Chrome")
+
+    let record = try recorder.prepareRecord(for: target, startedAt: Date(timeIntervalSince1970: 100))
+    _ = try recorder.markStopped(at: Date(timeIntervalSince1970: 200), endedReason: .targetProcessEnded)
+
+    let data = try Data(contentsOf: XCTUnwrap(record.diagnosticsURL))
+    let diagnostics = try JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
+    XCTAssertEqual(diagnostics.endedReason, .targetProcessEnded)
+    XCTAssertEqual(diagnostics.status, .targetProcessEnded)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `swift test --filter MeetingRecorderTests`
+
+Expected: FAIL because `markStopped(at:endedReason:)` does not exist.
+
+- [ ] **Step 3: Implement ended reason plumbing**
+
+Change signatures and calls in `MeetingRecorder`:
+
+```swift
+public func stopRecording(
+    at endedAt: Date = Date(),
+    endedReason: CaptureEndedReason = .saved
+) throws -> MeetingRecord? {
+    try writer?.close()
+    let activeTranscriber = transcriber
+    activeTranscriber?.finish()
+    if let failureReason = activeTranscriber?.failureReason {
+        try markTranscriptionFailed(failureReason)
+    }
+    captureSession?.stop()
+    diagnosticsTracker?.finish(endedReason: endedReason)
+    writer = nil
+    transcriber = nil
+    captureSession = nil
+    return try markStopped(at: endedAt, endedReason: endedReason)
+}
+
+public func markStopped(
+    at endedAt: Date = Date(),
+    endedReason: CaptureEndedReason = .saved
+) throws -> MeetingRecord? {
+    guard var record = activeRecord else {
+        state = .idle
+        return nil
+    }
+
+    record.endedAt = endedAt
+    if record.transcriptionStatus == .transcribing {
+        record.transcriptionStatus = .transcribed
+        record.transcriptionFailureReason = nil
+    }
+    diagnosticsTracker?.finish(endedReason: endedReason)
+    try diagnosticsTracker?.snapshot().writeIfPossible(to: record.diagnosticsURL)
+    diagnosticsTracker = nil
+    try store.save(record)
+    activeRecord = nil
+    state = .idle
+    return record
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `swift test --filter MeetingRecorderTests`
+
+Expected: PASS.
+
+### Task 3: App Target End Handling
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Write failing view-model test**
+
+Add this test to `MeetingAgentViewModelTests`:
+
+```swift
+func testDrainRecordingFramesStopsWhenTargetProcessEnds() throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = MeetingStore(baseDirectory: root)
+    var targets: [AudioCaptureTarget] = []
+    let endedAt = Date(timeIntervalSince1970: 200)
+    let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+    let viewModel = MeetingAgentViewModel(
+        store: store,
+        processTargetsProvider: { targets }
+    )
+
+    viewModel.setPendingCandidate(target)
+    try viewModel.acceptPendingCandidate(startedAt: Date(timeIntervalSince1970: 100))
+
+    viewModel.drainRecordingFrames(endedAt: endedAt)
+
+    XCTAssertEqual(viewModel.meetings.first?.endedAt, endedAt)
+    XCTAssertEqual(viewModel.statusText, "Target process ended: zoom.us")
+    XCTAssertFalse(viewModel.isRecording)
+
+    let data = try Data(contentsOf: XCTUnwrap(viewModel.meetings.first?.diagnosticsURL))
+    let diagnostics = try JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
+    XCTAssertEqual(diagnostics.endedReason, .targetProcessEnded)
+    XCTAssertEqual(diagnostics.status, .targetProcessEnded)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `swift test --filter MeetingAgentViewModelTests`
+
+Expected: FAIL because `processTargetsProvider` injection does not exist.
+
+- [ ] **Step 3: Inject process targets provider**
+
+Add a stored provider to `MeetingAgentViewModel`:
+
+```swift
+private let processTargetsProvider: () -> [AudioCaptureTarget]
+```
+
+Add this initializer parameter:
+
+```swift
+processTargetsProvider: @escaping () -> [AudioCaptureTarget] = RunningProcessDiscovery.currentTargets,
+```
+
+Assign it in `init`:
+
+```swift
+self.processTargetsProvider = processTargetsProvider
+```
+
+Update `pollForMeetingCandidates()`:
+
+```swift
+let targets = processTargetsProvider()
+```
+
+- [ ] **Step 4: Implement app stop on target end**
+
+Update `drainRecordingFrames()`:
+
+```swift
+public func drainRecordingFrames(endedAt: Date = Date()) {
+    try? recorder.drainFrames()
+    if stopRecordingIfTargetProcessEnded(at: endedAt) {
+        objectWillChange.send()
+        return
+    }
+    updateRecordingStatus()
+    objectWillChange.send()
+}
+```
+
+Add this helper:
+
+```swift
+private func stopRecordingIfTargetProcessEnded(at endedAt: Date = Date()) -> Bool {
+    guard let activeTarget else { return false }
+    let targets = processTargetsProvider()
+    guard processMonitor.hasProcessEnded(processID: activeTarget.processID, in: targets) else {
+        return false
+    }
+    if let stopped = try? recorder.stopRecording(at: endedAt, endedReason: .targetProcessEnded),
+       let index = meetings.firstIndex(where: { $0.id == stopped.id }) {
+        meetings[index] = stopped
+    }
+    statusText = "Target process ended: \(activeTarget.displayName)"
+    self.activeTarget = nil
+    return true
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `swift test --filter MeetingAgentViewModelTests`
+
+Expected: PASS.
+
+### Task 4: CLI Target End Handling
+
+**Files:**
+- Modify: `Sources/CoreAudioTapProbe/ProbeMain.swift`
+
+- [ ] **Step 1: Refactor loop ended reason variable**
+
+Before the CLI capture loop, add:
+
+```swift
+var endedReason = CaptureEndedReason.saved
+let processMonitor = MeetingProcessMonitor()
+```
+
+- [ ] **Step 2: Check target liveness in the loop**
+
+Inside the `while Date() < end` loop, after sleep and before draining frames, add:
+
+```swift
+let currentTargets = RunningProcessDiscovery.currentTargets()
+let targetProcessEnded = processMonitor.hasProcessEnded(processID: target.processID, in: currentTargets)
+if targetProcessEnded {
+    endedReason = .targetProcessEnded
+}
+```
+
+After logging any frame results for the tick, add:
+
+```swift
+if targetProcessEnded {
+    log("Target process ended: \(target.displayName) pid=\(target.processID)")
+    break
+}
+```
+
+For the `frames.isEmpty` branch, log idle and then break when `targetProcessEnded` is true before continuing.
+
+- [ ] **Step 3: Persist dynamic ended reason**
+
+Change:
+
+```swift
+diagnosticsTracker.finish(endedReason: .saved)
+```
+
+to:
+
+```swift
+diagnosticsTracker.finish(endedReason: endedReason)
+```
+
+- [ ] **Step 4: Build CLI**
+
+Run: `swift build --product CoreAudioTapProbe`
+
+Expected: PASS.
+
+### Task 5: Full Verification and Commit
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run full tests**
+
+Run: `swift test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run app build**
+
+Run: `swift build --product MeetingAgentApp`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run CLI build**
+
+Run: `swift build --product CoreAudioTapProbe`
+
+Expected: PASS.
+
+- [ ] **Step 4: Review diff**
+
+Run: `git diff --check` and `git diff --stat`
+
+Expected: no whitespace errors; diff only includes issue #15 files.
+
+- [ ] **Step 5: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/MeetingProcessMonitor.swift Sources/MeetingAgentCore/MeetingRecorder.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Sources/CoreAudioTapProbe/ProbeMain.swift Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+git commit -m "feat: detect target process ended during capture (#15)"
+```
+
+Expected: commit created.

--- a/docs/superpowers/specs/2026-04-25-target-process-ended-design.md
+++ b/docs/superpowers/specs/2026-04-25-target-process-ended-design.md
@@ -1,0 +1,39 @@
+# Target Process Ended Capture Status Design
+
+## Issue
+
+GitHub issue #15 asks the app and CLI to detect when the active capture target process exits during recording and persist capture diagnostics with `endedReason: targetProcessEnded`. WAV and transcript artifacts written before termination must remain saved.
+
+## Goals
+
+- Detect active target PID disappearance in both `MeetingAgentApp` and `CoreAudioTapProbe`.
+- Stop the active recording predictably when the target process disappears.
+- Persist `CaptureDiagnostics.endedReason` as `.targetProcessEnded` and `status` as `.targetProcessEnded`.
+- Preserve audio and transcript artifacts written up to the stop point.
+- Keep manual/user stop behavior unchanged as `.saved`.
+
+## Non-Goals
+
+- Do not add OS lifecycle notifications or event-source based monitoring.
+- Do not refactor the CLI to use `MeetingRecorder`.
+- Do not change capture setup, Core Audio tap creation, or transcription provider behavior.
+
+## Approach
+
+Use explicit process-liveness checks at existing polling points. The app already calls `drainRecordingFrames()` repeatedly while recording, and the CLI already loops every 250 ms while capture is active. These are the right places to check whether the active target PID is still present in `RunningProcessDiscovery.currentTargets()`.
+
+Add a small liveness helper to `MeetingProcessMonitor` so production code can query a PID against the current process list and tests can exercise the same logic with injected target arrays. Keep `RunningProcessDiscovery` as the production source of truth.
+
+Extend `MeetingRecorder.stopRecording` to accept a `CaptureEndedReason`, defaulting to `.saved`. On target exit, callers will pass `.targetProcessEnded`; normal user stops will continue using the default. `MeetingRecorder` will still close the writer, finish the transcriber, stop the capture session, save diagnostics, mark the meeting ended, and return to idle.
+
+In `MeetingAgentViewModel`, when `drainRecordingFrames()` sees the active target has ended, it will drain any buffered frames, stop the recorder with `.targetProcessEnded`, update the meeting row, clear `activeTarget`, and leave `statusText` as `Target process ended: <name>`.
+
+In `CoreAudioTapProbe`, each capture loop iteration will check target liveness. If the target process has disappeared, the loop will drain/write frames for that tick, finish the writer/transcriber, write diagnostics with `.targetProcessEnded`, and log diagnostics before exiting normally.
+
+## Testing
+
+- Add unit coverage for the process-liveness helper.
+- Add a `MeetingRecorder` test that `markStopped` or stop finalization can persist `.targetProcessEnded`.
+- Add a `MeetingAgentViewModel` test using an injected process-list provider so target PID disappearance stops the meeting and sets target-ended status.
+- Run `swift test` and `swift build --product CoreAudioTapProbe`.
+


### PR DESCRIPTION
## Summary

Fixes #15

- Detects when the active capture target PID disappears in both the app and CLI.
- Persists capture diagnostics with endedReason targetProcessEnded while preserving saved artifacts.

## Changes

- Sources/MeetingAgentCore/MeetingProcessMonitor.swift - adds testable PID liveness helpers.
- Sources/MeetingAgentCore/MeetingRecorder.swift - allows callers to persist a specific capture ended reason.
- Sources/MeetingAgentCore/MeetingAgentViewModel.swift - injects process target discovery and stops active recordings on target exit.
- Sources/CoreAudioTapProbe/ProbeMain.swift - stops CLI capture early when the target process exits.
- Tests/MeetingAgentCoreTests/* - adds regression coverage for process liveness, recorder diagnostics, and app transition.

## Test plan

- [x] Build/lint: git diff --check passed
- [x] Unit tests: swift test passed
- [x] E2E/integration: skipped, no E2E convention for process-liveness behavior
- [x] Product build: swift build --product MeetingAgentApp passed
- [x] Product build: swift build --product CoreAudioTapProbe passed
- [x] Code review: PASS
- [ ] Manual verification: not run; target process exit requires live macOS capture session