### PR TITLE
feat: merge same-speaker transcript turns

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -141,3 +141,19 @@ Test preferred-target behavior through automatic selection or candidate detectio
 When testing priority classification, choose assertions that fail without the classification, not assertions that can pass due to unrelated ordering.
 
 ---
+
+## [28] Preserve idempotence when merging append-only state
+
+**Date**: 2026-04-28
+**Category**: logic-error
+
+### What went wrong
+The first same-speaker live caption merge only checked the latest `sourceSegmentID`, so refreshing the same transcript document could append an earlier already-represented segment into the merged turn again.
+
+### Correct approach
+Merged display turns need to track every represented source segment ID and reject appends for segment IDs already present in that merged turn.
+
+### How to avoid
+When changing append-only state into grouped state, add an idempotent replay test that appends the same source item again after grouping.
+
+---

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -238,6 +238,10 @@ public struct LiveCaptionStore: Equatable {
             translationHealth: segment.isFinal ? .pending : .idle,
             createdAt: segment.createdAt
         )
+        if let representedIndex = turns.firstIndex(where: { $0.sourceSegmentIDs.contains(segment.id) }),
+           turns[representedIndex].sourceSegmentIDs.count > 1 {
+            return turns[representedIndex]
+        }
         if let index = turns.firstIndex(where: { $0.sourceSegmentID == segment.id }) {
             let previousTurn = turns[index]
             var updated = turn

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -103,6 +103,7 @@ public struct MeetingGoal: Codable, Equatable, Identifiable {
 public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
     public var id: String
     public var sourceSegmentID: String
+    public var sourceSegmentIDs: [String]
     public var speaker: TranscriptSpeaker
     public var originalText: String
     public var translatedText: String?
@@ -116,6 +117,7 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
     public init(
         id: String? = nil,
         sourceSegmentID: String,
+        sourceSegmentIDs: [String]? = nil,
         speaker: TranscriptSpeaker = .default,
         originalText: String,
         translatedText: String? = nil,
@@ -128,6 +130,7 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
     ) {
         self.id = id ?? sourceSegmentID
         self.sourceSegmentID = sourceSegmentID
+        self.sourceSegmentIDs = sourceSegmentIDs ?? [sourceSegmentID]
         self.speaker = speaker
         self.originalText = originalText
         self.translatedText = translatedText
@@ -137,6 +140,37 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
         self.captionHealth = captionHealth
         self.translationHealth = translationHealth
         self.createdAt = createdAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case sourceSegmentID
+        case sourceSegmentIDs
+        case speaker
+        case originalText
+        case translatedText
+        case sourceLocale
+        case targetLocale
+        case isFinal
+        case captionHealth
+        case translationHealth
+        case createdAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        sourceSegmentID = try container.decode(String.self, forKey: .sourceSegmentID)
+        sourceSegmentIDs = try container.decodeIfPresent([String].self, forKey: .sourceSegmentIDs) ?? [sourceSegmentID]
+        speaker = try container.decode(TranscriptSpeaker.self, forKey: .speaker)
+        originalText = try container.decode(String.self, forKey: .originalText)
+        translatedText = try container.decodeIfPresent(String.self, forKey: .translatedText)
+        sourceLocale = try container.decode(String.self, forKey: .sourceLocale)
+        targetLocale = try container.decode(String.self, forKey: .targetLocale)
+        isFinal = try container.decode(Bool.self, forKey: .isFinal)
+        captionHealth = try container.decode(LivePipelineHealth.self, forKey: .captionHealth)
+        translationHealth = try container.decode(LivePipelineHealth.self, forKey: .translationHealth)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
     }
 }
 
@@ -214,13 +248,61 @@ public struct LiveCaptionStore: Equatable {
             turns[index] = updated
             return updated
         }
+        if let index = mergeTargetIndex(for: turn) {
+            turns[index] = mergedTurn(turns[index], appending: turn)
+            return turns[index]
+        }
         turns.append(turn)
         return turn
+    }
+
+    private func mergeTargetIndex(for turn: LiveCaptionTurn) -> Int? {
+        guard turn.isFinal,
+              let lastIndex = turns.indices.last,
+              turns[lastIndex].isFinal,
+              turns[lastIndex].speaker == turn.speaker
+        else {
+            return nil
+        }
+        return lastIndex
+    }
+
+    private func mergedTurn(_ existing: LiveCaptionTurn, appending turn: LiveCaptionTurn) -> LiveCaptionTurn {
+        var merged = existing
+        merged.sourceSegmentID = turn.sourceSegmentID
+        merged.sourceSegmentIDs.append(contentsOf: turn.sourceSegmentIDs)
+        merged.originalText = joinedTranscriptText(existing.originalText, turn.originalText)
+        merged.sourceLocale = turn.sourceLocale
+        merged.targetLocale = turn.targetLocale
+        merged.isFinal = turn.isFinal
+        merged.captionHealth = turn.captionHealth
+        merged.translatedText = nil
+        merged.translationHealth = .pending
+        merged.createdAt = turn.createdAt
+        return merged
+    }
+
+    private func joinedTranscriptText(_ first: String, _ second: String) -> String {
+        let trimmedFirst = first.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedSecond = second.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedFirst.isEmpty {
+            return trimmedSecond
+        }
+        if trimmedSecond.isEmpty {
+            return trimmedFirst
+        }
+        return "\(trimmedFirst) \(trimmedSecond)"
     }
 
     public mutating func attachTranslation(_ text: String, toTurnID turnID: String) {
         guard let index = turns.firstIndex(where: { $0.id == turnID }) else { return }
         turns[index].translatedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        turns[index].translationHealth = .live
+    }
+
+    public mutating func appendTranslation(_ text: String, toTurnID turnID: String) {
+        guard let index = turns.firstIndex(where: { $0.id == turnID }) else { return }
+        turns[index].translatedText = joinedTranscriptText(turns[index].translatedText ?? "", text)
         turns[index].translationHealth = .live
     }
 

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -43,6 +43,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     @Published public private(set) var meetingGoal: MeetingGoal?
     private var meetingProgressCoordinator: MeetingProgressCoordinator?
     private var attachedRealtimeTranslationTurnIDs = Set<String>()
