### PR TITLE
feat: add installable app packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .build/
 .swiftpm/
 DerivedData/
+dist/
 .DS_Store
 .record/
 .superpowers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,13 @@ Use these from the repository root:
 ```sh
 make test
 swift build --product MeetingAgentApp
+make package-app
 swift run MeetingAgentApp
 ```
 
 The app stores user meeting data under `~/Library/Application Support/MeetingAgent/Meetings/`.
+
+Use `make package-app` to create `dist/MeetingAgent.app` for local installation or prototype sharing. The generated app bundle is not Developer ID signed or Apple notarized, so recipients may need to right-click Open or approve it in System Settings the first time they launch it.
 
 Implemented STT providers are `local`, backed by macOS Speech, and `whisper`, backed by a local `whisper.cpp` CLI and model.
 The default STT provider is `whisper` for the app. Use the app settings to select `local` only when explicitly testing macOS Speech.

--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -205,3 +205,19 @@ Use the semantic translation key and in-flight state to decide whether a pending
 When preserving old UI state during async refreshes, audit every downstream predicate that previously treated empty state as the only signal for pending work.
 
 ---
+
+## [38] Exclude bundle templates from SwiftPM source scanning
+
+**Date**: 2026-04-28
+**Category**: build-config
+
+### What went wrong
+The first app packaging pass added `Sources/MeetingAgentApp/Resources/Info.plist` under an executable target without excluding it from SwiftPM, which produced an unhandled-file warning. The packaging command also generated `dist/MeetingAgent.app` before `dist/` was ignored.
+
+### Correct approach
+Keep bundle templates in the app source tree for packaging, but add `exclude: ["Resources"]` to the SwiftPM target and ignore generated package output directories.
+
+### How to avoid
+When adding non-source packaging assets under `Sources/`, update both `Package.swift` source scanning rules and `.gitignore` in the same change.
+
+---

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: test
+.PHONY: test package-app
 
 test:
 	scripts/check-unit-coverage.sh
+
+package-app:
+	scripts/package-app.sh

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
         ),
         .executableTarget(
             name: "MeetingAgentApp",
-            dependencies: ["MeetingAgentCore"]
+            dependencies: ["MeetingAgentCore"],
+            exclude: ["Resources"]
         ),
         .testTarget(
             name: "MeetingAgentCoreTests",

--- a/Sources/MeetingAgentApp/Resources/Info.plist
+++ b/Sources/MeetingAgentApp/Resources/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Meeting Agent</string>
+    <key>CFBundleExecutable</key>
+    <string>MeetingAgentApp</string>
+    <key>CFBundleIdentifier</key>
+    <string>ai.plovr.MeetingAgent</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Meeting Agent</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.2</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Meeting Agent needs microphone access to capture meeting audio for transcription and summaries.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Meeting Agent uses speech recognition to transcribe meeting audio when the local Apple Speech provider is selected.</string>
+    <key>NSUserNotificationUsageDescription</key>
+    <string>Meeting Agent uses notifications to alert you when a meeting app is detected.</string>
+</dict>
+</plist>

--- a/Tests/MeetingAgentCoreTests/ScaffoldTests.swift
+++ b/Tests/MeetingAgentCoreTests/ScaffoldTests.swift
@@ -6,13 +6,52 @@ final class ScaffoldTests: XCTestCase {
     }
 
     func testPackageManifestDoesNotExposeCoreAudioTapProbe() throws {
-        let manifestURL = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("Package.swift")
-        let manifest = try String(contentsOf: manifestURL)
+        let manifest = try readRepositoryFile("Package.swift")
 
         XCTAssertFalse(manifest.contains("CoreAudioTapProbe"))
+    }
+
+    func testPackageAppScriptBuildsAndAssemblesBundle() throws {
+        let script = try readRepositoryFile("scripts/package-app.sh")
+
+        XCTAssertTrue(script.contains("swift build -c release --product MeetingAgentApp"))
+        XCTAssertTrue(script.contains("dist/MeetingAgent.app"))
+        XCTAssertTrue(script.contains("Contents/MacOS"))
+        XCTAssertTrue(script.contains("Contents/Resources"))
+        XCTAssertTrue(script.contains("Sources/MeetingAgentApp/Resources/Info.plist"))
+        XCTAssertTrue(script.contains("PkgInfo"))
+    }
+
+    func testAppInfoPlistContainsBundleMetadataAndPermissions() throws {
+        let plist = try readRepositoryFile("Sources/MeetingAgentApp/Resources/Info.plist")
+
+        XCTAssertTrue(plist.contains("<key>CFBundleExecutable</key>"))
+        XCTAssertTrue(plist.contains("<string>MeetingAgentApp</string>"))
+        XCTAssertTrue(plist.contains("<key>CFBundleIdentifier</key>"))
+        XCTAssertTrue(plist.contains("<string>ai.plovr.MeetingAgent</string>"))
+        XCTAssertTrue(plist.contains("<key>CFBundlePackageType</key>"))
+        XCTAssertTrue(plist.contains("<string>APPL</string>"))
+        XCTAssertTrue(plist.contains("<key>LSMinimumSystemVersion</key>"))
+        XCTAssertTrue(plist.contains("<string>14.2</string>"))
+        XCTAssertTrue(plist.contains("<key>NSMicrophoneUsageDescription</key>"))
+        XCTAssertTrue(plist.contains("<key>NSSpeechRecognitionUsageDescription</key>"))
+        XCTAssertTrue(plist.contains("<key>NSUserNotificationUsageDescription</key>"))
+    }
+
+    func testMakefileExposesPackageAppCommand() throws {
+        let makefile = try readRepositoryFile("Makefile")
+
+        XCTAssertTrue(makefile.contains(".PHONY: test package-app"))
+        XCTAssertTrue(makefile.contains("package-app:"))
+        XCTAssertTrue(makefile.contains("scripts/package-app.sh"))
+    }
+
+    private func readRepositoryFile(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url)
     }
 }

