### PR TITLE
fix: show source captions before translations

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -1112,12 +1112,12 @@ private struct BilingualTranscriptRow: View {
 
             switch LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: secondLanguageEnabled) {
             case .translated(let primaryText, let sourceText):
-                Text(primaryText)
+                Text(sourceText)
                     .font(CommandCenterTypography.transcript)
                     .lineSpacing(5)
                     .foregroundStyle(CommandCenterPalette.text)
                     .textSelection(.enabled)
-                Text(sourceText)
+                Text(primaryText)
                     .font(CommandCenterTypography.secondaryBody)
                     .lineSpacing(4)
                     .foregroundStyle(CommandCenterPalette.secondaryText)

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -190,6 +190,29 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("\" turns\""))
     }
 
+    func testTranslatedTranscriptRowsRenderSourceBeforeTranslation() throws {
+        let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+        let source = try String(contentsOf: sourceURL)
+
+        guard let translatedCaseRange = source.range(of: "case .translated(let primaryText, let sourceText):") else {
+            return XCTFail("Translated transcript branch is missing")
+        }
+        guard let originalOnlyRange = source.range(of: "case .originalOnly", range: translatedCaseRange.upperBound..<source.endIndex) else {
+            return XCTFail("Translated transcript branch end is missing")
+        }
+
+        let translatedBranch = source[translatedCaseRange.lowerBound..<originalOnlyRange.lowerBound]
+        guard let sourceTextRange = translatedBranch.range(of: "Text(sourceText)") else {
+            return XCTFail("Translated transcript branch does not render sourceText")
+        }
+        guard let primaryTextRange = translatedBranch.range(of: "Text(primaryText)") else {
+            return XCTFail("Translated transcript branch does not render primaryText")
+        }
+
+        XCTAssertLessThan(sourceTextRange.lowerBound, primaryTextRange.lowerBound)
+    }
+
     func testUnifiedTranscriptPreservesFallbackAndQuietCorrectionControls() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")

--- a/docs/superpowers/plans/2026-04-28-translation-ui-order.md
+++ b/docs/superpowers/plans/2026-04-28-translation-ui-order.md
@@ -1,0 +1,125 @@
+# Translation UI Order Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render original/source captions above translated captions in the live bilingual transcript UI for issue #42.
+
+**Architecture:** Keep translation state and stored transcript semantics unchanged. Change only the SwiftUI row rendering order for translated display state and add a source-layout regression test that fails on the current order.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest, Swift Package Manager via `make test`.
+
+---
+
+## File Structure
+
+- Modify `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`: add a regression test that inspects the translated branch in `BilingualTranscriptRow`.
+- Modify `Sources/MeetingAgentApp/MainWindowView.swift`: swap the two rendered `Text` blocks in the `.translated` case so `sourceText` renders first and `primaryText` renders second.
+
+### Task 1: Add Regression Test
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Add the failing source-layout test**
+
+Add this test near `testTranscriptPaneUsesUnifiedTranscriptSurface`:
+
+```swift
+    func testTranslatedTranscriptRowsRenderSourceBeforeTranslation() throws {
+        let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+        let source = try String(contentsOf: sourceURL)
+
+        guard let translatedCaseRange = source.range(of: "case .translated(let primaryText, let sourceText):") else {
+            return XCTFail("Translated transcript branch is missing")
+        }
+        guard let originalOnlyRange = source.range(of: "case .originalOnly", range: translatedCaseRange.upperBound..<source.endIndex) else {
+            return XCTFail("Translated transcript branch end is missing")
+        }
+
+        let translatedBranch = source[translatedCaseRange.lowerBound..<originalOnlyRange.lowerBound]
+        guard let sourceTextRange = translatedBranch.range(of: "Text(sourceText)") else {
+            return XCTFail("Translated transcript branch does not render sourceText")
+        }
+        guard let primaryTextRange = translatedBranch.range(of: "Text(primaryText)") else {
+            return XCTFail("Translated transcript branch does not render primaryText")
+        }
+
+        XCTAssertLessThan(sourceTextRange.lowerBound, primaryTextRange.lowerBound)
+    }
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testTranslatedTranscriptRowsRenderSourceBeforeTranslation
+```
+
+Expected: FAIL because the current translated branch renders `Text(primaryText)` before `Text(sourceText)`.
+
+### Task 2: Swap Render Order
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Update the translated branch**
+
+Replace the `.translated` case body with:
+
+```swift
+            case .translated(let primaryText, let sourceText):
+                Text(sourceText)
+                    .font(CommandCenterTypography.transcript)
+                    .lineSpacing(5)
+                    .foregroundStyle(CommandCenterPalette.text)
+                    .textSelection(.enabled)
+                Text(primaryText)
+                    .font(CommandCenterTypography.secondaryBody)
+                    .lineSpacing(4)
+                    .foregroundStyle(CommandCenterPalette.secondaryText)
+                    .textSelection(.enabled)
+```
+
+- [ ] **Step 2: Run the focused test and confirm it passes**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testTranslatedTranscriptRowsRenderSourceBeforeTranslation
+```
+
+Expected: PASS.
+
+### Task 3: Verify And Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Run full local verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "fix: show source captions before translations (#42)"
+```
+
+## Self-Review
+
+- Spec coverage: the plan changes only the live translated row order, leaves pending and failed states unchanged, and adds a focused regression test.
+- Placeholder scan: no placeholders remain.
+- Type consistency: the plan uses existing `primaryText` and `sourceText` bindings from `LiveCaptionDisplayState`.
+

