### PR TITLE
feat: add agenda single feed

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -2,87 +2,26 @@ import AppKit
 import MeetingAgentCore
 import SwiftUI
 
+private enum MainWindowDestination: Equatable {
+    case agenda
+    case detail
+    case settings
+}
+
 struct MainWindowView: View {
     @ObservedObject var viewModel: MeetingAgentViewModel
-    @State private var showSettings = false
+    @State private var destination: MainWindowDestination = .agenda
 
     var body: some View {
-        NavigationSplitView {
-            VStack(spacing: 0) {
-                HStack {
-                    Text("Meeting Agent")
-                        .commandCenterEyebrow()
-                    Spacer()
-                }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 16)
-                .background(CommandCenterPalette.surface)
-                .overlay(alignment: .bottom) {
-                    Rectangle()
-                        .fill(CommandCenterPalette.border)
-                        .frame(height: 1)
-                }
-
-                List(selection: Binding(
-                    get: { showSettings ? nil : viewModel.selectedMeetingID },
-                    set: { id in
-                        showSettings = false
-                        viewModel.selectMeeting(id)
-                    }
-                )) {
-                    Section {
-                        ForEach(viewModel.meetings) { meeting in
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(meeting.name)
-                                    .font(CommandCenterTypography.title)
-                                    .foregroundStyle(CommandCenterPalette.text)
-                                Text(meeting.startedAt, style: .date)
-                                    .font(CommandCenterTypography.caption)
-                                    .foregroundStyle(CommandCenterPalette.secondaryText)
-                            }
-                            .padding(.vertical, 4)
-                            .tag(Optional(meeting.id))
-                        }
-                    } header: {
-                        Text("Meetings")
-                            .foregroundStyle(CommandCenterPalette.secondaryText)
-                    }
-                }
-                .scrollContentBackground(.hidden)
-                .background(CommandCenterPalette.surface)
-                .environment(\.colorScheme, .dark)
-                .foregroundStyle(CommandCenterPalette.text)
-
-                Spacer()
-
-                Divider()
-                    .overlay(CommandCenterPalette.border)
-
-                Button {
-                    showSettings = true
-                } label: {
-                    Label("Settings", systemImage: "gearshape")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .buttonStyle(.plain)
-                .foregroundStyle(showSettings ? CommandCenterPalette.primary : CommandCenterPalette.text)
-                .padding(12)
-                .background(showSettings ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
-            }
-            .background(CommandCenterPalette.surface)
-            .frame(minWidth: 260, idealWidth: 300)
-        } detail: {
-            if showSettings {
-                SettingsView(
-                    configuration: viewModel.speechConfiguration,
-                    profiles: BilingualPipelineFactory.builtInProfiles,
-                    localeIdentifiers: MeetingAgentViewModel.supportedLocaleIdentifiers,
-                    isRecording: viewModel.isRecording,
-                    status: viewModel.speechConfigurationStatus,
-                    primaryChainPreflightResult: viewModel.primaryChainPreflightResult,
-                    save: { viewModel.saveSpeechConfiguration($0) }
-                )
-            } else {
+        AgendaShellView(
+            destination: $destination,
+            selectedMeetingID: viewModel.selectedMeetingID,
+            meetings: viewModel.meetings,
+            selectMeeting: { id in
+                viewModel.selectMeeting(id)
+                destination = .detail
+            },
+            detail: {
                 MeetingDetailView(
                     meeting: viewModel.selectedMeeting,
                     speechConfiguration: viewModel.speechConfiguration,
@@ -146,8 +85,19 @@ struct MainWindowView: View {
                         }
                     }
                 )
+            },
+            settings: {
+                SettingsView(
+                    configuration: viewModel.speechConfiguration,
+                    profiles: BilingualPipelineFactory.builtInProfiles,
+                    localeIdentifiers: MeetingAgentViewModel.supportedLocaleIdentifiers,
+                    isRecording: viewModel.isRecording,
+                    status: viewModel.speechConfigurationStatus,
+                    primaryChainPreflightResult: viewModel.primaryChainPreflightResult,
+                    save: { viewModel.saveSpeechConfiguration($0) }
+                )
             }
-        }
+        )
         .background(CommandCenterPalette.window)
         .foregroundStyle(CommandCenterPalette.text)
         .toolbarBackground(CommandCenterPalette.surface, for: .windowToolbar)
@@ -213,6 +163,284 @@ struct MainWindowView: View {
         return sanitized.isEmpty ? "meeting" : sanitized
     }
 
+}
+
+private struct AgendaShellView<Detail: View, Settings: View>: View {
+    @Binding var destination: MainWindowDestination
+    let selectedMeetingID: UUID?
+    let meetings: [MeetingRecord]
+    let selectMeeting: (UUID) -> Void
+    private let detail: Detail
+    private let settings: Settings
+
+    init(
+        destination: Binding<MainWindowDestination>,
+        selectedMeetingID: UUID?,
+        meetings: [MeetingRecord],
+        selectMeeting: @escaping (UUID) -> Void,
+        @ViewBuilder detail: () -> Detail,
+        @ViewBuilder settings: () -> Settings
+    ) {
+        _destination = destination
+        self.selectedMeetingID = selectedMeetingID
+        self.meetings = meetings
+        self.selectMeeting = selectMeeting
+        self.detail = detail()
+        self.settings = settings()
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            navigationRail
+
+            Divider()
+                .overlay(CommandCenterPalette.border)
+
+            Group {
+                switch destination {
+                case .agenda:
+                    AgendaFeedView(
+                        meetings: meetings,
+                        selectedMeetingID: selectedMeetingID,
+                        selectMeeting: selectMeeting
+                    )
+                case .detail:
+                    detail
+                case .settings:
+                    settings
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(CommandCenterPalette.window)
+    }
+
+    private var navigationRail: some View {
+        VStack(spacing: 0) {
+            Text("Meeting Agent")
+                .commandCenterEyebrow()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 16)
+
+            Button {
+                destination = .agenda
+            } label: {
+                Label("Agenda", systemImage: "calendar")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(destination == .agenda ? CommandCenterPalette.primary : CommandCenterPalette.text)
+            .padding(12)
+            .background(destination == .agenda ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
+
+            Spacer()
+
+            Divider()
+                .overlay(CommandCenterPalette.border)
+
+            Button {
+                destination = .settings
+            } label: {
+                Label("Settings", systemImage: "gearshape")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(destination == .settings ? CommandCenterPalette.primary : CommandCenterPalette.text)
+            .padding(12)
+            .background(destination == .settings ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
+        }
+        .background(CommandCenterPalette.surface)
+        .frame(minWidth: 180, idealWidth: 210, maxWidth: 240)
+    }
+}
+
+private struct AgendaFeedView: View {
+    private let recentHistoryDays = 7
+    let meetings: [MeetingRecord]
+    let selectedMeetingID: UUID?
+    let selectMeeting: (UUID) -> Void
+
+    var body: some View {
+        CommandCenterScrollView(content: {
+            VStack(alignment: .leading, spacing: 22) {
+                header
+                todaySection
+                recentSection
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(28)
+        })
+        .background(CommandCenterPalette.window)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Agenda")
+                .commandCenterTitle()
+            Text("Meeting schedule and metadata")
+                .commandCenterCaption(CommandCenterPalette.secondaryText)
+        }
+    }
+
+    private var todayMeetings: [MeetingRecord] {
+        sortedMeetings.filter { Calendar.current.isDateInToday($0.startedAt) }
+    }
+
+    private var recentGroups: [(Date, [MeetingRecord])] {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: Date())
+        let recentHistoryStart = calendar.date(byAdding: .day, value: -recentHistoryDays, to: startOfToday) ?? startOfToday
+        let recentMeetings = sortedMeetings.filter { meeting in
+            let day = calendar.startOfDay(for: meeting.startedAt)
+            return day >= recentHistoryStart && day < startOfToday
+        }
+        let grouped = Dictionary(grouping: recentMeetings) { meeting in
+            calendar.startOfDay(for: meeting.startedAt)
+        }
+        return grouped.keys.sorted(by: >).map { day in
+            (day, grouped[day] ?? [])
+        }
+    }
+
+    private var sortedMeetings: [MeetingRecord] {
+        meetings.sorted { $0.startedAt > $1.startedAt }
+    }
+
+    private var todaySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Today")
+                .commandCenterEyebrow()
+            if todayMeetings.isEmpty {
+                CommandCenterPanel {
+                    Text("No meetings scheduled for this section.")
+                        .commandCenterCaption(CommandCenterPalette.secondaryText)
+                }
+            } else {
+                ForEach(todayMeetings) { meeting in
+                    AgendaMeetingCard(
+                        meeting: meeting,
+                        isSelected: selectedMeetingID == meeting.id,
+                        prominent: true,
+                        open: { selectMeeting(meeting.id) }
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recentSection: some View {
+        if !recentGroups.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Recent")
+                    .commandCenterEyebrow()
+                ForEach(recentGroups, id: \.0) { day, meetings in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(day.formatted(date: .abbreviated, time: .omitted))
+                            .font(CommandCenterTypography.sectionTitle)
+                            .foregroundStyle(CommandCenterPalette.text)
+                        ForEach(meetings) { meeting in
+                            AgendaMeetingCard(
+                                meeting: meeting,
+                                isSelected: selectedMeetingID == meeting.id,
+                                prominent: false,
+                                open: { selectMeeting(meeting.id) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct AgendaMeetingCard: View {
+    let meeting: MeetingRecord
+    let isSelected: Bool
+    let prominent: Bool
+    let open: () -> Void
+
+    var body: some View {
+        Button(action: open) {
+            CommandCenterPanel {
+                VStack(alignment: .leading, spacing: prominent ? 12 : 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text(meeting.name)
+                            .font(prominent ? CommandCenterTypography.title : CommandCenterTypography.sectionTitle)
+                            .foregroundStyle(CommandCenterPalette.text)
+                            .lineLimit(2)
+                        Spacer()
+                        Text(meeting.startedAt.formatted(date: .abbreviated, time: .shortened))
+                            .commandCenterMono()
+                    }
+
+                    HStack(spacing: 8) {
+                        CommandCenterChip(title: statusText(for: meeting), tint: statusTint(for: meeting), filled: true)
+                        CommandCenterChip(title: durationText(for: meeting))
+                        CommandCenterChip(title: meeting.speechLocaleIdentifier, tint: CommandCenterPalette.cyan)
+                        CommandCenterChip(title: artifactText(for: meeting), tint: artifactTint(for: meeting))
+                    }
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? CommandCenterPalette.primary : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func statusText(for meeting: MeetingRecord) -> String {
+        switch meeting.transcriptionStatus {
+        case .notStarted:
+            return "Not started"
+        case .transcribing:
+            return "Transcribing"
+        case .transcribed:
+            return "Transcribed"
+        case .failed:
+            return "Failed"
+        case .retryRequested:
+            return "Retry requested"
+        }
+    }
+
+    private func statusTint(for meeting: MeetingRecord) -> Color {
+        switch meeting.transcriptionStatus {
+        case .failed:
+            return CommandCenterPalette.danger
+        case .transcribed:
+            return CommandCenterPalette.primary
+        case .transcribing, .retryRequested:
+            return CommandCenterPalette.warning
+        case .notStarted:
+            return CommandCenterPalette.secondaryText
+        }
+    }
+
+    private func durationText(for meeting: MeetingRecord) -> String {
+        let interval = (meeting.endedAt ?? Date()).timeIntervalSince(meeting.startedAt)
+        let minutes = max(Int(interval) / 60, 0)
+        return minutes == 1 ? "1 min" : "\(minutes) min"
+    }
+
+    private func artifactText(for meeting: MeetingRecord) -> String {
+        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil {
+            return "Summary ready"
+        }
+        if meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+            return "Transcript ready"
+        }
+        return "Artifacts pending"
+    }
+
+    private func artifactTint(for meeting: MeetingRecord) -> Color {
+        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil || meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+            return CommandCenterPalette.primary
+        }
+        return CommandCenterPalette.secondaryText
+    }
 }
 
 private struct MeetingDetailView: View {

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -12,12 +12,15 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains(".defaultSize(width: defaultWindowSize.width, height: defaultWindowSize.height)"))
     }
 
-    func testMeetingsSidebarUsesWiderDefaultWidth() throws {
+    func testMainWindowUsesAgendaFeedInsteadOfNavigationSplitView() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        XCTAssertTrue(source.contains(".frame(minWidth: 260, idealWidth: 300)"))
+        XCTAssertFalse(source.contains("NavigationSplitView"))
+        XCTAssertTrue(source.contains("AgendaShellView("))
+        XCTAssertTrue(source.contains("AgendaFeedView("))
+        XCTAssertTrue(source.contains("AgendaMeetingCard("))
     }
 
     func testRecordingAndRetryButtonsShareActionRow() throws {
@@ -57,7 +60,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        XCTAssertTrue(source.contains("@State private var showSettings = false"))
+        XCTAssertTrue(source.contains("@State private var destination: MainWindowDestination = .agenda"))
         XCTAssertTrue(source.contains("SettingsView("))
         XCTAssertFalse(source.contains("TextField("))
         XCTAssertFalse(source.contains("\"Whisper Binary Path\""))
@@ -65,30 +68,39 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("\"STT Locale\""))
     }
 
-    func testMeetingRowsUseListSelectionTags() throws {
+    func testAgendaFeedShowsTodayAndRecentHistoryWithoutStaticYesterdaySection() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        XCTAssertTrue(source.contains("List(selection: Binding("))
-        XCTAssertTrue(source.contains(".tag(Optional(meeting.id))"))
-        XCTAssertFalse(source.contains(".onTapGesture {\n                            viewModel.selectMeeting(meeting.id)"))
+        XCTAssertTrue(source.contains("Text(\"Today\")"))
+        XCTAssertTrue(source.contains("Text(\"Recent\")"))
+        XCTAssertTrue(source.contains("recentHistoryDays = 7"))
+        XCTAssertTrue(source.contains("recentHistoryStart"))
+        XCTAssertFalse(source.contains("Text(\"Yesterday\")"))
     }
 
-    func testSettingsEntryIsFixedAtBottomOfSidebar() throws {
+    func testAgendaCardsExposeMeetingMetadata() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        guard let spacerRange = source.range(of: "Spacer()") else {
-            return XCTFail("Sidebar spacer is missing")
-        }
-        guard let settingsRange = source.range(of: "Button {") else {
-            return XCTFail("Settings bottom button is missing")
-        }
+        XCTAssertTrue(source.contains("statusText(for: meeting)"))
+        XCTAssertTrue(source.contains("durationText(for: meeting)"))
+        XCTAssertTrue(source.contains("artifactText(for: meeting)"))
+        XCTAssertTrue(source.contains("meeting.speechLocaleIdentifier"))
+        XCTAssertTrue(source.contains("meeting.startedAt.formatted(date: .abbreviated, time: .shortened)"))
+    }
 
-        XCTAssertLessThan(spacerRange.lowerBound, settingsRange.lowerBound)
-        XCTAssertTrue(source.contains("showSettings = true"))
+    func testSettingsEntryRemainsFixedInAgendaShell() throws {
+        let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+        let source = try String(contentsOf: sourceURL)
+
+        XCTAssertTrue(source.contains("AgendaShellView("))
+        XCTAssertTrue(source.contains("Label(\"Agenda\", systemImage: \"calendar\")"))
+        XCTAssertTrue(source.contains("Label(\"Settings\", systemImage: \"gearshape\")"))
+        XCTAssertTrue(source.contains("destination = .settings"))
     }
 
     func testSidebarTitleUsesCommandCenterStylingInsteadOfSystemNavigationTitle() throws {
@@ -118,8 +130,8 @@ final class MainWindowViewLayoutTests: XCTestCase {
         let source = try String(contentsOf: sourceURL)
 
         XCTAssertFalse(source.contains("Section(\"Meetings\")"))
-        XCTAssertTrue(source.contains("Section {"))
-        XCTAssertTrue(source.contains("Text(\"Meetings\")"))
+        XCTAssertTrue(source.contains("AgendaMeetingCard("))
+        XCTAssertTrue(source.contains("Text(\"Today\")"))
         XCTAssertTrue(source.contains(".foregroundStyle(CommandCenterPalette.secondaryText)"))
     }
 

--- a/docs/superpowers/plans/2026-04-28-agenda-single-feed.md
+++ b/docs/superpowers/plans/2026-04-28-agenda-single-feed.md
@@ -1,0 +1,535 @@
+# Agenda Single Feed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the split meeting list/detail agenda with a single feed that shows today's meetings and recent date-grouped history with visible metadata.
+
+**Architecture:** Keep `MeetingAgentViewModel` unchanged. Replace the `NavigationSplitView` shell in `MainWindowView` with a command-center shell that routes between agenda, meeting detail, and settings. Add focused SwiftUI views in `MainWindowView.swift` for the agenda feed, date grouping, and meeting cards.
+
+**Tech Stack:** Swift 5.9, SwiftUI, macOS 14.2, XCTest source-layout tests, existing command-center styling helpers.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentApp/MainWindowView.swift`: remove `NavigationSplitView`, add `MainWindowDestination`, `AgendaShellView`, `AgendaFeedView`, `AgendaMeetingCard`, and date grouping helpers.
+- Modify `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`: replace split-view/sidebar assertions with agenda-feed assertions while preserving existing detail/control checks.
+
+### Task 1: Source-Layout Regression Tests
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Replace sidebar split-view tests with agenda tests**
+
+Update the tests that currently assert the split sidebar:
+
+```swift
+func testMainWindowUsesAgendaFeedInsteadOfNavigationSplitView() throws {
+    let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+    let source = try String(contentsOf: sourceURL)
+
+    XCTAssertFalse(source.contains("NavigationSplitView"))
+    XCTAssertTrue(source.contains("AgendaShellView("))
+    XCTAssertTrue(source.contains("AgendaFeedView("))
+    XCTAssertTrue(source.contains("AgendaMeetingCard("))
+}
+
+func testAgendaFeedShowsTodayAndRecentHistoryWithoutStaticYesterdaySection() throws {
+    let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+    let source = try String(contentsOf: sourceURL)
+
+    XCTAssertTrue(source.contains("Text(\"Today\")"))
+    XCTAssertTrue(source.contains("Text(\"Recent\")"))
+    XCTAssertTrue(source.contains("recentHistoryDays = 7"))
+    XCTAssertTrue(source.contains("recentHistoryStart"))
+    XCTAssertFalse(source.contains("Text(\"Yesterday\")"))
+}
+
+func testAgendaCardsExposeMeetingMetadata() throws {
+    let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+    let source = try String(contentsOf: sourceURL)
+
+    XCTAssertTrue(source.contains("statusText(for: meeting)"))
+    XCTAssertTrue(source.contains("durationText(for: meeting)"))
+    XCTAssertTrue(source.contains("artifactText(for: meeting)"))
+    XCTAssertTrue(source.contains("meeting.speechLocaleIdentifier"))
+    XCTAssertTrue(source.contains("meeting.startedAt.formatted(date: .abbreviated, time: .shortened)"))
+}
+
+func testSettingsEntryRemainsFixedInAgendaShell() throws {
+    let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+    let source = try String(contentsOf: sourceURL)
+
+    XCTAssertTrue(source.contains("AgendaShellView("))
+    XCTAssertTrue(source.contains("Label(\"Agenda\", systemImage: \"calendar\")"))
+    XCTAssertTrue(source.contains("Label(\"Settings\", systemImage: \"gearshape\")"))
+    XCTAssertTrue(source.contains("destination = .settings"))
+}
+```
+
+- [ ] **Step 2: Run focused layout tests and verify failure**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests
+```
+
+Expected: FAIL because `MainWindowView` still contains `NavigationSplitView` and no agenda feed views.
+
+### Task 2: Agenda Shell and Routing
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Add destination state**
+
+Replace `@State private var showSettings = false` with:
+
+```swift
+@State private var destination: MainWindowDestination = .agenda
+```
+
+Add near the top-level view declarations:
+
+```swift
+private enum MainWindowDestination: Equatable {
+    case agenda
+    case detail
+    case settings
+}
+```
+
+- [ ] **Step 2: Replace `NavigationSplitView` with `AgendaShellView`**
+
+In `MainWindowView.body`, render:
+
+```swift
+AgendaShellView(
+    destination: $destination,
+    selectedMeetingID: viewModel.selectedMeetingID,
+    meetings: viewModel.meetings,
+    selectMeeting: { id in
+        viewModel.selectMeeting(id)
+        destination = .detail
+    },
+    detail: {
+        MeetingDetailView(
+            meeting: viewModel.selectedMeeting,
+            speechConfiguration: viewModel.speechConfiguration,
+            primaryChainPreflightResult: viewModel.primaryChainPreflightResult,
+            statusText: viewModel.statusText,
+            isRecording: viewModel.isRecording,
+            liveCaptionTurns: viewModel.liveCaptionTurns,
+            stopRecording: {
+                Task {
+                    do {
+                        try await viewModel.stopRecordingAndGenerateSummary()
+                    } catch {
+                        viewModel.setRecordingStartError(error)
+                    }
+                }
+            },
+            copySummary: { meeting in copySummary(for: meeting) },
+            exportTranscript: { meeting in
+                export("transcript.txt", for: meeting) { destination in
+                    try viewModel.exportTranscript(for: meeting.id, to: destination)
+                }
+            },
+            exportMeetingData: { meeting in
+                export("meeting.json", for: meeting) { destination in
+                    try viewModel.exportMeetingData(for: meeting.id, to: destination)
+                }
+            },
+            exportSRT: { meeting in
+                export("captions.srt", for: meeting) { destination in
+                    try viewModel.exportSubtitles(for: meeting.id, format: .srt, to: destination)
+                }
+            },
+            exportVTT: { meeting in
+                export("captions.vtt", for: meeting) { destination in
+                    try viewModel.exportSubtitles(for: meeting.id, format: .vtt, to: destination)
+                }
+            },
+            retryTranscription: { meeting in
+                Task { await viewModel.retryTranscription(for: meeting.id) }
+            },
+            updateSpeakerLabel: { meeting, speakerID, label in
+                Task {
+                    do {
+                        try await viewModel.updateSpeakerLabel(for: meeting.id, speakerID: speakerID, label: label)
+                    } catch {
+                        NSSound.beep()
+                    }
+                }
+            },
+            updateTranscriptSegmentText: { meeting, segmentID, text in
+                Task {
+                    do {
+                        try await viewModel.updateTranscriptSegmentText(for: meeting.id, segmentID: segmentID, text: text)
+                    } catch {
+                        NSSound.beep()
+                    }
+                }
+            }
+        )
+    },
+    settings: {
+        SettingsView(
+            configuration: viewModel.speechConfiguration,
+            profiles: BilingualPipelineFactory.builtInProfiles,
+            localeIdentifiers: MeetingAgentViewModel.supportedLocaleIdentifiers,
+            isRecording: viewModel.isRecording,
+            status: viewModel.speechConfigurationStatus,
+            primaryChainPreflightResult: viewModel.primaryChainPreflightResult,
+            save: { viewModel.saveSpeechConfiguration($0) }
+        )
+    }
+)
+```
+
+- [ ] **Step 3: Run focused tests and verify shell assertions still fail until shell types exist**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testMainWindowUsesAgendaFeedInsteadOfNavigationSplitView
+```
+
+Expected: FAIL until `AgendaShellView`, `AgendaFeedView`, and `AgendaMeetingCard` are added.
+
+### Task 3: Agenda Feed Views
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Add `AgendaShellView`**
+
+Add a private generic shell below `MainWindowView`:
+
+```swift
+private struct AgendaShellView<Detail: View, Settings: View>: View {
+    @Binding var destination: MainWindowDestination
+    let selectedMeetingID: UUID?
+    let meetings: [MeetingRecord]
+    let selectMeeting: (UUID) -> Void
+    @ViewBuilder let detail: () -> Detail
+    @ViewBuilder let settings: () -> Settings
+
+    var body: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 0) {
+                Text("Meeting Agent")
+                    .commandCenterEyebrow()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 16)
+
+                Button {
+                    destination = .agenda
+                } label: {
+                    Label("Agenda", systemImage: "calendar")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(destination == .agenda ? CommandCenterPalette.primary : CommandCenterPalette.text)
+                .padding(12)
+                .background(destination == .agenda ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
+
+                Spacer()
+
+                Divider()
+                    .overlay(CommandCenterPalette.border)
+
+                Button {
+                    destination = .settings
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(destination == .settings ? CommandCenterPalette.primary : CommandCenterPalette.text)
+                .padding(12)
+                .background(destination == .settings ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
+            }
+            .background(CommandCenterPalette.surface)
+            .frame(minWidth: 180, idealWidth: 210, maxWidth: 240)
+
+            Divider()
+                .overlay(CommandCenterPalette.border)
+
+            Group {
+                switch destination {
+                case .agenda:
+                    AgendaFeedView(
+                        meetings: meetings,
+                        selectedMeetingID: selectedMeetingID,
+                        selectMeeting: selectMeeting
+                    )
+                case .detail:
+                    detail()
+                case .settings:
+                    settings()
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .background(CommandCenterPalette.window)
+    }
+}
+```
+
+- [ ] **Step 2: Add `AgendaFeedView` with Today and Recent grouping**
+
+Add:
+
+```swift
+private struct AgendaFeedView: View {
+    private let recentHistoryDays = 7
+    let meetings: [MeetingRecord]
+    let selectedMeetingID: UUID?
+    let selectMeeting: (UUID) -> Void
+
+    var body: some View {
+        CommandCenterScrollView(content: {
+            VStack(alignment: .leading, spacing: 22) {
+                header
+                section(title: "Today", meetings: todayMeetings, prominent: true)
+                recentSection
+            }
+            .padding(28)
+        })
+        .background(CommandCenterPalette.window)
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Agenda").commandCenterTitle()
+            Text("Meeting schedule and metadata")
+                .commandCenterCaption(CommandCenterPalette.secondaryText)
+        }
+    }
+
+    private var todayMeetings: [MeetingRecord] {
+        sortedMeetings.filter { Calendar.current.isDateInToday($0.startedAt) }
+    }
+
+    private var recentGroups: [(Date, [MeetingRecord])] {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: Date())
+        let recentHistoryStart = calendar.date(byAdding: .day, value: -recentHistoryDays, to: startOfToday) ?? startOfToday
+        let recentMeetings = sortedMeetings.filter { meeting in
+            let day = calendar.startOfDay(for: meeting.startedAt)
+            return day >= recentHistoryStart && day < startOfToday
+        }
+        let grouped = Dictionary(grouping: recentMeetings) { meeting in
+            calendar.startOfDay(for: meeting.startedAt)
+        }
+        return grouped.keys.sorted(by: >).map { day in
+            (day, grouped[day] ?? [])
+        }
+    }
+
+    private var sortedMeetings: [MeetingRecord] {
+        meetings.sorted { $0.startedAt > $1.startedAt }
+    }
+
+    @ViewBuilder
+    private var recentSection: some View {
+        if !recentGroups.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Recent").commandCenterEyebrow()
+                ForEach(recentGroups, id: \.0) { day, meetings in
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(day.formatted(date: .abbreviated, time: .omitted))
+                            .font(CommandCenterTypography.sectionTitle)
+                            .foregroundStyle(CommandCenterPalette.text)
+                        ForEach(meetings) { meeting in
+                            AgendaMeetingCard(
+                                meeting: meeting,
+                                isSelected: selectedMeetingID == meeting.id,
+                                prominent: false,
+                                open: { selectMeeting(meeting.id) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func section(title: String, meetings: [MeetingRecord], prominent: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title).commandCenterEyebrow()
+            if meetings.isEmpty {
+                CommandCenterPanel {
+                    Text("No meetings scheduled for this section.")
+                        .commandCenterCaption(CommandCenterPalette.secondaryText)
+                }
+            } else {
+                ForEach(meetings) { meeting in
+                    AgendaMeetingCard(
+                        meeting: meeting,
+                        isSelected: selectedMeetingID == meeting.id,
+                        prominent: prominent,
+                        open: { selectMeeting(meeting.id) }
+                    )
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add `AgendaMeetingCard` metadata display**
+
+Add:
+
+```swift
+private struct AgendaMeetingCard: View {
+    let meeting: MeetingRecord
+    let isSelected: Bool
+    let prominent: Bool
+    let open: () -> Void
+
+    var body: some View {
+        Button(action: open) {
+            CommandCenterPanel {
+                VStack(alignment: .leading, spacing: prominent ? 12 : 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text(meeting.name)
+                            .font(prominent ? CommandCenterTypography.title : CommandCenterTypography.sectionTitle)
+                            .foregroundStyle(CommandCenterPalette.text)
+                            .lineLimit(2)
+                        Spacer()
+                        Text(meeting.startedAt.formatted(date: .abbreviated, time: .shortened))
+                            .commandCenterMono()
+                    }
+
+                    HStack(spacing: 8) {
+                        CommandCenterChip(title: statusText(for: meeting), tint: statusTint(for: meeting), filled: true)
+                        CommandCenterChip(title: durationText(for: meeting))
+                        CommandCenterChip(title: meeting.speechLocaleIdentifier, tint: CommandCenterPalette.cyan)
+                        CommandCenterChip(title: artifactText(for: meeting), tint: artifactTint(for: meeting))
+                    }
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? CommandCenterPalette.primary : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func statusText(for meeting: MeetingRecord) -> String {
+        switch meeting.transcriptionStatus {
+        case .notStarted:
+            return "Not started"
+        case .transcribing:
+            return "Transcribing"
+        case .transcribed:
+            return "Transcribed"
+        case .failed:
+            return "Failed"
+        case .retryRequested:
+            return "Retry requested"
+        }
+    }
+
+    private func statusTint(for meeting: MeetingRecord) -> Color {
+        switch meeting.transcriptionStatus {
+        case .failed:
+            return CommandCenterPalette.danger
+        case .transcribed:
+            return CommandCenterPalette.primary
+        case .transcribing, .retryRequested:
+            return CommandCenterPalette.warning
+        case .notStarted:
+            return CommandCenterPalette.secondaryText
+        }
+    }
+
+    private func durationText(for meeting: MeetingRecord) -> String {
+        let interval = (meeting.endedAt ?? Date()).timeIntervalSince(meeting.startedAt)
+        let minutes = max(Int(interval) / 60, 0)
+        return minutes == 1 ? "1 min" : "\(minutes) min"
+    }
+
+    private func artifactText(for meeting: MeetingRecord) -> String {
+        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil {
+            return "Summary ready"
+        }
+        if meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+            return "Transcript ready"
+        }
+        return "Artifacts pending"
+    }
+
+    private func artifactTint(for meeting: MeetingRecord) -> Color {
+        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil || meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+            return CommandCenterPalette.primary
+        }
+        return CommandCenterPalette.secondaryText
+    }
+}
+```
+
+- [ ] **Step 4: Run focused tests and fix compile/source issues**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests
+```
+
+Expected: PASS.
+
+### Task 4: Full Verification and Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Build the app**
+
+Run:
+
+```bash
+swift build --product MeetingAgentApp
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run required test entrypoint**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS with coverage enforcement.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: add agenda single feed (#39)"
+```
+
+Expected: commit created.
+
+## Self-Review
+
+- Spec coverage: covers single feed, Today prominence, recent seven-day date grouping, no static Yesterday, metadata cards, settings, and existing detail workflow preservation.
+- Placeholder scan: no `TBD`, `TODO`, or unresolved implementation placeholders.
+- Type consistency: plan uses existing `MeetingRecord`, `MeetingAgentViewModel`, `CommandCenterPanel`, `CommandCenterScrollView`, `CommandCenterChip`, and command-center typography/palette helpers.

--- a/docs/superpowers/specs/2026-04-28-agenda-single-feed-design.md
+++ b/docs/superpowers/specs/2026-04-28-agenda-single-feed-design.md
@@ -1,0 +1,82 @@
+# Agenda Single Feed Design
+
+## Issue
+
+GitHub issue #39 asks to optimize the agenda page UI. The current app uses a left meeting list and a right detail area, which makes meeting meta information hard to scan directly from the agenda.
+
+## Goal
+
+Replace the meeting list/detail agenda with a single feed that makes meeting schedule and metadata visible at a glance. Today's meetings should be the primary section. Recent historical meetings should remain available without dominating the first screen.
+
+## Selected Direction
+
+Use a single agenda feed. This was selected over a today-first dashboard and date-navigation layout because it removes the split view most directly and lets each meeting card carry its own metadata.
+
+The feed structure is:
+
+- `Today`: always first, showing today's meetings with fuller cards.
+- `Recent`: meetings from the previous seven calendar days, grouped by non-empty date sections.
+- Older meetings: not expanded in the agenda page for this issue.
+
+The UI should not render an empty `Yesterday` section. A dedicated `Yesterday` label is too brittle for low-frequency meeting histories and cross-time-zone use. Date sections should appear only when at least one meeting exists for that day.
+
+## Requirements
+
+- Remove the meeting list/detail split from `MainWindowView`.
+- Keep Settings reachable as a fixed command in the same left-side app shell.
+- Show the agenda as the default main content when settings are not open.
+- Render each meeting as a self-contained card with:
+  - meeting name
+  - start date and time
+  - duration or live elapsed time
+  - transcription status
+  - locale
+  - whether summary/export artifacts are available
+- Selecting a meeting opens the existing detail experience for transcript, summary, export, and correction workflows.
+- Today cards should be visually richer than recent-history cards, but both must expose core metadata.
+- Recent history should include only meetings from the previous seven days and should be grouped by actual meeting date.
+- Preserve existing recording, retry transcription, export, speaker edit, transcript edit, and settings behavior.
+
+## Non-Requirements
+
+- No new persisted fields.
+- No search, filtering, or calendar picker in this issue.
+- No expansion of meetings older than seven days.
+- No redesign of `MeetingCommandCenterView`, `TranscriptPaneView`, or `InsightPaneView` beyond what is necessary to route from the agenda.
+- No changes to meeting storage or transcription behavior.
+
+## Approach
+
+`MainWindowView` will keep the current command-center theme and settings destination but replace the `NavigationSplitView` meeting list with a custom shell. The shell has a narrow left rail for app identity and Settings, and a main content area that shows either `AgendaFeedView`, `MeetingDetailView`, or `SettingsView`.
+
+`AgendaFeedView` receives `viewModel.meetings`, the selected meeting ID, and selection callbacks. It computes `todayMeetings` and `recentMeetingsByDate` using calendar-day comparisons. It renders Today as prominent cards and Recent as compact cards grouped by formatted date headers.
+
+`AgendaMeetingCard` is a focused presentational view for one meeting card. It computes status text, duration text, summary availability, transcript availability, and locale chips from `MeetingRecord` only.
+
+## Data Flow
+
+`MeetingAgentViewModel` remains the source of truth. The agenda reads `meetings` and calls `viewModel.selectMeeting(_:)` when a card is opened. The existing detail view reads `viewModel.selectedMeeting` exactly as it does today.
+
+Settings remains controlled by `showSettings`. Opening Settings clears the agenda/detail destination visually but does not mutate the selected meeting. Selecting a meeting sets `showSettings = false`.
+
+## Testing
+
+Add source-layout regression coverage because existing UI tests in this repository verify SwiftUI structure by inspecting source text.
+
+Tests should assert:
+
+- `NavigationSplitView` is no longer used by `MainWindowView`.
+- `AgendaFeedView` and `AgendaMeetingCard` exist.
+- Today and Recent sections are present.
+- The code filters recent history to seven days.
+- No static `Yesterday` section is rendered.
+- Settings remains fixed in the app shell.
+- Existing implemented detail controls remain present.
+
+Run `make test` before completion.
+
+## Risks
+
+- The main window may become too dense if every card tries to show full detail. The design avoids this by using fuller Today cards and compact Recent cards.
+- Removing `NavigationSplitView` can accidentally hide settings or detail workflows. The implementation should keep explicit view states for agenda, detail, and settings.
+- Date grouping can be off by calendar boundary. Use `Calendar.current` day comparisons instead of raw second intervals for section membership.


### PR DESCRIPTION
## Summary

Fixes #39

- Replaces the split meeting list/detail agenda with a single agenda feed shell.
- Adds Today and Recent sections, with Recent limited to the previous 7 calendar days and grouped only by dates that have meetings.
- Adds metadata-rich meeting cards for status, duration, locale, and transcript/summary availability.
- Preserves existing meeting detail, recording, retry, export, correction, and settings flows.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - adds agenda/detail/settings routing, agenda feed, and meeting cards.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - updates source-layout coverage for the new agenda shell and cards.
- `docs/superpowers/specs/2026-04-28-agenda-single-feed-design.md` - records the approved design.
- `docs/superpowers/plans/2026-04-28-agenda-single-feed.md` - records the implementation plan.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests` passed; `make test` passed, 377 tests, coverage gate passed
- [x] E2E/integration: skipped, no E2E convention for this SwiftUI source-layout change
- [x] Code review: PASS, manual Swift review against AGENTS.md
- [x] Manual verification: not run; source-layout tests cover the visible shell/card structure