--- a/docs/superpowers/plans/2026-04-28-installable-app-package.md
+++ b/docs/superpowers/plans/2026-04-28-installable-app-package.md
@@ -1,0 +1,290 @@
+# Installable App Package Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reproducible local packaging workflow that builds `dist/MeetingAgent.app` from the existing SwiftPM `MeetingAgentApp` product.
+
+**Architecture:** Keep SwiftPM as the build source of truth. Add bundle metadata as an app resource template, add a shell script that assembles a standard macOS `.app` layout from the release executable, and expose the script through `make package-app`. Use source-level tests to protect the package script, `Info.plist`, and supported command surface.
+
+**Tech Stack:** Swift Package Manager, Swift 5.9, XCTest, POSIX shell, macOS app bundle layout.
+
+---
+
+## File Structure
+
+- `Sources/MeetingAgentApp/Resources/Info.plist`: bundle metadata copied into `MeetingAgent.app/Contents/Info.plist`.
+- `scripts/package-app.sh`: build and bundle script.
+- `Makefile`: adds the stable `package-app` entrypoint.
+- `AGENTS.md`: documents the packaging command and unsigned distribution limitation.
+- `Tests/MeetingAgentCoreTests/ScaffoldTests.swift`: source-level regression tests for packaging files and metadata.
+
+### Task 1: Add Packaging Regression Tests
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/ScaffoldTests.swift`
+
+- [ ] **Step 1: Add helper methods and failing tests**
+
+Add these helpers and tests inside `ScaffoldTests`:
+
+```swift
+    func testPackageAppScriptBuildsAndAssemblesBundle() throws {
+        let script = try readRepositoryFile("scripts/package-app.sh")
+
+        XCTAssertTrue(script.contains("swift build -c release --product MeetingAgentApp"))
+        XCTAssertTrue(script.contains("dist/MeetingAgent.app"))
+        XCTAssertTrue(script.contains("Contents/MacOS"))
+        XCTAssertTrue(script.contains("Contents/Resources"))
+        XCTAssertTrue(script.contains("Sources/MeetingAgentApp/Resources/Info.plist"))
+        XCTAssertTrue(script.contains("PkgInfo"))
+    }
+
+    func testAppInfoPlistContainsBundleMetadataAndPermissions() throws {
+        let plist = try readRepositoryFile("Sources/MeetingAgentApp/Resources/Info.plist")
+
+        XCTAssertTrue(plist.contains("<key>CFBundleExecutable</key>"))
+        XCTAssertTrue(plist.contains("<string>MeetingAgentApp</string>"))
+        XCTAssertTrue(plist.contains("<key>CFBundleIdentifier</key>"))
+        XCTAssertTrue(plist.contains("<string>ai.plovr.MeetingAgent</string>"))
+        XCTAssertTrue(plist.contains("<key>CFBundlePackageType</key>"))
+        XCTAssertTrue(plist.contains("<string>APPL</string>"))
+        XCTAssertTrue(plist.contains("<key>LSMinimumSystemVersion</key>"))
+        XCTAssertTrue(plist.contains("<string>14.2</string>"))
+        XCTAssertTrue(plist.contains("<key>NSMicrophoneUsageDescription</key>"))
+        XCTAssertTrue(plist.contains("<key>NSSpeechRecognitionUsageDescription</key>"))
+        XCTAssertTrue(plist.contains("<key>NSUserNotificationUsageDescription</key>"))
+    }
+
+    func testMakefileExposesPackageAppCommand() throws {
+        let makefile = try readRepositoryFile("Makefile")
+
+        XCTAssertTrue(makefile.contains(".PHONY: test package-app"))
+        XCTAssertTrue(makefile.contains("package-app:"))
+        XCTAssertTrue(makefile.contains("scripts/package-app.sh"))
+    }
+
+    private func readRepositoryFile(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url)
+    }
+```
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run: `swift test --filter ScaffoldTests`
+
+Expected: FAIL because `scripts/package-app.sh` and `Sources/MeetingAgentApp/Resources/Info.plist` do not exist, and `Makefile` does not expose `package-app`.
+
+- [ ] **Step 3: Commit the failing tests only if project convention requires red commits**
+
+Do not commit yet for this repository. Keep the failing tests in the working tree and implement the minimal files in Task 2.
+
+### Task 2: Add Bundle Metadata
+
+**Files:**
+- Create: `Sources/MeetingAgentApp/Resources/Info.plist`
+
+- [ ] **Step 1: Create the resources directory**
+
+Run: `mkdir -p Sources/MeetingAgentApp/Resources`
+
+- [ ] **Step 2: Add `Info.plist`**
+
+Create `Sources/MeetingAgentApp/Resources/Info.plist` with:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleDisplayName</key>
+    <string>Meeting Agent</string>
+    <key>CFBundleExecutable</key>
+    <string>MeetingAgentApp</string>
+    <key>CFBundleIdentifier</key>
+    <string>ai.plovr.MeetingAgent</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Meeting Agent</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.2</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Meeting Agent needs microphone access to capture meeting audio for transcription and summaries.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Meeting Agent uses speech recognition to transcribe meeting audio when the local Apple Speech provider is selected.</string>
+    <key>NSUserNotificationUsageDescription</key>
+    <string>Meeting Agent uses notifications to alert you when a meeting app is detected.</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 3: Run the focused plist test**
+
+Run: `swift test --filter ScaffoldTests/testAppInfoPlistContainsBundleMetadataAndPermissions`
+
+Expected: PASS.
+
+### Task 3: Add Packaging Script and Make Target
+
+**Files:**
+- Create: `scripts/package-app.sh`
+- Modify: `Makefile`
+
+- [ ] **Step 1: Create `scripts/package-app.sh`**
+
+Create `scripts/package-app.sh` with:
+
+```sh
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+APP_NAME="MeetingAgent"
+EXECUTABLE_NAME="MeetingAgentApp"
+APP_BUNDLE="$REPO_ROOT/dist/$APP_NAME.app"
+CONTENTS_DIR="$APP_BUNDLE/Contents"
+MACOS_DIR="$CONTENTS_DIR/MacOS"
+RESOURCES_DIR="$CONTENTS_DIR/Resources"
+INFO_PLIST="$REPO_ROOT/Sources/MeetingAgentApp/Resources/Info.plist"
+RELEASE_EXECUTABLE="$REPO_ROOT/.build/release/$EXECUTABLE_NAME"
+
+if [ ! -f "$INFO_PLIST" ]; then
+    echo "Missing app Info.plist at $INFO_PLIST" >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+swift build -c release --product MeetingAgentApp
+
+rm -rf "$APP_BUNDLE"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+cp "$RELEASE_EXECUTABLE" "$MACOS_DIR/$EXECUTABLE_NAME"
+cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
+printf "APPL????" > "$CONTENTS_DIR/PkgInfo"
+
+if command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "$APP_BUNDLE"
+fi
+
+echo "Packaged $APP_BUNDLE"
+```
+
+- [ ] **Step 2: Make the script executable**
+
+Run: `chmod +x scripts/package-app.sh`
+
+- [ ] **Step 3: Update `Makefile`**
+
+Replace `Makefile` contents with:
+
+```make
+.PHONY: test package-app
+
+test:
+	scripts/check-unit-coverage.sh
+
+package-app:
+	scripts/package-app.sh
+```
+
+- [ ] **Step 4: Run the focused script and Makefile tests**
+
+Run: `swift test --filter ScaffoldTests/testPackageAppScriptBuildsAndAssemblesBundle`
+
+Expected: PASS.
+
+Run: `swift test --filter ScaffoldTests/testMakefileExposesPackageAppCommand`
+
+Expected: PASS.
+
+### Task 4: Document Packaging Workflow
+
+**Files:**
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Update common commands**
+
+Change the common commands block to include `make package-app`:
+
+```sh
+make test
+swift build --product MeetingAgentApp
+make package-app
+swift run MeetingAgentApp
+```
+
+- [ ] **Step 2: Add packaging note**
+
+Add this paragraph after the app data location paragraph:
+
+```markdown
+Use `make package-app` to create `dist/MeetingAgent.app` for local installation or prototype sharing. The generated app bundle is not Developer ID signed or Apple notarized, so recipients may need to right-click Open or approve it in System Settings the first time they launch it.
+```
+
+### Task 5: Verify Packaging End-to-End
+
+**Files:**
+- All files changed by Tasks 1-4
+
+- [ ] **Step 1: Run focused scaffold tests**
+
+Run: `swift test --filter ScaffoldTests`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full unit verification**
+
+Run: `make test`
+
+Expected: PASS with coverage threshold satisfied.
+
+- [ ] **Step 3: Build the app product**
+
+Run: `swift build --product MeetingAgentApp`
+
+Expected: PASS.
+
+- [ ] **Step 4: Build the installable app bundle**
+
+Run: `make package-app`
+
+Expected: PASS and output includes `Packaged /Users/allan/workspace/meeting/meeting-agent-issue-38/dist/MeetingAgent.app`.
+
+- [ ] **Step 5: Inspect generated bundle**
+
+Run: `find dist/MeetingAgent.app -maxdepth 3 -type f | sort`
+
+Expected output includes:
+
+```text
+dist/MeetingAgent.app/Contents/Info.plist
+dist/MeetingAgent.app/Contents/MacOS/MeetingAgentApp
+dist/MeetingAgent.app/Contents/PkgInfo
+```
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git add AGENTS.md Makefile Sources/MeetingAgentApp/Resources/Info.plist scripts/package-app.sh Tests/MeetingAgentCoreTests/ScaffoldTests.swift docs/superpowers/plans/2026-04-28-installable-app-package.md
+git commit -m "feat: add installable app packaging (#38)"
+```
+