+    private var realtimeTranslationAttachmentCountsByCaptionID: [String: Int] = [:]
     private let processTargetsProvider: () -> [AudioCaptureTarget]
     private let processMonitor = MeetingProcessMonitor()
     private var activeTarget: AudioCaptureTarget?
@@ -665,6 +666,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             targetLocale: speechConfiguration.targetLocaleIdentifier
         )
         attachedRealtimeTranslationTurnIDs.removeAll()
+        realtimeTranslationAttachmentCountsByCaptionID.removeAll()
         liveCaptionTurns = []
         meetingProgressHealth.caption = .idle
         meetingProgressHealth.translation = .idle
@@ -738,15 +740,20 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
         for translation in unattachedFinalTranslations {
             guard let caption = liveCaptionStore.turns.first(where: {
-                $0.isFinal && ($0.translatedText?.isEmpty ?? true)
+                $0.isFinal && realtimeTranslationAttachmentCount(for: $0) < $0.sourceSegmentIDs.count
             }) else {
                 break
             }
-            liveCaptionStore.attachTranslation(translation.text, toTurnID: caption.id)
+            liveCaptionStore.appendTranslation(translation.text, toTurnID: caption.id)
+            realtimeTranslationAttachmentCountsByCaptionID[caption.id, default: 0] += 1
             attachedRealtimeTranslationTurnIDs.insert(translation.id)
         }
         liveCaptionTurns = liveCaptionStore.turns
         updateTranslationHealthFromRealtimeStatus()
