### PR TITLE
fix: detect Feishu meeting audio targets

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -125,3 +125,19 @@ When replacing a UI shell, map every old visible control to a new visible contro
 For UI restyles, review both callback wiring and rendered control labels against the previous screen.
 
 ---
+
+## [25] Avoid sorting-only tests for preferred-target behavior
+
+**Date**: 2026-04-28
+**Category**: test-mistake
+
+### What went wrong
+The first Feishu discovery regression test expected Feishu to sort before Notes, but that passed alphabetically even when Feishu was not in the preferred bundle set.
+
+### Correct approach
+Test preferred-target behavior through automatic selection or candidate detection where non-preferred active apps are filtered out.
+
+### How to avoid
+When testing priority classification, choose assertions that fail without the classification, not assertions that can pass due to unrelated ordering.
+
+---

--- a/Sources/MeetingAgentCore/RunningProcessDiscovery.swift
+++ b/Sources/MeetingAgentCore/RunningProcessDiscovery.swift
@@ -11,6 +11,7 @@ public struct RunningProcessDiscovery {
         "company.thebrowser.Browser",
         "com.apple.Safari",
         "com.larksuite.Lark",
+        "com.electron.larkFeishu",
         "com.tencent.meeting"
     ]
 

--- a/Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift
@@ -67,6 +67,20 @@ final class MeetingProcessMonitorTests: XCTestCase {
         XCTAssertEqual(active, [activeChrome])
     }
 
+    func testDetectsFeishuWhenAudioOutputIsActive() {
+        let feishu = AudioCaptureTarget(
+            processID: 321,
+            displayName: "Feishu",
+            bundleIdentifier: "com.electron.larkFeishu",
+            isAudioOutputActive: true
+        )
+        let monitor = MeetingProcessMonitor()
+
+        let candidates = monitor.detectNewCandidates(in: [feishu], isRecording: false)
+
+        XCTAssertEqual(candidates, [feishu])
+    }
+
     func testDetectsRunningProcessIDFromTargets() {
         let monitor = MeetingProcessMonitor()
         let zoom = AudioCaptureTarget(processID: 123, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")

--- a/Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift
+++ b/Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift
@@ -57,6 +57,27 @@ final class RunningProcessDiscoveryTests: XCTestCase {
         XCTAssertEqual(targets.map(\.displayName), ["Microsoft Edge", "Notes"])
     }
 
+    func testAutomaticallySelectsFeishuAsMeetingApp() {
+        let targets = [
+            AudioCaptureTarget(
+                processID: 200,
+                displayName: "Notes",
+                bundleIdentifier: "com.apple.Notes",
+                isAudioOutputActive: true
+            ),
+            AudioCaptureTarget(
+                processID: 201,
+                displayName: "Feishu",
+                bundleIdentifier: "com.electron.larkFeishu",
+                isAudioOutputActive: true
+            )
+        ]
+
+        let selected = RunningProcessDiscovery.automaticTarget(from: targets)
+
+        XCTAssertEqual(selected?.processID, 201)
+    }
+
     func testAutomaticallySelectsFirstPreferredTarget() {
         let targets = [
             AudioCaptureTarget(processID: 200, displayName: "Notes", bundleIdentifier: "com.apple.Notes"),


### PR DESCRIPTION
## Summary

Fixes #25

- Recognizes the Feishu macOS app bundle identifier as a preferred meeting target.
- Adds regression coverage for Feishu automatic target selection and prompt candidate detection.

## Changes

- `Sources/MeetingAgentCore/RunningProcessDiscovery.swift` - adds `com.electron.larkFeishu` to preferred bundle IDs.
- `Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift` - verifies Feishu can be automatically selected when audio is active.
- `Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift` - verifies Feishu triggers a new candidate when audio output is active.
- `MISTAKES.md` - records a reusable test-design lesson from the TDD cycle.

## Test plan

- [x] Build/lint: `make test` passed
- [x] Unit tests: focused Feishu tests failed before the fix and passed after the fix; `make test` passed 357 tests with coverage gate
- [x] E2E/integration: skipped; no E2E convention for this process-discovery unit behavior
- [x] Code review: PASS
- [x] Manual verification: not applicable beyond targeted process-discovery regression tests