--- a/docs/superpowers/specs/2026-04-28-installable-app-package-design.md
+++ b/docs/superpowers/specs/2026-04-28-installable-app-package-design.md
@@ -1,0 +1,96 @@
+# Installable App Package Design
+
+## Issue
+
+GitHub issue #38 asks for a complete app project adaptation so other people can install and use Meeting Agent. The current project is a Swift Package with a `MeetingAgentApp` executable target. That supports `swift run` and `swift build`, but it does not produce a standard macOS `.app` bundle that someone can drag into `/Applications`.
+
+## Scope
+
+This issue adds a reproducible local packaging path that produces `dist/MeetingAgent.app` from the existing SwiftPM app target.
+
+In scope:
+
+- Build `MeetingAgentApp` in release mode.
+- Assemble a standard macOS app bundle under `dist/MeetingAgent.app`.
+- Add app bundle metadata in an `Info.plist`.
+- Preserve required macOS permission usage strings for audio capture, speech recognition, and notifications.
+- Add a stable `make package-app` entrypoint.
+- Add regression tests for packaging script and bundle metadata structure.
+
+Out of scope:
+
+- Developer ID signing.
+- Apple notarization.
+- DMG or PKG installer generation.
+- CI release publishing.
+- Bundling external Whisper binaries or models.
+
+The generated app is locally installable and can be shared for prototype testing, but because it is not Developer ID signed or notarized, Gatekeeper may require users to right-click Open or approve the app in System Settings on first launch.
+
+## Options Considered
+
+1. Keep SwiftPM and add a packaging script.
+   - Pros: small change, matches the current package structure, produces a usable `.app` immediately, and keeps future signing/notarization as a separate layer.
+   - Cons: installer polish and notarized distribution remain follow-up work.
+
+2. Convert the project to an Xcode app project.
+   - Pros: closer to conventional macOS distribution and future signing workflows.
+   - Cons: adds generated project-file complexity and duplicates build configuration that SwiftPM already owns.
+
+3. Implement a SwiftPM command plugin for packaging.
+   - Pros: more SwiftPM-native command surface.
+   - Cons: higher implementation and maintenance cost without clear benefit for this repository today.
+
+Selected approach: option 1. The repository already treats SwiftPM as the source of truth, and issue #38 only needs an installable app artifact for others to use.
+
+## Design
+
+Add `Sources/MeetingAgentApp/Resources/Info.plist` as the bundle metadata template. It will declare:
+
+- `CFBundleName` and `CFBundleDisplayName` as `Meeting Agent`.
+- `CFBundleExecutable` as `MeetingAgentApp`.
+- A stable bundle identifier, `ai.plovr.MeetingAgent`.
+- `CFBundlePackageType` as `APPL`.
+- `LSMinimumSystemVersion` as `14.2`.
+- Version fields for the prototype bundle.
+- Permission usage descriptions for microphone access, speech recognition, and user notifications.
+
+Add `scripts/package-app.sh`. The script will:
+
+1. Resolve the repository root from its own location.
+2. Run `swift build -c release --product MeetingAgentApp`.
+3. Recreate `dist/MeetingAgent.app/Contents/MacOS` and `dist/MeetingAgent.app/Contents/Resources`.
+4. Copy the release executable to `Contents/MacOS/MeetingAgentApp`.
+5. Copy the app `Info.plist` to `Contents/Info.plist`.
+6. Add a `PkgInfo` file with `APPL????`.
+7. Optionally run ad-hoc codesigning when `codesign` is available, using `codesign --force --sign -`.
+8. Print the generated app path.
+
+Ad-hoc signing is not treated as a substitute for Developer ID signing. It only makes the local bundle more coherent for prototype testing. If ad-hoc signing fails, the script should fail clearly rather than silently producing a misleading artifact.
+
+Add `package-app` to `Makefile` so the supported commands become:
+
+- `make test`
+- `make package-app`
+- `swift build --product MeetingAgentApp`
+- `swift run MeetingAgentApp`
+
+Update `AGENTS.md` with the packaging command and distribution limitation: the artifact is locally installable but unsigned and unnotarized.
+
+## Testing
+
+Add source-level scaffold tests instead of launching the GUI app. The tests should verify:
+
+- `scripts/package-app.sh` exists.
+- The script builds `MeetingAgentApp` in release mode.
+- The script creates `dist/MeetingAgent.app/Contents/MacOS` and `Contents/Resources`.
+- The script copies `Sources/MeetingAgentApp/Resources/Info.plist`.
+- The `Info.plist` contains the expected bundle executable, package type, minimum macOS version, and permission usage keys.
+- `Makefile` exposes `package-app`.
+
+Local verification will run:
+
+- `make test`
+- `swift build --product MeetingAgentApp`
+- `make package-app`
+

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+EXECUTABLE_NAME="MeetingAgentApp"
+APP_BUNDLE="$REPO_ROOT/dist/MeetingAgent.app"
+CONTENTS_DIR="$APP_BUNDLE/Contents"
+MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
+RESOURCES_DIR="$APP_BUNDLE/Contents/Resources"
+INFO_PLIST="$REPO_ROOT/Sources/MeetingAgentApp/Resources/Info.plist"
+RELEASE_EXECUTABLE="$REPO_ROOT/.build/release/$EXECUTABLE_NAME"
+
+if [ ! -f "$INFO_PLIST" ]; then
+    echo "Missing app Info.plist at $INFO_PLIST" >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+swift build -c release --product MeetingAgentApp
+
+rm -rf "$APP_BUNDLE"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+cp "$RELEASE_EXECUTABLE" "$MACOS_DIR/$EXECUTABLE_NAME"
+cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
+printf "APPL????" > "$CONTENTS_DIR/PkgInfo"
+
+if command -v codesign >/dev/null 2>&1; then
+    codesign --force --sign - "$APP_BUNDLE"
+fi
+
+echo "Packaged $APP_BUNDLE"