+    }
+
+    private func realtimeTranslationAttachmentCount(for caption: LiveCaptionTurn) -> Int {
+        realtimeTranslationAttachmentCountsByCaptionID[caption.id, default: 0]
     }
 
     private func updateTranslationHealthFromRealtimeStatus() {

--- a/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
@@ -48,10 +48,10 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
     func testURLSessionStreamingSessionSendsReceivesAndClosesSocket() async throws {
         let task = FakeDeepgramWebSocketTask()
         let session = URLSessionDeepgramStreamingSession(task: task, localeIdentifier: "en-US")
-        var received: [TranscriptSegment] = []
+        let received = TranscriptSegmentCollector()
         let receiveTask = Task {
             for await segment in session.segments {
-                received.append(segment)
+                await received.append(segment)
             }
         }
         try await Task.sleep(nanoseconds: 10_000_000)
@@ -73,7 +73,8 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         await session.close()
         await receiveTask.value
 
-        XCTAssertEqual(received.map(\.text), ["hello"])
+        let receivedTexts = await received.texts
+        XCTAssertEqual(receivedTexts, ["hello"])
         XCTAssertEqual(task.sentMessages.count, 2)
         if case .data(let data) = task.sentMessages.first {
             XCTAssertEqual(data, Data([1, 2, 3]))
@@ -188,6 +189,18 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(document.segments.map(\.text), ["Hello team.", "Yes."])
         XCTAssertEqual(document.segments.map(\.startTimeSeconds), [0.0, 0.9])
         XCTAssertEqual(document.segments.map(\.endTimeSeconds), [0.8, 1.1])
+    }
+}
+
+private actor TranscriptSegmentCollector {
+    private var segments: [TranscriptSegment] = []
+
+    var texts: [String] {
+        segments.map(\.text)
+    }
+
+    func append(_ segment: TranscriptSegment) {
+        segments.append(segment)
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
@@ -135,6 +135,20 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(store.turns.first?.translationHealth, .pending)
     }
 
+    func testAppendingAlreadyRepresentedSegmentToMergedTurnDoesNotDuplicateText() {
+        var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User 1")
+        _ = store.append(TranscriptSegment(id: "segment-1", speaker: speaker, text: "first", language: "en-US", isFinal: true))
+        _ = store.append(TranscriptSegment(id: "segment-2", speaker: speaker, text: "second", language: "en-US", isFinal: true))
+
+        let existing = store.append(TranscriptSegment(id: "segment-1", speaker: speaker, text: "first", language: "en-US", isFinal: true))
+
+        XCTAssertEqual(store.turns.count, 1)
+        XCTAssertEqual(existing.originalText, "first second")
+        XCTAssertEqual(existing.sourceSegmentIDs, ["segment-1", "segment-2"])
+        XCTAssertEqual(store.turns.first?.originalText, "first second")
+    }
+
     func testAttachTranslationUpdatesSameTurn() {
         var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
         _ = store.append(TranscriptSegment(id: "segment-1", text: "hello", language: "en-US"))

--- a/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
@@ -52,6 +52,89 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(store.turns.first?.translationHealth, .pending)
     }
 
+    func testAppendingFinalSegmentFromSameSpeakerMergesIntoLatestTurn() {
+        var store = LiveCaptionStore(sourceLocale: "zh-CN", targetLocale: "en-US")
+        let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User 1")
+        _ = store.append(TranscriptSegment(
+            id: "segment-1",
+            speaker: speaker,
+            text: "我们先看一下",
+            language: "zh-CN",
+            isFinal: true,
+            createdAt: Date(timeIntervalSince1970: 100)
+        ))
+
+        let merged = store.append(TranscriptSegment(
+            id: "segment-2",
+            speaker: speaker,
+            text: "这个季度的目标",
+            language: "zh-CN",
+            isFinal: true,
+            createdAt: Date(timeIntervalSince1970: 120)
+        ))
+
+        XCTAssertEqual(store.turns.count, 1)
+        XCTAssertEqual(merged.id, "segment-1")
+        XCTAssertEqual(merged.sourceSegmentID, "segment-2")
+        XCTAssertEqual(merged.sourceSegmentIDs, ["segment-1", "segment-2"])
+        XCTAssertEqual(merged.originalText, "我们先看一下 这个季度的目标")
+        XCTAssertEqual(merged.speaker, speaker)
+        XCTAssertEqual(merged.sourceLocale, "zh-CN")
+        XCTAssertEqual(merged.targetLocale, "en-US")
+        XCTAssertTrue(merged.isFinal)
+        XCTAssertEqual(merged.translationHealth, .pending)
+        XCTAssertEqual(merged.createdAt, Date(timeIntervalSince1970: 120))
+    }
+
+    func testAppendingFinalSegmentFromDifferentSpeakerCreatesNewTurn() {
+        var store = LiveCaptionStore(sourceLocale: "zh-CN", targetLocale: "en-US")
+        _ = store.append(TranscriptSegment(
+            id: "segment-1",
+            speaker: TranscriptSpeaker(identifier: "speaker-1", label: "User 1"),
+            text: "我们先看一下",
+            language: "zh-CN",
+            isFinal: true
+        ))
+
+        _ = store.append(TranscriptSegment(
+            id: "segment-2",
+            speaker: TranscriptSpeaker(identifier: "speaker-2", label: "User 2"),
+            text: "我有一个问题",
+            language: "zh-CN",
+            isFinal: true
+        ))
+
+        XCTAssertEqual(store.turns.count, 2)
+        XCTAssertEqual(store.turns.map(\.originalText), ["我们先看一下", "我有一个问题"])
+    }
+
+    func testMergingSameSpeakerClearsStaleTranslation() {
+        var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User 1")
+        _ = store.append(TranscriptSegment(
+            id: "segment-1",
+            speaker: speaker,
+            text: "first",
+            language: "en-US",
+            isFinal: true
+        ))
+        store.attachTranslation("第一句", toTurnID: "segment-1")
+
+        let merged = store.append(TranscriptSegment(
+            id: "segment-2",
+            speaker: speaker,
+            text: "second",
+            language: "en-US",
+            isFinal: true
+        ))
+
+        XCTAssertEqual(merged.originalText, "first second")
+        XCTAssertNil(merged.translatedText)
+        XCTAssertEqual(merged.translationHealth, .pending)
+        XCTAssertNil(store.turns.first?.translatedText)
+        XCTAssertEqual(store.turns.first?.translationHealth, .pending)
+    }
+
     func testAttachTranslationUpdatesSameTurn() {
         var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
         _ = store.append(TranscriptSegment(id: "segment-1", text: "hello", language: "en-US"))
@@ -59,6 +142,19 @@ final class LiveCaptionStoreTests: XCTestCase {
         store.attachTranslation("你好", toTurnID: "segment-1")
 
         XCTAssertEqual(store.turns.first?.translatedText, "你好")
+        XCTAssertEqual(store.turns.first?.translationHealth, .live)
+    }
+
+    func testAppendTranslationCombinesTranslatedTextForMergedTurn() {
+        var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User 1")
+        _ = store.append(TranscriptSegment(id: "segment-1", speaker: speaker, text: "first", language: "en-US", isFinal: true))
+        _ = store.append(TranscriptSegment(id: "segment-2", speaker: speaker, text: "second", language: "en-US", isFinal: true))
+
+        store.appendTranslation("第一句", toTurnID: "segment-1")
+        store.appendTranslation("第二句", toTurnID: "segment-1")
+
+        XCTAssertEqual(store.turns.first?.translatedText, "第一句 第二句")
         XCTAssertEqual(store.turns.first?.translationHealth, .live)
     }
 

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -1254,7 +1254,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
         viewModel.syncRealtimeTranslationState()
         viewModel.syncRealtimeTranslationState()
 
-        XCTAssertEqual(viewModel.liveCaptionTurns.map(\.translatedText), ["第一个决定。", "第二个决定。"])
+        XCTAssertEqual(viewModel.liveCaptionTurns.map(\.translatedText), ["第一个决定。 第二个决定。"])
     }
 
     func testStopRealtimeTranslationResetsState() async {

--- a/docs/superpowers/plans/2026-04-28-merge-same-speaker-transcript-turns.md
+++ b/docs/superpowers/plans/2026-04-28-merge-same-speaker-transcript-turns.md
@@ -188,15 +188,19 @@ Add `sourceSegmentIDs` to `LiveCaptionTurn`, defaulting to `[sourceSegmentID]`, 
 
 When `LiveCaptionStore` merges same-speaker turns, append the new turn's `sourceSegmentIDs` into the existing turn so consumers know how many final source segments the display turn represents.
 
-- [ ] **Step 3: Add append-translation behavior**
+- [ ] **Step 3: Keep refresh idempotent**
+
+Before duplicate-segment update and merge logic, return the existing merged turn when an incoming segment ID is already present in a multi-segment turn's `sourceSegmentIDs`. This prevents repeated transcript refreshes from duplicating already represented source text.
+
+- [ ] **Step 4: Add append-translation behavior**
 
 Add `LiveCaptionStore.appendTranslation(_:toTurnID:)` to join multiple realtime target text finals into one merged turn without changing `attachTranslation(_:toTurnID:)`, which still replaces a turn's translation for one-shot translation providers.
 
-- [ ] **Step 4: Update realtime attachment counts**
+- [ ] **Step 5: Update realtime attachment counts**
 
 In `MeetingAgentViewModel`, track `realtimeTranslationAttachmentCountsByCaptionID`. In `attachRealtimeTranslationsToLiveCaptions`, choose the first final caption where attached translation count is less than `sourceSegmentIDs.count`, append the translation, increment the count, and mark the realtime translation turn attached.
 
-- [ ] **Step 5: Run targeted tests**
+- [ ] **Step 6: Run targeted tests**
 
 Run:
 

--- a/docs/superpowers/plans/2026-04-28-merge-same-speaker-transcript-turns.md
+++ b/docs/superpowers/plans/2026-04-28-merge-same-speaker-transcript-turns.md
@@ -1,0 +1,241 @@
+# Merge Same-Speaker Transcript Turns Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consecutive final transcript segments from the same speaker render as one live caption turn instead of separate blocks.
+
+**Architecture:** Implement the behavior in `LiveCaptionStore.append(_:)` so all consumers receive merged turn state. Keep duplicate segment ID updates first, then merge only adjacent final same-speaker turns. Clear stale translations whenever source text changes.
+
+**Tech Stack:** Swift 5.9, SwiftPM, XCTest, `MeetingAgentCore`.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`: update `LiveCaptionTurn` and `LiveCaptionStore.append(_:)`, add private merge helpers, and support appending multiple translations into a merged turn.
+- Modify `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`: attach realtime final translations into merged captions until each represented source segment has one translation.
+- Modify `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`: add focused regression tests for same-speaker merging and preserved separation/update behavior.
+- Modify `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`: update realtime translation expectations for merged same-speaker captions.
+
+### Task 1: Add Failing Same-Speaker Merge Tests
+
+**Files:**
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+
+- [ ] **Step 1: Add regression tests**
+
+Add these tests to `LiveCaptionStoreTests`:
+
+```swift
+func testAppendingFinalSegmentFromSameSpeakerMergesIntoLatestTurn() {
+    var store = LiveCaptionStore(sourceLocale: "zh-CN", targetLocale: "en-US")
+    let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User 1")
+    _ = store.append(TranscriptSegment(
+        id: "segment-1",
+        speaker: speaker,
+        text: "我们先看一下",
+        language: "zh-CN",
+        isFinal: true,
+        createdAt: Date(timeIntervalSince1970: 100)
+    ))
+
+    let merged = store.append(TranscriptSegment(
+        id: "segment-2",
+        speaker: speaker,
+        text: "这个季度的目标",
+        language: "zh-CN",
+        isFinal: true,
+        createdAt: Date(timeIntervalSince1970: 120)
+    ))
+
+    XCTAssertEqual(store.turns.count, 1)
+    XCTAssertEqual(merged.id, "segment-1")
+    XCTAssertEqual(merged.sourceSegmentID, "segment-2")
+    XCTAssertEqual(merged.originalText, "我们先看一下 这个季度的目标")
+    XCTAssertEqual(merged.speaker, speaker)
+    XCTAssertEqual(merged.sourceLocale, "zh-CN")
+    XCTAssertEqual(merged.targetLocale, "en-US")
+    XCTAssertTrue(merged.isFinal)
+    XCTAssertEqual(merged.translationHealth, .pending)
+    XCTAssertEqual(merged.createdAt, Date(timeIntervalSince1970: 120))
+}
+
+func testAppendingFinalSegmentFromDifferentSpeakerCreatesNewTurn() {
+    var store = LiveCaptionStore(sourceLocale: "zh-CN", targetLocale: "en-US")
+    _ = store.append(TranscriptSegment(
+        id: "segment-1",
+        speaker: TranscriptSpeaker(identifier: "speaker-1", label: "User 1"),
+        text: "我们先看一下",
+        language: "zh-CN",
+        isFinal: true
+    ))
+
+    _ = store.append(TranscriptSegment(
+        id: "segment-2",
+        speaker: TranscriptSpeaker(identifier: "speaker-2", label: "User 2"),
+        text: "我有一个问题",
+        language: "zh-CN",
+        isFinal: true
+    ))
+
+    XCTAssertEqual(store.turns.count, 2)
+    XCTAssertEqual(store.turns.map(\.originalText), ["我们先看一下", "我有一个问题"])
+}
+
+func testMergingSameSpeakerClearsStaleTranslation() {
+    var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+    let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User 1")
+    _ = store.append(TranscriptSegment(id: "segment-1", speaker: speaker, text: "first", language: "en-US", isFinal: true))
+    store.attachTranslation("第一句", toTurnID: "segment-1")
+
+    let merged = store.append(TranscriptSegment(id: "segment-2", speaker: speaker, text: "second", language: "en-US", isFinal: true))
+
+    XCTAssertEqual(merged.originalText, "first second")
+    XCTAssertNil(merged.translatedText)
+    XCTAssertEqual(merged.translationHealth, .pending)
+    XCTAssertNil(store.turns.first?.translatedText)
+    XCTAssertEqual(store.turns.first?.translationHealth, .pending)
+}
+```
+
+- [ ] **Step 2: Run focused tests and confirm failure**
+
+Run: `swift test --filter LiveCaptionStoreTests`
+
+Expected: FAIL because `LiveCaptionStore.append(_:)` still appends same-speaker final segments as separate turns.
+
+### Task 2: Implement Merge in LiveCaptionStore
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+
+- [ ] **Step 1: Update append logic**
+
+In `LiveCaptionStore.append(_:)`, keep the existing duplicate `sourceSegmentID` update block before any new merge logic. After that block, add a same-speaker merge path before `turns.append(turn)`:
+
+```swift
+if let index = mergeTargetIndex(for: turn) {
+    turns[index] = mergedTurn(turns[index], appending: turn)
+    return turns[index]
+}
+turns.append(turn)
+return turn
+```
+
+- [ ] **Step 2: Add merge helpers**
+
+Add these private helpers inside `LiveCaptionStore`:
+
+```swift
+private func mergeTargetIndex(for turn: LiveCaptionTurn) -> Int? {
+    guard turn.isFinal,
+          let lastIndex = turns.indices.last,
+          turns[lastIndex].isFinal,
+          turns[lastIndex].speaker == turn.speaker
+    else {
+        return nil
+    }
+    return lastIndex
+}
+
+private func mergedTurn(_ existing: LiveCaptionTurn, appending turn: LiveCaptionTurn) -> LiveCaptionTurn {
+    var merged = existing
+    merged.sourceSegmentID = turn.sourceSegmentID
+    merged.originalText = joinedTranscriptText(existing.originalText, turn.originalText)
+    merged.sourceLocale = turn.sourceLocale
+    merged.targetLocale = turn.targetLocale
+    merged.isFinal = turn.isFinal
+    merged.captionHealth = turn.captionHealth
+    merged.translatedText = nil
+    merged.translationHealth = .pending
+    merged.createdAt = turn.createdAt
+    return merged
+}
+
+private func joinedTranscriptText(_ first: String, _ second: String) -> String {
+    let trimmedFirst = first.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedSecond = second.trimmingCharacters(in: .whitespacesAndNewlines)
+    if trimmedFirst.isEmpty {
+        return trimmedSecond
+    }
+    if trimmedSecond.isEmpty {
+        return trimmedFirst
+    }
+    return "\(trimmedFirst) \(trimmedSecond)"
+}
+```
+
+- [ ] **Step 3: Run focused tests and confirm pass**
+
+Run: `swift test --filter LiveCaptionStoreTests`
+
+Expected: PASS.
+
+### Task 3: Preserve Realtime Translation Attachment for Merged Captions
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Track represented source segments**
+
+Add `sourceSegmentIDs` to `LiveCaptionTurn`, defaulting to `[sourceSegmentID]`, and preserve backward decoding by defaulting missing `sourceSegmentIDs` to `[sourceSegmentID]`.
+
+- [ ] **Step 2: Append source segment IDs during merge**
+
+When `LiveCaptionStore` merges same-speaker turns, append the new turn's `sourceSegmentIDs` into the existing turn so consumers know how many final source segments the display turn represents.
+
+- [ ] **Step 3: Add append-translation behavior**
+
+Add `LiveCaptionStore.appendTranslation(_:toTurnID:)` to join multiple realtime target text finals into one merged turn without changing `attachTranslation(_:toTurnID:)`, which still replaces a turn's translation for one-shot translation providers.
+
+- [ ] **Step 4: Update realtime attachment counts**
+
+In `MeetingAgentViewModel`, track `realtimeTranslationAttachmentCountsByCaptionID`. In `attachRealtimeTranslationsToLiveCaptions`, choose the first final caption where attached translation count is less than `sourceSegmentIDs.count`, append the translation, increment the count, and mark the realtime translation turn attached.
+
+- [ ] **Step 5: Run targeted tests**
+
+Run:
+
+```bash
+swift test --filter LiveCaptionStoreTests
+swift test --filter MeetingAgentViewModelTests/testRealtimeTranslationFinalTextsAttachByCaptionOrderOnce
+```
+
+Expected: PASS.
+
+### Task 4: Verify Full Test Suite and Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Modify: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Run repository verification**
+
+Run: `make test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Review diff**
+
+Run: `git diff -- Sources/MeetingAgentCore/LiveMeetingCockpit.swift Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+
+Expected: diff only contains same-speaker merge behavior and tests.
+
+- [ ] **Step 3: Commit implementation**
+
+```bash
+git add Sources/MeetingAgentCore/LiveMeetingCockpit.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift docs/superpowers/plans/2026-04-28-merge-same-speaker-transcript-turns.md
+git commit -m "feat: merge same-speaker transcript turns (#28)"
+```
+
+## Self-Review
+
+- Spec coverage: covered same-speaker merge, different-speaker separation, duplicate segment update preservation, stale translation clearing, and focused/full verification.
+- Placeholder scan: no placeholder steps remain.
+- Type consistency: uses existing `LiveCaptionStore`, `LiveCaptionTurn`, `TranscriptSegment`, `TranscriptSpeaker`, and `LivePipelineHealth` names.

--- a/docs/superpowers/specs/2026-04-28-merge-same-speaker-transcript-turns-design.md
+++ b/docs/superpowers/specs/2026-04-28-merge-same-speaker-transcript-turns-design.md
@@ -1,0 +1,47 @@
+# Merge Same-Speaker Transcript Turns Design
+
+## Context
+
+GitHub issue #28 reports that the updated transcript module now displays every model-recognized segment as its own block with speaker, original text, and translation. This splits a single user's sentence across multiple visible modules. Earlier UI behavior merged adjacent dialogue from the same user, and the issue asks to restore that behavior.
+
+## Goal
+
+Consecutive live caption segments from the same speaker should display as one transcript turn. Different speakers should remain separated. Existing duplicate segment updates, translation state, editing, auto-scroll, and analysis behavior should stay coherent.
+
+## Non-Goals
+
+- Do not merge non-adjacent turns from the same speaker.
+- Do not change transcript file persistence or export formatting in this issue.
+- Do not add language-specific sentence segmentation.
+- Do not redesign the transcript row UI.
+
+## Selected Approach
+
+Merge at the `LiveCaptionStore` boundary. `UnifiedTranscriptView` already consumes `liveCaptionTurns`, and downstream live meeting analysis also reads `LiveCaptionTurn` values. Keeping the merge in store state makes the transcript UI, edit actions, translation status, auto-scroll, and progress analysis use the same turn model.
+
+The store should continue to update an existing turn when a segment with the same `sourceSegmentID` arrives. That duplicate-segment update path must run before same-speaker merging so revised provider output does not create duplicate text.
+
+When a new final segment has the same speaker as the latest final turn, append the new segment text to that turn instead of adding a new turn. The merged turn should keep the first turn's stable `id`, update `sourceSegmentID` to the latest segment for "last analyzed" tracking, preserve the original speaker, source locale, target locale, final state, and newest creation timestamp. Because the source text changed, stale translation must be cleared and translation health should return to `.pending`.
+
+Different speakers, partial segments, and empty text should continue to create or update separate turns according to existing behavior.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+  - Update `LiveCaptionStore.append(_:)`.
+  - Add small private helpers if needed for turn merging and text joining.
+- `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+  - Add regression tests for same-speaker merging, different-speaker separation, duplicate updates, and stale translation clearing.
+
+## Test Plan
+
+- Add a failing unit test proving consecutive final segments from the same speaker become a single turn with combined text.
+- Add a unit test proving consecutive final segments from different speakers remain separate turns.
+- Preserve existing duplicate segment update behavior.
+- Verify merged source text clears old translated text and sets translation health to `.pending`.
+- Run `swift test --filter LiveCaptionStoreTests`.
+- Run `make test` for full repository verification.
+
+## Risks
+
+Merging changes the meaning of `sourceSegmentID` for a displayed turn. The chosen behavior is to keep `id` stable for UI identity and update `sourceSegmentID` to the latest merged segment so progress analysis can advance past merged content. Editing a merged turn currently uses `turn.id`, which remains the first source segment ID; editing all merged source segments is outside this issue's scope.

--- a/scripts/check-unit-coverage.sh
+++ b/scripts/check-unit-coverage.sh
@@ -10,5 +10,5 @@ mkdir -p "$MODULE_CACHE_PATH"
 export CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_PATH"
 
 swift test --scratch-path "$SCRATCH_PATH" --enable-code-coverage
-COVERAGE_JSON="$(swift test --scratch-path "$SCRATCH_PATH" --enable-code-coverage --show-codecov-path)"
+COVERAGE_JSON="$(swift test --scratch-path "$SCRATCH_PATH" --show-codecov-path)"
 scripts/check-unit-coverage.swift "$COVERAGE_JSON"


### PR DESCRIPTION
## Summary

Fixes #28

- Merge adjacent final live caption segments from the same speaker into one transcript turn.
- Track represented source segment IDs so refreshes are idempotent and realtime translations append into merged turns.
- Add regression coverage for merging, stale translation clearing, idempotent refresh, and realtime translation attachment.
- Repair CI-only Swift compatibility issues discovered while watching the PR.

## Changes

- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift` - adds merged-turn source segment tracking and same-speaker merge behavior.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - appends realtime final translations into merged caption turns by represented segment count.
- `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift` - covers merge, separation, translation clearing, translation append, and idempotent replay.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - updates realtime translation expectation for merged same-speaker captions.
- `Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift` - uses an actor-backed collector to satisfy CI Swift concurrency checks.
- `scripts/check-unit-coverage.sh` - makes SwiftPM code coverage path lookup compatible with the CI SwiftPM version.
- `docs/superpowers/specs/2026-04-28-merge-same-speaker-transcript-turns-design.md` and `docs/superpowers/plans/2026-04-28-merge-same-speaker-transcript-turns.md` - record design and implementation plan.
- `MISTAKES.md` - records the review lesson from this issue.

## Test plan

- [x] Unit tests: `swift test --filter LiveCaptionStoreTests` passed
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests/testRealtimeTranslationFinalTextsAttachByCaptionOrderOnce` passed
- [x] Unit tests: `swift test --filter DeepgramStreamingTranscriptionProviderTests` passed
- [x] Full verification: `make test` passed outside sandbox, 371 tests, coverage gate passed
- [x] Code review: PASS after one idempotence fix round
- [x] CI: GitHub `unit-tests` passed