### PR TITLE
feat: keep caption translation visible while updating

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -189,3 +189,19 @@ Await the provider call using local immutable inputs, then mutate the actor-isol
 When a helper both awaits and mutates actor-owned state, split it into an async value-producing step and a synchronous actor mutation step.
 
 ---
+
+## [35] Update scheduler predicates when preserving visible fallback state
+
+**Date**: 2026-04-28
+**Category**: logic-error
+
+### What went wrong
+The first stable caption translation fix preserved the old translated text during same-speaker merging, but the translation scheduler still required pending turns to have empty translated text before requesting the updated full-turn translation.
+
+### Correct approach
+Use the semantic translation key and in-flight state to decide whether a pending turn needs translation; do not use visible fallback text emptiness as the scheduling gate.
+
+### How to avoid
+When preserving old UI state during async refreshes, audit every downstream predicate that previously treated empty state as the only signal for pending work.
+
+---

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -280,7 +280,6 @@ public struct LiveCaptionStore: Equatable {
         merged.targetLocale = turn.targetLocale
         merged.isFinal = turn.isFinal
         merged.captionHealth = turn.captionHealth
-        merged.translatedText = nil
         merged.translationHealth = .pending
         merged.createdAt = turn.createdAt
         return merged

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -742,8 +742,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     private func scheduleCaptionTextTranslationIfNeeded() {
         let candidates = liveCaptionStore.turns.filter { turn in
             guard turn.isFinal,
-                  turn.translationHealth == .pending,
-                  (turn.translatedText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+                  turn.translationHealth == .pending
             else {
                 return false
             }

--- a/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
@@ -108,7 +108,7 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(store.turns.map(\.originalText), ["我们先看一下", "我有一个问题"])
     }
 
-    func testMergingSameSpeakerClearsStaleTranslation() {
+    func testMergingSameSpeakerPreservesTranslationWhileRetranslating() {
         var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
         let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User 1")
         _ = store.append(TranscriptSegment(
@@ -129,9 +129,9 @@ final class LiveCaptionStoreTests: XCTestCase {
         ))
 
         XCTAssertEqual(merged.originalText, "first second")
-        XCTAssertNil(merged.translatedText)
+        XCTAssertEqual(merged.translatedText, "第一句")
         XCTAssertEqual(merged.translationHealth, .pending)
-        XCTAssertNil(store.turns.first?.translatedText)
+        XCTAssertEqual(store.turns.first?.translatedText, "第一句")
         XCTAssertEqual(store.turns.first?.translationHealth, .pending)
     }
 

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -390,7 +390,10 @@ final class MeetingAgentViewModelTests: XCTestCase {
         ])
 
         viewModel.drainRecordingFrames()
-        try await Task.sleep(nanoseconds: 80_000_000)
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.translatedText == "第一句"
+                && viewModel.liveCaptionTurns.first?.translationHealth == .live
+        }
 
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句")
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
@@ -418,7 +421,10 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句")
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .pending)
 
-        try await Task.sleep(nanoseconds: 80_000_000)
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.translatedText == "第一句 第二句"
+                && viewModel.liveCaptionTurns.first?.translationHealth == .live
+        }
 
         XCTAssertEqual(provider.requests.map(\.segmentIDs), [["segment-1"], ["segment-2"]])
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句 第二句")
@@ -1501,6 +1507,23 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedMeeting?.id, second.record.id)
         viewModel.selectMeeting(first.record.id)
         XCTAssertEqual(viewModel.selectedMeeting?.id, first.record.id)
+    }
+
+    private func waitFor(
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: () -> Bool
+    ) async throws {
+        let interval: UInt64 = 10_000_000
+        let attempts = max(1, Int(timeoutNanoseconds / interval))
+        for _ in 0..<attempts {
+            if condition() {
+                return
+            }
+            try await Task.sleep(nanoseconds: interval)
+        }
+        XCTAssertTrue(condition(), "Timed out waiting for condition", file: file, line: line)
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -346,6 +346,85 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(provider.requests.count, 1)
     }
 
