### PR TITLE
fix: style sidebar title with command center theme

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -9,6 +9,20 @@ struct MainWindowView: View {
     var body: some View {
         NavigationSplitView {
             VStack(spacing: 0) {
+                HStack {
+                    Text("Meeting Agent")
+                        .commandCenterEyebrow()
+                    Spacer()
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 16)
+                .background(CommandCenterPalette.surface)
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(CommandCenterPalette.border)
+                        .frame(height: 1)
+                }
+
                 List(selection: Binding(
                     get: { showSettings ? nil : viewModel.selectedMeetingID },
                     set: { id in
@@ -50,7 +64,6 @@ struct MainWindowView: View {
                 .background(showSettings ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
             }
             .background(CommandCenterPalette.surface)
-            .navigationTitle("Meeting Agent")
         } detail: {
             if showSettings {
                 SettingsView(

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -72,6 +72,16 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("showSettings = true"))
     }
 
+    func testSidebarTitleUsesCommandCenterStylingInsteadOfSystemNavigationTitle() throws {
+        let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+        let source = try String(contentsOf: sourceURL)
+
+        XCTAssertTrue(source.contains("Text(\"Meeting Agent\")"))
+        XCTAssertTrue(source.contains(".commandCenterEyebrow()"))
+        XCTAssertFalse(source.contains(".navigationTitle(\"Meeting Agent\")"))
+    }
+
     func testMainWindowContainsLiveTranslationControls() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")


### PR DESCRIPTION
## Summary

Follow-up to #22 after the original UI PR was merged.

- Replaces the gray system `.navigationTitle("Meeting Agent")` with a custom sidebar header using the command-center design system.
- Uses `commandCenterEyebrow()`, `CommandCenterPalette.surface`, and `CommandCenterPalette.border` so the title matches the rest of the dark theme.
- Adds a source-layout regression test to prevent the system navigation title from returning.

## Test plan

- [x] `swift test --filter MainWindowViewLayoutTests`
- [x] `swift build --product MeetingAgentApp`
- [x] `swift test` passed 291 tests

## Notes

This branch is based on latest `origin/main` and contains only one commit: `7aaf9f7 fix: style sidebar title with command center theme (#22)`.