### PR TITLE
feat: skip same-language translation

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -301,3 +301,19 @@ Await actor-isolated values into local constants before passing them to XCTest a
 When asserting actor state in XCTest, split `let value = await actor.value` from `XCTAssertEqual(value, expected)`.
 
 ---
+
+## [43] Use detected transcript language after source setting removal
+
+**Date**: 2026-04-29
+**Category**: wrong-assumption
+
+### What went wrong
+The first same-language translation skip was written against the old source-locale setting model, but main later removed the Deepgram source language setting and made transcript segments carry detected language codes.
+
+### Correct approach
+Live caption translation skip logic should compare each turn's actual source locale from the transcript segment against the configured main/target language, including bare detected language codes like `ja` against locales like `ja-JP`.
+
+### How to avoid
+When a setting is redefined or removed, audit behavior against the runtime data that now represents that concept instead of the old configuration field.
+
+---

--- a/Sources/MeetingAgentCore/BilingualProvider.swift
+++ b/Sources/MeetingAgentCore/BilingualProvider.swift
@@ -100,6 +100,36 @@ public struct TranslationOptions: Equatable {
     }
 }
 
+public extension TranslationOptions {
+    var isSameLanguage: Bool {
+        LocaleLanguageMatcher.isSameLanguage(sourceLocale, targetLocale)
+    }
+}
+
+enum LocaleLanguageMatcher {
+    static func isSameLanguage(_ lhs: String, _ rhs: String) -> Bool {
+        guard let left = languageCode(from: lhs),
+              let right = languageCode(from: rhs)
+        else {
+            return false
+        }
+        return left == right
+    }
+
+    private static func languageCode(from localeIdentifier: String) -> String? {
+        let normalized = localeIdentifier
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "-")
+            .lowercased()
+        guard let language = normalized.split(separator: "-").first,
+              !language.isEmpty
+        else {
+            return nil
+        }
+        return String(language)
+    }
+}
+
 public typealias SpeechTranslationOptions = TranslationOptions
 public typealias BilingualSubtitleOptions = TranslationOptions
 