+    func testExpandingTranslatedCaptionKeepsVisibleTranslationUntilFullTurnTranslationCompletes() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "Alex")
+        let provider = ViewModelFakeTextTranslationProvider(
+            translations: [
+                "segment-1": "第一句",
+                "segment-2": "第一句 第二句"
+            ],
+            delayNanoseconds: 50_000_000
+        )
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "en-US",
+                targetLocaleIdentifier: "zh-CN",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil,
+                transcriptionExecutionMode: .hosted,
+                translationExecutionMode: .hosted,
+                hostedTranscriptionProviderID: "deepgram-transcribe",
+                hostedTranslationProviderID: "openrouter-translation",
+                openRouterAPIKey: "settings-openrouter-key",
+                deepgramAPIKey: "settings-deepgram-key"
+            ),
+            captionTranslationProviderFactory: { _ in provider },
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        let record = try XCTUnwrap(viewModel.meetings.first)
+        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
+        try transcriptWriter.replace(with: [
+            TranscriptSegment(
+                id: "segment-1",
+                speaker: speaker,
+                text: "first",
+                language: "en-US",
+                isFinal: true
+            )
+        ])
+
+        viewModel.drainRecordingFrames()
+        try await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句")
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
+
+        try transcriptWriter.replace(with: [
+            TranscriptSegment(
+                id: "segment-1",
+                speaker: speaker,
+                text: "first",
+                language: "en-US",
+                isFinal: true
+            ),
+            TranscriptSegment(
+                id: "segment-2",
+                speaker: speaker,
+                text: "second",
+                language: "en-US",
+                isFinal: true
+            )
+        ])
+
+        viewModel.drainRecordingFrames()
+
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "first second")
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句")
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .pending)
+
+        try await Task.sleep(nanoseconds: 80_000_000)
+
+        XCTAssertEqual(provider.requests.map(\.segmentIDs), [["segment-1"], ["segment-2"]])
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句 第二句")
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
+    }
+
     func testRefreshMeetingProgressAnalyzesLiveCaptionsAndWritesProgressArtifact() async throws {
         let fixture = try ViewModelRecorderFixture()
         let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
@@ -1523,9 +1602,11 @@ private final class ViewModelFakeTextTranslationProvider: TextTranslationProvide
 
     var requests: [Request] = []
     private let translations: [String: String]
+    private let delayNanoseconds: UInt64
 
-    init(translations: [String: String]) {
+    init(translations: [String: String], delayNanoseconds: UInt64 = 0) {
         self.translations = translations
+        self.delayNanoseconds = delayNanoseconds
     }
 
     let descriptor = ProviderDescriptor(
@@ -1545,6 +1626,9 @@ private final class ViewModelFakeTextTranslationProvider: TextTranslationProvide
             targetLocale: options.targetLocale,
             segmentIDs: transcript.segments.map(\.id)
         ))
+        if delayNanoseconds > 0 {
+            try await Task.sleep(nanoseconds: delayNanoseconds)
+        }
         return TranslatedTranscript(
             sourceLocale: options.sourceLocale,
             targetLocale: options.targetLocale,

--- a/docs/superpowers/plans/2026-04-28-stable-caption-translation.md
+++ b/docs/superpowers/plans/2026-04-28-stable-caption-translation.md
@@ -1,0 +1,83 @@
+# Stable Caption Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent translated live caption text from disappearing while a same-speaker merged turn is being retranslated.
+
+**Architecture:** Keep the fix at the `LiveCaptionStore` merge boundary, where the blank state is created. Preserve existing translated text while setting translation health back to pending, and rely on the existing view-model translation key to request and attach the updated full-turn translation.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest.
+
+---
+
+### Task 1: Store-Level Regression
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Rename `testMergingSameSpeakerClearsStaleTranslation` to `testMergingSameSpeakerPreservesTranslationWhileRetranslating` and assert that after appending a second same-speaker final segment, `translatedText` remains the previous visible translation and `translationHealth` is `.pending`.
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter LiveCaptionStoreTests/testMergingSameSpeakerPreservesTranslationWhileRetranslating`
+
+Expected before implementation: fail because `mergedTurn` clears `translatedText`.
+
+- [ ] **Step 3: Implement minimal store change**
+
+In `LiveCaptionStore.mergedTurn`, remove the assignment that sets `merged.translatedText = nil`. Keep `merged.translationHealth = .pending`.
+
+- [ ] **Step 4: Run focused test**
+
+Run: `swift test --filter LiveCaptionStoreTests/testMergingSameSpeakerPreservesTranslationWhileRetranslating`
+
+Expected after implementation: pass.
+
+### Task 2: View-Model Regression
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Add an async provider gate**
+
+Extend `ViewModelFakeTextTranslationProvider` with an optional `delayNanoseconds` so the test can observe the in-flight pending state before translation finishes.
+
+- [ ] **Step 2: Write the regression test**
+
+Add `testExpandingTranslatedCaptionKeepsVisibleTranslationUntilFullTurnTranslationCompletes`. The test should translate `segment-1`, append `segment-2` from the same speaker, call `drainRecordingFrames()`, assert the merged turn still displays the first translation while `translationHealth` is pending, then wait for the delayed translation and assert the full-turn translation replaces it.
+
+- [ ] **Step 3: Run focused test**
+
+Run: `swift test --filter MeetingAgentViewModelTests/testExpandingTranslatedCaptionKeepsVisibleTranslationUntilFullTurnTranslationCompletes`
+
+Expected after Task 1: pass.
+
+### Task 3: Verification And Commit
+
+**Files:**
+- Modified source, test, spec, and plan files.
+
+- [ ] **Step 1: Run full verification**
+
+Run: `make test`
+
+Expected: pass.
+
+- [ ] **Step 2: Review local diff**
+
+Run: `git diff --stat` and `git diff`
+
+Expected: only issue #35 source, tests, spec, and plan files changed.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-04-28-stable-caption-translation-design.md docs/superpowers/plans/2026-04-28-stable-caption-translation.md Sources/MeetingAgentCore/LiveMeetingCockpit.swift Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+git commit -m "feat: keep caption translation visible while updating (#35)"
+```
+

--- a/docs/superpowers/specs/2026-04-28-stable-caption-translation-design.md
+++ b/docs/superpowers/specs/2026-04-28-stable-caption-translation-design.md
@@ -1,0 +1,38 @@
+# Stable Caption Translation Design
+
+## Context
+
+GitHub issue #35 reports that when one speaker keeps talking, already translated text disappears while a new translation is triggered, then reappears after the fuller translation completes. The current live caption store merges adjacent final transcript segments from the same speaker. During that merge it clears `translatedText` and marks translation as pending so the expanded source turn can be translated again.
+
+## Goal
+
+Keep the previously visible translation on screen while a same-speaker turn is being retranslated with newly appended source text. The expanded turn should still request a fresh full-turn translation, and the completed result should replace the preserved older translation.
+
+## Non-Goals
+
+- Do not add streaming OpenRouter translation.
+- Do not debounce translation until speaker changes.
+- Do not change provider APIs or transcript file formats.
+- Do not redesign the caption UI.
+
+## Selected Approach
+
+Preserve non-empty `translatedText` in `LiveCaptionStore.mergedTurn` when a same-speaker final segment is appended. Set `translationHealth` back to `.pending` so the view model still schedules a full-turn translation for the changed source text. `LiveCaptionDisplayState` already prioritizes non-empty translated text, so keeping the existing value prevents the visible blank state while retranslation is in flight.
+
+When `MeetingAgentViewModel.translateCaptionTurns` receives the new full-turn translation, it continues to call `attachTranslation`, replacing the preserved text and marking the turn live. The existing `captionTranslationKey` includes merged source segment IDs and original text, so expanded turns remain eligible for one new translation request per changed source turn.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+  - Update same-speaker merge behavior to preserve the last visible translation while marking translation pending.
+- `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+  - Update the stale-translation merge regression to expect preserved pending text.
+- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+  - Add a regression test proving an expanded same-speaker turn keeps the old translation during the new provider request and replaces it when the request completes.
+
+## Test Plan
+
+- Run `swift test --filter LiveCaptionStoreTests/testMergingSameSpeakerPreservesTranslationWhileRetranslating`.
+- Run `swift test --filter MeetingAgentViewModelTests/testExpandingTranslatedCaptionKeepsVisibleTranslationUntilFullTurnTranslationCompletes`.
+- Run `make test`.
+


### PR DESCRIPTION
## Summary

Fixes #35

- Keeps the previous translated caption visible while same-speaker text is being retranslated.
- Allows pending turns with preserved translated text to request a fresh full-turn translation using the existing translation key guard.
- Records the design, implementation plan, and reusable scheduler lesson.

## Changes

- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift` - preserve translated text when merging adjacent same-speaker final segments.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - schedule pending changed translations even when fallback translated text remains visible.
- `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift` - update store regression for preserved pending translation.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - add async regression for visible translation during full-turn retranslation.

## Test plan

- [x] Build/lint: `make test` passed
- [x] Unit tests: `swift test --filter LiveCaptionStoreTests/testMergingSameSpeakerPreservesTranslationWhileRetranslating` passed; `swift test --filter MeetingAgentViewModelTests/testExpandingTranslatedCaptionKeepsVisibleTranslationUntilFullTurnTranslationCompletes` passed
- [x] E2E/integration: skipped, no E2E convention for this core caption-store/view-model behavior
- [x] Code review: PASS
- [x] Manual verification: reviewed diff and issue workflow ledger