--- a/docs/superpowers/specs/2026-04-28-translation-ui-order-design.md
+++ b/docs/superpowers/specs/2026-04-28-translation-ui-order-design.md
@@ -1,0 +1,35 @@
+# Translation UI Order Design
+
+## Issue
+
+GitHub issue #42 asks to adjust the live bilingual transcript UI order. The current app shows translated text above the original/source text. The requested behavior is to show the original language above the translated language.
+
+## Success Criteria
+
+- Live bilingual transcript rows render original/source text first.
+- Translated text remains visible directly below the source text when translation is available.
+- Pending and failed translation states continue to show source text above their status labels.
+- Transcript storage, translation scheduling, exports, and summary behavior are unchanged.
+- A focused regression test protects the order in `BilingualTranscriptRow`.
+
+## Selected Approach
+
+Use a UI-only change in `BilingualTranscriptRow`. `LiveCaptionDisplayState` can keep describing the translation as the primary translated text plus source text because other core tests already cover that state contract. The SwiftUI row should decide visual hierarchy by rendering `sourceText` first and `primaryText` second for translated rows.
+
+This is the smallest change that directly addresses the issue without changing model semantics or persisted artifacts.
+
+## Alternatives Considered
+
+1. Change `LiveCaptionDisplayState` so source text is the primary value. This would make the display-state contract match the new visual hierarchy, but it changes core semantics for a UI-specific order decision.
+2. Add a configurable order setting. This is more flexible, but issue #42 requests one product behavior and the settings surface does not need another option yet.
+
+## Affected Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+## Test Plan
+
+- Add a source-layout regression test that finds the `.translated` switch branch and asserts `Text(sourceText)` appears before `Text(primaryText)`.
+- Run `make test`.
+


### PR DESCRIPTION
## Summary

Fixes #42

- Shows original/source caption text above translated text in bilingual transcript rows.
- Keeps translation state, exports, pending state, and failure state behavior unchanged.
- Adds a regression test for translated row render order.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - render `sourceText` before `primaryText` in translated live transcript rows.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - assert translated rows render source text before translation text.
- `docs/superpowers/specs/2026-04-28-translation-ui-order-design.md` - design artifact for #42.
- `docs/superpowers/plans/2026-04-28-translation-ui-order.md` - implementation plan for #42.

## Test plan

- [x] Build/lint: `make test` passed
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testTranslatedTranscriptRowsRenderSourceBeforeTranslation` failed before fix and passed after fix
- [x] Unit tests: `make test` passed, 378 tests, coverage gate passed at line 95.66% and method 95.72%
- [x] E2E/integration: skipped; no E2E convention for this source-layout UI order change
- [x] Code review: PASS, manual Swift diff review
- [x] Manual verification: not applicable beyond source-layout regression for row order