--- a/Sources/MeetingAgentCore/BilingualSubtitlePipelineOrchestrator.swift
+++ b/Sources/MeetingAgentCore/BilingualSubtitlePipelineOrchestrator.swift
@@ -127,6 +127,16 @@ public final class BilingualSubtitlePipelineOrchestrator {
         targetLocale: String,
         provenance: inout PipelineProvenance
     ) async throws -> TranslatedTranscript {
+        let options = TranslationOptions(sourceLocale: sourceLocale, targetLocale: targetLocale)
+        if options.isSameLanguage {
+            return sourceOnlyTranslation(
+                transcript: transcript,
+                sourceLocale: sourceLocale,
+                targetLocale: targetLocale,
+                provenance: provenance,
+                errorMessage: nil
+            )
+        }
         for reference in [step.primary] + step.fallbacks {
             guard case .provider(let providerID) = reference else { continue }
             guard let provider = textTranslationProviders[providerID] else { continue }
@@ -134,7 +144,7 @@ public final class BilingualSubtitlePipelineOrchestrator {
             do {
                 let result = try await provider.translate(
                     transcript: transcript,
-                    options: TranslationOptions(sourceLocale: sourceLocale, targetLocale: targetLocale)
+                    options: options
                 )
                 provenance.successfulProviders.append(providerID)
                 return result
@@ -143,7 +153,23 @@ public final class BilingualSubtitlePipelineOrchestrator {
             }
         }
 
-        return TranslatedTranscript(
+        return sourceOnlyTranslation(
+            transcript: transcript,
+            sourceLocale: sourceLocale,
+            targetLocale: targetLocale,
+            provenance: provenance,
+            errorMessage: "all translation providers failed"
+        )
+    }
+
+    private func sourceOnlyTranslation(
+        transcript: TranscriptDocument,
+        sourceLocale: String,
+        targetLocale: String,
+        provenance: PipelineProvenance,
+        errorMessage: String?
+    ) -> TranslatedTranscript {
+        TranslatedTranscript(
             sourceLocale: sourceLocale,
             targetLocale: targetLocale,
             segments: transcript.segments.map {
@@ -156,7 +182,7 @@ public final class BilingualSubtitlePipelineOrchestrator {
                     targetText: "",
                     confidence: $0.confidence,
                     status: .sourceOnly,
-                    errorMessage: "all translation providers failed",
+                    errorMessage: errorMessage,
                     providerChain: provenance.successfulProviders
                 )
             },

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -589,6 +589,12 @@ public struct LiveCaptionStore: Equatable {
         turns[index].translationHealth = .live
     }
 
+    public mutating func markTranslationCompleteWithoutText(forTurnID turnID: String) {
+        guard let index = turns.firstIndex(where: { $0.id == turnID }) else { return }
+        turns[index].translatedText = nil
+        turns[index].translationHealth = .live
+    }
+
     public mutating func markTranslationFailed(forTurnID turnID: String, message: String) {
         guard let index = turns.firstIndex(where: { $0.id == turnID }) else { return }
         turns[index].translationHealth = .failed(message)
@@ -615,6 +621,11 @@ public struct LiveCaptionTranslationAdapter {
 
     public func translate(turn: LiveCaptionTurn, in store: inout LiveCaptionStore) async throws {
         guard turn.isFinal else { return }
+        let options = TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
+        if options.isSameLanguage {
+            store.markTranslationCompleteWithoutText(forTurnID: turn.id)
+            return
+        }
         let segment = TranscriptSegment(
             id: turn.sourceSegmentID,
             speaker: turn.speaker,
@@ -626,7 +637,7 @@ public struct LiveCaptionTranslationAdapter {
         do {
             let translated = try await provider.translate(
                 transcript: TranscriptDocument(segments: [segment]),
-                options: TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
+                options: options
             )
             let translatedText = translated.segments.first { $0.id == turn.sourceSegmentID }?.targetText ?? ""
             store.attachTranslation(translatedText, toTurnID: turn.id)

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -921,6 +921,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     }
 
     private func scheduleCaptionTextTranslationIfNeeded() {
+        completeSameLanguageCaptionTranslationsIfNeeded()
         let draftCandidates = liveCaptionStore.turns.filter { turn in
             guard turn.translationHealth == .pending,
                   shouldScheduleDraftTranslation(for: turn),
@@ -962,6 +963,19 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
     }
 
+    private func completeSameLanguageCaptionTranslationsIfNeeded() {
+        var completedAny = false
+        for turn in liveCaptionStore.turns where turn.translationHealth == .pending {
+            let options = TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
+            guard options.isSameLanguage else { continue }
+            completeCaptionTranslationWithoutProvider(for: turn)
+            completedAny = true
+        }
+        guard completedAny else { return }
+        liveCaptionTurns = liveCaptionStore.turns
+        updateTranslationHealthFromRealtimeStatus()
+    }
+
     private func shouldScheduleDraftTranslation(for turn: LiveCaptionTurn) -> Bool {
         guard turn.translationState != .final else {
             return false
@@ -995,6 +1009,12 @@ public final class MeetingAgentViewModel: ObservableObject {
         for request in requests {
             let turn = request.turn
             let sourceText = translationSourceText(for: turn, final: !request.isDraft)
+            let options = TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
+            if options.isSameLanguage {
+                completeCaptionTranslationWithoutProvider(for: turn)
+                liveCaptionTurns = liveCaptionStore.turns
+                continue
+            }
             let segment = TranscriptSegment(
                 id: turn.sourceSegmentID,
                 speaker: turn.speaker,
@@ -1006,7 +1026,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             do {
                 let translated = try await provider.translate(
                     transcript: TranscriptDocument(segments: [segment]),
-                    options: TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
+                    options: options
                 )
                 let translatedText = translated.segments.first { $0.id == turn.sourceSegmentID }?.targetText ?? ""
                 if request.isDraft {
@@ -1022,6 +1042,15 @@ public final class MeetingAgentViewModel: ObservableObject {
             }
         }
         updateTranslationHealthFromRealtimeStatus()
+    }
+
+    private func completeCaptionTranslationWithoutProvider(for turn: LiveCaptionTurn) {
+        liveCaptionStore.markTranslationCompleteWithoutText(forTurnID: turn.id)
+        draftTranslationKeysByTurnID[turn.id] = draftCaptionTranslationKey(for: turn)
+        draftTranslationCharacterCountsByTurnID[turn.id] = turn.originalText.count
+        finalTranslationKeysByTurnID[turn.id] = finalCaptionTranslationKey(for: turn)
+        draftTranslationInFlightByTurnID.removeValue(forKey: turn.id)
+        finalTranslationInFlightTurnIDs.remove(turn.id)
     }
 
     private func translationSourceText(for turn: LiveCaptionTurn, final: Bool) -> String {

--- a/Tests/MeetingAgentCoreTests/BilingualProviderRegistryTests.swift
+++ b/Tests/MeetingAgentCoreTests/BilingualProviderRegistryTests.swift
@@ -35,6 +35,15 @@ final class BilingualProviderRegistryTests: XCTestCase {
         XCTAssertTrue(descriptor.supports(sourceLocale: "ko-KR", targetLocale: "zh-CN"))
     }
 
+    func testTranslationOptionsDetectSameLanguageLocales() {
+        XCTAssertTrue(TranslationOptions(sourceLocale: "en-US", targetLocale: "en-GB").isSameLanguage)
+        XCTAssertTrue(TranslationOptions(sourceLocale: " zh_CN ", targetLocale: "zh-TW").isSameLanguage)
+        XCTAssertTrue(TranslationOptions(sourceLocale: "JA", targetLocale: "ja-JP").isSameLanguage)
+        XCTAssertFalse(TranslationOptions(sourceLocale: "en-US", targetLocale: "zh-CN").isSameLanguage)
+        XCTAssertFalse(TranslationOptions(sourceLocale: "", targetLocale: "en-US").isSameLanguage)
+        XCTAssertFalse(TranslationOptions(sourceLocale: "   ", targetLocale: "   ").isSameLanguage)
+    }
+
     func testBuiltInRegistryIncludesOpenAIRealtimeTranscriptionDescriptor() {
         let descriptor = BilingualPipelineFactory.builtInRegistry.descriptor(id: "openai-realtime-transcribe")
 

--- a/Tests/MeetingAgentCoreTests/BilingualSubtitlePipelineOrchestratorTests.swift
+++ b/Tests/MeetingAgentCoreTests/BilingualSubtitlePipelineOrchestratorTests.swift
@@ -165,6 +165,42 @@ final class BilingualSubtitlePipelineOrchestratorTests: XCTestCase {
         XCTAssertEqual(output.provenance.fallbackReasons["mt"], "Speech recognition error: translation failed")
     }
 
+    func testSkipsTranslationProviderWhenSourceAndTargetLanguagesMatch() async throws {
+        let transcription = FakeAudioTranscriptionProvider(id: "stt", result: .success(TranscriptDocument(segments: [
+            TranscriptSegment(id: "segment-1", startTimeSeconds: 1, endTimeSeconds: 2, text: "hello", language: "en-US", sourceProvider: "stt")
+        ])))
+        let translation = FakeTextTranslationProvider(id: "mt", result: .success(TranslatedTranscript(
+            sourceLocale: "en-US",
+            targetLocale: "en-GB",
+            segments: [
+                BilingualSubtitleSegment(id: "segment-1", sourceText: "hello", targetText: "translated")
+            ],
+            provenance: PipelineProvenance(profileID: "profile")
+        )))
+        let profile = BilingualPipelineProfile(id: "profile", displayName: "Profile", steps: [
+            PipelineStep(capability: .audioTranscription, primary: .provider("stt")),
+            PipelineStep(capability: .textTranslation, primary: .provider("mt"))
+        ])
+        let orchestrator = BilingualSubtitlePipelineOrchestrator(
+            profiles: [profile],
+            audioTranscriptionProviders: [transcription],
+            textTranslationProviders: [translation]
+        )
+
+        let output = try await orchestrator.generate(
+            audio: AudioInput(localeIdentifier: "en-US"),
+            sourceLocale: "en-US",
+            targetLocale: "en-GB",
+            profileID: "profile"
+        )
+
+        XCTAssertEqual(translation.translateCallCount, 0)
+        XCTAssertEqual(output.segments.first?.sourceText, "hello")
+        XCTAssertEqual(output.segments.first?.targetText, "")
+        XCTAssertEqual(output.segments.first?.status, .sourceOnly)
+        XCTAssertEqual(output.provenance.successfulProviders, ["stt"])
+    }
+
     func testThrowsForMissingProfilesCyclesUnsupportedStepsAndBadOrdering() async {
         let cycleProfile = BilingualPipelineProfile(id: "cycle", displayName: "Cycle", steps: [
             PipelineStep(capability: .bilingualSubtitle, primary: .profile("cycle"))
@@ -237,9 +273,10 @@ private struct FakeAudioTranscriptionProvider: AudioTranscriptionProvider {
     }
 }
 
-private struct FakeTextTranslationProvider: TextTranslationProvider {
+private final class FakeTextTranslationProvider: TextTranslationProvider {
     let descriptor: ProviderDescriptor
     let result: Result<TranslatedTranscript, Error>
+    private(set) var translateCallCount = 0
 
     init(id: String, result: Result<TranslatedTranscript, Error>) {
         descriptor = ProviderDescriptor(id: id, displayName: id, capability: .textTranslation, executionMode: .hosted, supportedSourceLocales: ["*"], supportedTargetLocales: ["*"], requiresNetwork: false, requiresAPIKey: false)
@@ -247,7 +284,8 @@ private struct FakeTextTranslationProvider: TextTranslationProvider {
     }
 
     func translate(transcript: TranscriptDocument, options: TranslationOptions) async throws -> TranslatedTranscript {
-        try result.get()
+        translateCallCount += 1
+        return try result.get()
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/LiveCaptionTranslationAdapterTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionTranslationAdapterTests.swift
@@ -41,6 +41,19 @@ final class LiveCaptionTranslationAdapterTests: XCTestCase {
         XCTAssertNil(store.turns.first?.translatedText)
         XCTAssertEqual(store.turns.first?.translationHealth, .pending)
     }
+
+    func testSameLanguageFinalCaptionDoesNotCallTranslationProvider() async throws {
+        var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "en-GB")
+        let turn = store.append(TranscriptSegment(id: "segment-1", text: "hello", language: "en-US", isFinal: true))
+        let provider = FakeTextTranslationProvider(translations: ["segment-1": "translated"])
+        let adapter = LiveCaptionTranslationAdapter(provider: provider)
+
+        try await adapter.translate(turn: turn, in: &store)
+
+        XCTAssertEqual(provider.translateCallCount, 0)
+        XCTAssertNil(store.turns.first?.translatedText)
+        XCTAssertEqual(store.turns.first?.translationHealth, .live)
+    }
 }
 
 private final class FakeTextTranslationProvider: TextTranslationProvider {

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -414,6 +414,96 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(provider.requests.count, 1)
     }
 
+    func testDrainRecordingFramesSkipsCaptionTranslationWhenSourceAndTargetLanguagesMatch() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        var providerFactoryCallCount = 0
+        let provider = ViewModelFakeTextTranslationProvider(translations: ["segment-1": "translated"])
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "en-US",
+                targetLocaleIdentifier: "en-GB",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil,
+                transcriptionExecutionMode: .hosted,
+                translationExecutionMode: .hosted,
+                hostedTranscriptionProviderID: "deepgram-transcribe",
+                hostedTranslationProviderID: "openrouter-translation",
+                openRouterAPIKey: "settings-openrouter-key",
+                deepgramAPIKey: "settings-deepgram-key"
+            ),
+            captionTranslationProviderFactory: { _ in
+                providerFactoryCallCount += 1
+                return provider
+            },
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        let record = try XCTUnwrap(viewModel.meetings.first)
+        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
+        try transcriptWriter.replace(with: [
+            TranscriptSegment(id: "segment-1", text: "Alex is the launch owner.", language: "en-US", isFinal: true)
+        ])
+
+        viewModel.drainRecordingFrames()
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(providerFactoryCallCount, 0)
+        XCTAssertEqual(provider.requests.count, 0)
+        XCTAssertNil(viewModel.liveCaptionTurns.first?.translatedText)
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
+        XCTAssertEqual(viewModel.meetingProgressHealth.translation, .live)
+    }
+
+    func testDrainRecordingFramesSkipsCaptionTranslationWhenDetectedLanguageMatchesMainLanguage() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        var providerFactoryCallCount = 0
+        let provider = ViewModelFakeTextTranslationProvider(translations: ["segment-1": "translated"])
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "en-US",
+                targetLocaleIdentifier: "ja-JP",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil,
+                transcriptionExecutionMode: .hosted,
+                translationExecutionMode: .hosted,
+                hostedTranscriptionProviderID: "deepgram-transcribe",
+                hostedTranslationProviderID: "openrouter-translation",
+                openRouterAPIKey: "settings-openrouter-key",
+                deepgramAPIKey: "settings-deepgram-key"
+            ),
+            captionTranslationProviderFactory: { _ in
+                providerFactoryCallCount += 1
+                return provider
+            },
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        let record = try XCTUnwrap(viewModel.meetings.first)
+        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
+        try transcriptWriter.replace(with: [
+            TranscriptSegment(id: "segment-1", text: "開始しましょう。", language: "ja", isFinal: true)
+        ])
+
+        viewModel.drainRecordingFrames()
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(providerFactoryCallCount, 0)
+        XCTAssertEqual(provider.requests.count, 0)
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.sourceLocale, "ja")
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.targetLocale, "ja-JP")
+        XCTAssertNil(viewModel.liveCaptionTurns.first?.translatedText)
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
+        XCTAssertEqual(viewModel.meetingProgressHealth.translation, .live)
+    }
+
     func testExpandingTranslatedCaptionKeepsVisibleTranslationUntilFullTurnTranslationCompletes() async throws {
         let fixture = try ViewModelRecorderFixture()
         let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "Alex")

--- a/docs/superpowers/plans/2026-04-28-skip-same-language-translation.md
+++ b/docs/superpowers/plans/2026-04-28-skip-same-language-translation.md
@@ -1,0 +1,305 @@
+# Skip Same-Language Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Skip text translation calls when source and target language identifiers represent the same language.
+
+**Architecture:** Add one shared locale-language predicate on `TranslationOptions`, then use it in the bilingual subtitle orchestrator, the live caption adapter, and the view-model scheduler. Same-language live captions become complete original-only captions, while pipeline exports emit source-only bilingual segments.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, macOS 14.2 target.
+
+---
+
+### Task 1: Shared Same-Language Predicate
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/BilingualProvider.swift`
+- Modify: `Tests/MeetingAgentCoreTests/BilingualProviderRegistryTests.swift`
+
+- [ ] **Step 1: Write locale matching tests**
+
+Add this test to `BilingualProviderRegistryTests`:
+
+```swift
+func testTranslationOptionsDetectSameLanguageLocales() {
+    XCTAssertTrue(TranslationOptions(sourceLocale: "en-US", targetLocale: "en-GB").isSameLanguage)
+    XCTAssertTrue(TranslationOptions(sourceLocale: " zh_CN ", targetLocale: "zh-TW").isSameLanguage)
+    XCTAssertTrue(TranslationOptions(sourceLocale: "JA", targetLocale: "ja-JP").isSameLanguage)
+    XCTAssertFalse(TranslationOptions(sourceLocale: "en-US", targetLocale: "zh-CN").isSameLanguage)
+    XCTAssertFalse(TranslationOptions(sourceLocale: "", targetLocale: "en-US").isSameLanguage)
+    XCTAssertFalse(TranslationOptions(sourceLocale: "   ", targetLocale: "   ").isSameLanguage)
+}
+```
+
+- [ ] **Step 2: Run the focused test and confirm it fails**
+
+Run: `swift test --filter BilingualProviderRegistryTests/testTranslationOptionsDetectSameLanguageLocales`
+
+Expected: compile failure because `isSameLanguage` does not exist.
+
+- [ ] **Step 3: Add the shared predicate**
+
+Add this to `BilingualProvider.swift` after `TranslationOptions`:
+
+```swift
+public extension TranslationOptions {
+    var isSameLanguage: Bool {
+        LocaleLanguageMatcher.isSameLanguage(sourceLocale, targetLocale)
+    }
+}
+
+enum LocaleLanguageMatcher {
+    static func isSameLanguage(_ lhs: String, _ rhs: String) -> Bool {
+        guard let left = languageCode(from: lhs),
+              let right = languageCode(from: rhs)
+        else {
+            return false
+        }
+        return left == right
+    }
+
+    private static func languageCode(from localeIdentifier: String) -> String? {
+        let normalized = localeIdentifier
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "-")
+            .lowercased()
+        guard let language = normalized.split(separator: "-").first,
+              !language.isEmpty
+        else {
+            return nil
+        }
+        return String(language)
+    }
+}
+```
+
+- [ ] **Step 4: Run the focused test and confirm it passes**
+
+Run: `swift test --filter BilingualProviderRegistryTests/testTranslationOptionsDetectSameLanguageLocales`
+
+Expected: pass.
+
+### Task 2: Skip Same-Language Pipeline Translation
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/BilingualSubtitlePipelineOrchestrator.swift`
+- Modify: `Tests/MeetingAgentCoreTests/BilingualSubtitlePipelineOrchestratorTests.swift`
+
+- [ ] **Step 1: Make fake translation provider count calls**
+
+Update the fake provider in `BilingualSubtitlePipelineOrchestratorTests`:
+
+```swift
+private final class FakeTextTranslationProvider: TextTranslationProvider {
+    let descriptor: ProviderDescriptor
+    let result: Result<TranslatedTranscript, Error>
+    private(set) var translateCallCount = 0
+
+    init(id: String, result: Result<TranslatedTranscript, Error>) {
+        descriptor = ProviderDescriptor(id: id, displayName: id, capability: .textTranslation, executionMode: .hosted, supportedSourceLocales: ["*"], supportedTargetLocales: ["*"], requiresNetwork: false, requiresAPIKey: false)
+        self.result = result
+    }
+
+    func translate(transcript: TranscriptDocument, options: TranslationOptions) async throws -> TranslatedTranscript {
+        translateCallCount += 1
+        return try result.get()
+    }
+}
+```
+
+- [ ] **Step 2: Write the skip test**
+
+Add this test:
+
+```swift
+func testSkipsTranslationProviderWhenSourceAndTargetLanguagesMatch() async throws {
+    let transcription = FakeAudioTranscriptionProvider(id: "stt", result: .success(TranscriptDocument(segments: [
+        TranscriptSegment(id: "segment-1", startTimeSeconds: 1, endTimeSeconds: 2, text: "hello", language: "en-US", sourceProvider: "stt")
+    ])))
+    let translation = FakeTextTranslationProvider(id: "mt", result: .success(TranslatedTranscript(
+        sourceLocale: "en-US",
+        targetLocale: "en-GB",
+        segments: [
+            BilingualSubtitleSegment(id: "segment-1", sourceText: "hello", targetText: "translated")
+        ],
+        provenance: PipelineProvenance(profileID: "profile")
+    )))
+    let profile = BilingualPipelineProfile(id: "profile", displayName: "Profile", steps: [
+        PipelineStep(capability: .audioTranscription, primary: .provider("stt")),
+        PipelineStep(capability: .textTranslation, primary: .provider("mt"))
+    ])
+    let orchestrator = BilingualSubtitlePipelineOrchestrator(
+        profiles: [profile],
+        audioTranscriptionProviders: [transcription],
+        textTranslationProviders: [translation]
+    )
+
+    let output = try await orchestrator.generate(
+        audio: AudioInput(localeIdentifier: "en-US"),
+        sourceLocale: "en-US",
+        targetLocale: "en-GB",
+        profileID: "profile"
+    )
+
+    XCTAssertEqual(translation.translateCallCount, 0)
+    XCTAssertEqual(output.segments.first?.sourceText, "hello")
+    XCTAssertEqual(output.segments.first?.targetText, "")
+    XCTAssertEqual(output.segments.first?.status, .sourceOnly)
+    XCTAssertEqual(output.provenance.successfulProviders, ["stt"])
+}
+```
+
+- [ ] **Step 3: Run the focused test and confirm it fails**
+
+Run: `swift test --filter BilingualSubtitlePipelineOrchestratorTests/testSkipsTranslationProviderWhenSourceAndTargetLanguagesMatch`
+
+Expected: failure because the translation provider is called.
+
+- [ ] **Step 4: Implement pipeline skip**
+
+In `runTranslationStep`, create `let options = TranslationOptions(sourceLocale: sourceLocale, targetLocale: targetLocale)`. If `options.isSameLanguage`, return a `TranslatedTranscript` with source-only segments before iterating providers.
+
+- [ ] **Step 5: Run the focused test and confirm it passes**
+
+Run: `swift test --filter BilingualSubtitlePipelineOrchestratorTests/testSkipsTranslationProviderWhenSourceAndTargetLanguagesMatch`
+
+Expected: pass.
+
+### Task 3: Skip Same-Language Live Caption Translation
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Modify: `Tests/MeetingAgentCoreTests/LiveCaptionTranslationAdapterTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Write adapter skip test**
+
+Add this to `LiveCaptionTranslationAdapterTests`:
+
+```swift
+func testSameLanguageFinalCaptionDoesNotCallTranslationProvider() async throws {
+    var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "en-GB")
+    let turn = store.append(TranscriptSegment(id: "segment-1", text: "hello", language: "en-US", isFinal: true))
+    let provider = FakeTextTranslationProvider(translations: ["segment-1": "translated"])
+    let adapter = LiveCaptionTranslationAdapter(provider: provider)
+
+    try await adapter.translate(turn: turn, in: &store)
+
+    XCTAssertEqual(provider.translateCallCount, 0)
+    XCTAssertNil(store.turns.first?.translatedText)
+    XCTAssertEqual(store.turns.first?.translationHealth, .live)
+}
+```
+
+- [ ] **Step 2: Write view-model scheduler skip test**
+
+Add this near the existing live caption translation tests in `MeetingAgentViewModelTests`:
+
+```swift
+func testDrainRecordingFramesSkipsCaptionTranslationWhenSourceAndTargetLanguagesMatch() async throws {
+    let fixture = try ViewModelRecorderFixture()
+    var providerFactoryCallCount = 0
+    let provider = ViewModelFakeTextTranslationProvider(translations: ["segment-1": "translated"])
+    let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+    let viewModel = MeetingAgentViewModel(
+        store: fixture.store,
+        recorder: fixture.recorder,
+        speechConfiguration: SpeechTranscriptionConfiguration(
+            provider: .whisper,
+            localeIdentifier: "en-US",
+            targetLocaleIdentifier: "en-GB",
+            whisperBinaryPath: nil,
+            whisperModelPath: nil,
+            transcriptionExecutionMode: .hosted,
+            translationExecutionMode: .hosted,
+            hostedTranscriptionProviderID: "deepgram-transcribe",
+            hostedTranslationProviderID: "openrouter-translation",
+            openRouterAPIKey: "settings-openrouter-key",
+            deepgramAPIKey: "settings-deepgram-key"
+        ),
+        captionTranslationProviderFactory: { _ in
+            providerFactoryCallCount += 1
+            return provider
+        },
+        processTargetsProvider: { [target] }
+    )
+    try await viewModel.startRecording(for: target)
+    let record = try XCTUnwrap(viewModel.meetings.first)
+    let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
+    try transcriptWriter.replace(with: [
+        TranscriptSegment(id: "segment-1", text: "Alex is the launch owner.", language: "en-US", isFinal: true)
+    ])
+
+    viewModel.drainRecordingFrames()
+    try await Task.sleep(nanoseconds: 20_000_000)
+
+    XCTAssertEqual(providerFactoryCallCount, 0)
+    XCTAssertEqual(provider.requests.count, 0)
+    XCTAssertNil(viewModel.liveCaptionTurns.first?.translatedText)
+    XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
+    XCTAssertEqual(viewModel.meetingProgressHealth.translation, .live)
+}
+```
+
+- [ ] **Step 3: Run focused tests and confirm they fail**
+
+Run: `swift test --filter LiveCaptionTranslationAdapterTests/testSameLanguageFinalCaptionDoesNotCallTranslationProvider`
+
+Expected: failure because the provider is called.
+
+Run: `swift test --filter MeetingAgentViewModelTests/testDrainRecordingFramesSkipsCaptionTranslationWhenSourceAndTargetLanguagesMatch`
+
+Expected: failure because the provider factory is called or the caption remains pending.
+
+- [ ] **Step 4: Add a completion helper to the store**
+
+Add this method to `LiveCaptionStore`:
+
+```swift
+public mutating func markTranslationCompleteWithoutText(forTurnID turnID: String) {
+    guard let index = turns.firstIndex(where: { $0.id == turnID }) else { return }
+    turns[index].translatedText = nil
+    turns[index].translationHealth = .live
+}
+```
+
+- [ ] **Step 5: Use the helper in adapter and scheduler**
+
+In `LiveCaptionTranslationAdapter.translate`, return early after marking complete when `TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale).isSameLanguage`.
+
+In `MeetingAgentViewModel.scheduleCaptionTextTranslationIfNeeded`, first mark same-language pending final turns complete, store their translation keys, publish `liveCaptionTurns`, update translation health, and exclude those turns from provider candidates.
+
+- [ ] **Step 6: Run focused tests and confirm they pass**
+
+Run the two focused test commands from Step 3.
+
+Expected: both pass.
+
+### Task 4: Full Verification and Commit
+
+**Files:**
+- All modified implementation, tests, spec, and plan files.
+
+- [ ] **Step 1: Run local verification**
+
+Run: `make test`
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Inspect diff**
+
+Run: `git diff --check`
+
+Expected: no whitespace errors.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/BilingualProvider.swift Sources/MeetingAgentCore/BilingualSubtitlePipelineOrchestrator.swift Sources/MeetingAgentCore/LiveMeetingCockpit.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Tests/MeetingAgentCoreTests/BilingualProviderRegistryTests.swift Tests/MeetingAgentCoreTests/BilingualSubtitlePipelineOrchestratorTests.swift Tests/MeetingAgentCoreTests/LiveCaptionTranslationAdapterTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift docs/superpowers/specs/2026-04-28-skip-same-language-translation-design.md docs/superpowers/plans/2026-04-28-skip-same-language-translation.md
+git commit -m "feat: skip same-language translation (#43)"
+```
+
+Expected: commit succeeds.

--- a/docs/superpowers/specs/2026-04-28-skip-same-language-translation-design.md
+++ b/docs/superpowers/specs/2026-04-28-skip-same-language-translation-design.md
@@ -1,0 +1,69 @@
+# Skip Same-Language Translation Design
+
+## Issue
+
+GitHub issue #43 requests that translation is not called when the original language and target language are the same. The goal is to avoid wasting hosted or local translation capacity when the transcript can be shown directly.
+
+## Success Criteria
+
+- Live caption text translation does not call a translation provider when the source and target languages match.
+- The historical bilingual subtitle pipeline does not call a text translation provider when the source and target languages match after transcription.
+- Same-language matching is based on language identity, not exact region identity, so `en-US` and `en-GB` are treated as same language.
+- Existing cross-language translation behavior is unchanged.
+- Regression tests prove provider calls are skipped.
+
+## Requirements
+
+- Normalize locale identifiers by trimming whitespace, lowercasing, replacing `_` with `-`, and comparing the first language subtag.
+- Empty or malformed locale values must not be treated as same-language.
+- For same-language live captions, final captions should leave `translatedText` empty and mark `translationHealth` as `.live`, letting existing display logic render original-only instead of pending.
+- For same-language bilingual pipeline output, produce `BilingualSubtitleSegment` values with `sourceText` copied from the transcript, empty `targetText`, `.sourceOnly` status, and the current provenance without adding translation providers.
+
+## Non-Requirements
+
+- Do not change settings UI or provider configuration.
+- Do not skip direct bilingual providers before transcription, because those providers may be doing their own bilingual generation.
+- Do not add language-family special cases beyond the primary language subtag comparison.
+
+## Approach Options
+
+### Option A: Shared Locale Predicate
+
+Add a small public helper in `BilingualProvider.swift`, then call it from live captions and the orchestrator. This centralizes the language comparison and keeps provider-specific code unchanged.
+
+Trade-off: one new core API, but it avoids duplicated normalization logic.
+
+### Option B: Inline Checks Per Caller
+
+Add local `source == target` checks in the view model, live caption adapter, and orchestrator.
+
+Trade-off: smallest surface area per file, but it risks drift between live and export paths and would likely miss regional variants.
+
+### Option C: Wrap Translation Providers
+
+Introduce a provider decorator that skips calls when `TranslationOptions` are same-language.
+
+Trade-off: elegant at the provider boundary, but the current code constructs providers in multiple places and the orchestrator still needs to produce source-only output intentionally.
+
+## Selected Design
+
+Use Option A. Add `TranslationOptions.isSameLanguage` backed by a `LocaleLanguageMatcher` helper. The orchestrator uses this before entering the provider loop for text translation. Live caption scheduling filters out same-language work, marks those turns complete, and never constructs a hosted provider for skipped turns. `LiveCaptionTranslationAdapter` also uses the same check so its direct API obeys the same contract.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/BilingualProvider.swift`
+- `Sources/MeetingAgentCore/BilingualSubtitlePipelineOrchestrator.swift`
+- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- `Tests/MeetingAgentCoreTests/BilingualProviderRegistryTests.swift`
+- `Tests/MeetingAgentCoreTests/BilingualSubtitlePipelineOrchestratorTests.swift`
+- `Tests/MeetingAgentCoreTests/LiveCaptionTranslationAdapterTests.swift`
+- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+## Test Plan
+
+- Add unit tests for locale language matching, including case, whitespace, underscore, regional variants, and empty values.
+- Add orchestrator coverage proving text translation providers are not called when `sourceLocale` and `targetLocale` share the same language.
+- Add live caption adapter coverage proving same-language final turns are marked live without provider calls.
+- Add view-model coverage proving same-language live caption scheduling does not instantiate the caption translation provider.
+- Run `make test`.


### PR DESCRIPTION
## Summary

Fixes #43

- Skips text translation when source and target locale identifiers share the same language.
- Preserves source-only bilingual subtitle output for same-language export paths.
- Marks same-language live captions complete without constructing or calling hosted translation providers.
- Handles main's Deepgram source-language change by comparing detected transcript languages, including bare codes like `ja`, against the configured main language locale.

## Changes

- `Sources/MeetingAgentCore/BilingualProvider.swift` - adds shared same-language locale matching on `TranslationOptions`.
- `Sources/MeetingAgentCore/BilingualSubtitlePipelineOrchestrator.swift` - returns source-only output before provider calls for same-language text translation steps.
- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift` - marks same-language live caption adapter work complete without provider calls.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - completes same-language draft/final caption turns before requesting a caption translation provider.
- `Tests/MeetingAgentCoreTests/*` - adds regression coverage for locale matching, pipeline skip, adapter skip, view-model scheduling skip, and Deepgram detected-language/main-language matching.
- `MISTAKES.md` - records the source-language redefinition lesson.

## Test plan

- [x] Build/lint: `git diff --check` passed
- [x] Unit tests: `make test` passed, 469 tests, coverage gate passed
- [x] Focused regression: `swift test --filter MeetingAgentViewModelTests/testDrainRecordingFramesSkipsCaptionTranslationWhenDetectedLanguageMatchesMainLanguage` passed
- [x] E2E/integration: skipped; no app-level E2E convention for this core translation behavior
- [x] Code review: PASS