### PR DESCRIPTION
## Summary

Fixes #38

- Add a reproducible `make package-app` workflow that builds `dist/MeetingAgent.app` from the SwiftPM app product.
- Add macOS bundle metadata and required permission usage descriptions.
- Document unsigned/unnotarized prototype distribution limits and ignore generated `dist/` output.

## Changes

- `scripts/package-app.sh` - builds the release executable and assembles a standard macOS app bundle.
- `Sources/MeetingAgentApp/Resources/Info.plist` - defines app bundle metadata and permission strings.
- `Makefile` - adds `package-app`.
- `Package.swift` - excludes app bundle templates from SwiftPM source scanning.
- `Tests/MeetingAgentCoreTests/ScaffoldTests.swift` - adds packaging regression coverage.
- `AGENTS.md` - documents the packaging command and Gatekeeper limitation.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `make test` passed, 379 tests, coverage gate passed
- [x] E2E/integration: `make package-app` passed and generated `dist/MeetingAgent.app`
- [x] Code review: PASS via manual SwiftPM diff review; code-review skill is TS/Java-only
- [x] Manual verification: `find dist/MeetingAgent.app -maxdepth 3 -type f` confirmed `Contents/Info.plist`, `Contents/MacOS/MeetingAgentApp`, and `Contents/PkgInfo`