### PR TITLE
feat: reduce transcript startup latency

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -221,3 +221,19 @@ Keep bundle templates in the app source tree for packaging, but add `exclude: ["
 When adding non-source packaging assets under `Sources/`, update both `Package.swift` source scanning rules and `.gitignore` in the same change.
 
 ---
+
+## [46] Keep interim replacement IDs from collapsing later final segments
+
+**Date**: 2026-04-28
+**Category**: logic-error
+
+### What went wrong
+The first Deepgram interim upsert design used one fallback active segment ID for responses without word timings, which let an interim update become final but also caused later unrelated final responses without word timings to overwrite the previous final segment.
+
+### Correct approach
+Use a stateful fallback ID in the streaming transcriber: keep one active fallback ID through interim updates, then advance it after the final segment is written.
+
+### How to avoid
+When using upsert for streaming interim data, test both interim-to-final replacement and multiple final utterances that lack provider timing IDs.
+
+---

--- a/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
@@ -347,6 +347,7 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
     private let writer: TranscriptFileWriter
     private var receiveTask: Task<Void, Never>?
     private var sendFailure: String?
+    private var fallbackSegmentIndex = 0
 
     var failureReason: String? {
         sendFailure
@@ -355,9 +356,9 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
     init(session: DeepgramStreamingTranscriptionSession, writer: TranscriptFileWriter) {
         self.session = session
         self.writer = writer
-        self.receiveTask = Task { [session, writer] in
+        self.receiveTask = Task { [weak self, session] in
             for await segment in session.segments {
-                try? writer.upsert(segment)
+                try? self?.write(segment)
             }
         }
     }
@@ -378,6 +379,32 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
             await session.close()
             try? writer.close()
         }
+    }
+
+    private func write(_ segment: TranscriptSegment) throws {
+        let segment = stableFallbackSegment(segment)
+        try writer.upsert(segment)
+        if segment.isFinal, segment.id.hasSuffix("-stream-active-\(fallbackSegmentIndex)") {
+            fallbackSegmentIndex += 1
+        }
+    }
+
+    private func stableFallbackSegment(_ segment: TranscriptSegment) -> TranscriptSegment {
+        let fallbackID = "\(segment.sourceProvider)-stream-active"
+        guard segment.id == fallbackID else { return segment }
+        return TranscriptSegment(
+            id: "\(fallbackID)-\(fallbackSegmentIndex)",
+            speaker: segment.speaker,
+            startTimeSeconds: segment.startTimeSeconds,
+            endTimeSeconds: segment.endTimeSeconds,
+            text: segment.text,
+            language: segment.language,
+            sourceProvider: segment.sourceProvider,
+            isFinal: segment.isFinal,
+            confidence: segment.confidence,
+            createdAt: segment.createdAt,
+            timingSource: segment.timingSource
+        )
     }
 }
 

--- a/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
@@ -231,7 +231,7 @@ public enum DeepgramStreamingResponseMapper {
         providerID: String
     ) -> [TranscriptSegment] {
         guard let response = try? JSONDecoder.meetingAgent.decode(DeepgramStreamingResponse.self, from: data),
-              response.isFinal == true,
+              let isFinal = response.isFinal,
               let alternative = response.channel?.alternatives.first
         else {
             return []
@@ -243,9 +243,11 @@ public enum DeepgramStreamingResponseMapper {
             guard !text.isEmpty else { return [] }
             return [
                 TranscriptSegment(
+                    id: activeSegmentID(providerID: providerID, words: words),
                     text: text,
                     language: localeIdentifier,
                     sourceProvider: providerID,
+                    isFinal: isFinal,
                     confidence: alternative.confidence
                 )
             ]
@@ -259,16 +261,27 @@ public enum DeepgramStreamingResponseMapper {
             let firstWord = run.words.first
             let lastWord = run.words.last
             return TranscriptSegment(
+                id: activeSegmentID(providerID: providerID, words: run.words),
                 speaker: speaker(for: run.speaker),
                 startTimeSeconds: firstWord?.start,
                 endTimeSeconds: lastWord?.end,
                 text: text,
                 language: localeIdentifier,
                 sourceProvider: providerID,
+                isFinal: isFinal,
                 confidence: alternative.confidence,
                 timingSource: firstWord?.start == nil && lastWord?.end == nil ? .unavailable : .precise
             )
         }
+    }
+
+    private static func activeSegmentID(providerID: String, words: [DeepgramStreamingResponse.Word]) -> String {
+        guard let firstWord = words.first,
+              let start = firstWord.start
+        else {
+            return "\(providerID)-stream-active"
+        }
+        return "\(providerID)-stream-\(start)"
     }
 
     private static func speakerRuns(from words: [DeepgramStreamingResponse.Word]) -> [SpeakerRun] {
@@ -344,7 +357,7 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
         self.writer = writer
         self.receiveTask = Task { [session, writer] in
             for await segment in session.segments {
-                try? writer.append(segment)
+                try? writer.upsert(segment)
             }
         }
     }

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -730,7 +730,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             liveCaptionTurns = []
             return
         }
-        for segment in document.segments where segment.isFinal {
+        for segment in document.segments {
             _ = liveCaptionStore.append(segment)
         }
         liveCaptionTurns = liveCaptionStore.turns

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -16,6 +16,9 @@ public final class MeetingRecorder {
     private var writer: AudioFrameWriting?
     private var transcriber: AudioFrameTranscriber?
     private var diagnosticsTracker: CaptureDiagnosticsTracker?
+    private var pendingTranscriptionFrames: [AudioFrame] = []
+    private var isStartingTranscriber = false
+    private let pendingTranscriptionFrameLimit = 512
 
     public private(set) var state: MeetingRecorderState = .idle
     public weak var realtimeFrameConsumer: RealtimeFrameConsumer?
@@ -91,6 +94,8 @@ public final class MeetingRecorder {
         updatedRecord.transcriptionStatus = .transcribing
         updatedRecord.transcriptionFailureReason = nil
         activeRecord = updatedRecord
+        pendingTranscriptionFrames = []
+        isStartingTranscriber = false
         try store.save(updatedRecord)
 
         let session = captureSessionFactory()
@@ -117,13 +122,19 @@ public final class MeetingRecorder {
 
         if let transcriptURL = updatedRecord.transcriptURL {
             do {
-                transcriber = try await transcriberFactory(
+                isStartingTranscriber = true
+                let startedTranscriber = try await transcriberFactory(
                     effectiveConfiguration,
                     transcriptURL,
                     session.outputSampleRate,
                     session.outputChannelCount
                 )
+                transcriber = startedTranscriber
+                isStartingTranscriber = false
+                try flushPendingTranscriptionFrames()
             } catch {
+                isStartingTranscriber = false
+                pendingTranscriptionFrames = []
                 try markTranscriptionFailed("Speech recognition unavailable: \(error)")
                 transcriber = nil
             }
@@ -144,12 +155,10 @@ public final class MeetingRecorder {
         )
         for frame in frames {
             try writer?.append(frame)
-            do {
-                try transcriber?.append(frame)
-            } catch {
-                try persistTranscriptionFailure("Speech recognition failed: \(error)")
-                transcriber?.finish()
-                transcriber = nil
+            if transcriber != nil {
+                try appendFrameToTranscriber(frame)
+            } else if isStartingTranscriber {
+                bufferPendingTranscriptionFrame(frame)
             }
         }
         deliverFramesToRealtimeConsumerForTesting(frames)
@@ -207,6 +216,31 @@ public final class MeetingRecorder {
 
     private func persistTranscriptionFailure(_ message: String) throws {
         try markTranscriptionFailed(message)
+    }
+
+    private func flushPendingTranscriptionFrames() throws {
+        let frames = pendingTranscriptionFrames
+        pendingTranscriptionFrames = []
+        for frame in frames {
+            try appendFrameToTranscriber(frame)
+        }
+    }
+
+    private func appendFrameToTranscriber(_ frame: AudioFrame) throws {
+        do {
+            try transcriber?.append(frame)
+        } catch {
+            try persistTranscriptionFailure("Speech recognition failed: \(error)")
+            transcriber?.finish()
+            transcriber = nil
+        }
+    }
+
+    private func bufferPendingTranscriptionFrame(_ frame: AudioFrame) {
+        pendingTranscriptionFrames.append(frame)
+        if pendingTranscriptionFrames.count > pendingTranscriptionFrameLimit {
+            pendingTranscriptionFrames.removeFirst(pendingTranscriptionFrames.count - pendingTranscriptionFrameLimit)
+        }
     }
 
     private func markTranscriptionFailed(_ message: String) throws {

--- a/Sources/MeetingAgentCore/TranscriptFileWriter.swift
+++ b/Sources/MeetingAgentCore/TranscriptFileWriter.swift
@@ -34,6 +34,17 @@ public final class TranscriptFileWriter {
         try replace(with: document.segments)
     }
 
+    public func upsert(_ segment: TranscriptSegment) throws {
+        guard !isClosed else { return }
+        var document = try Self.readDocument(from: structuredURL)
+        if let index = document.segments.firstIndex(where: { $0.id == segment.id }) {
+            document.segments[index] = segment
+        } else {
+            document.segments.append(segment)
+        }
+        try replace(with: document.segments)
+    }
+
     public func close() throws {
         isClosed = true
     }

--- a/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
@@ -210,9 +210,60 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         let document = try TranscriptFileWriter.readDocument(
             from: transcriptURL.deletingPathExtension().appendingPathExtension("json")
         )
-        XCTAssertEqual(document.segments.map(\.id), ["deepgram-transcribe-stream-active"])
+        XCTAssertEqual(document.segments.map(\.id), ["deepgram-transcribe-stream-active-0"])
         XCTAssertEqual(document.segments.map(\.text), ["hello world"])
         XCTAssertEqual(document.segments.map(\.isFinal), [true])
+    }
+
+    func testStreamingProviderAppendsSeparateFinalSegmentsWithoutWordTimings() async throws {
+        let transcriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("deepgram-stream-no-words-\(UUID().uuidString)")
+            .appendingPathExtension("txt")
+        defer {
+            try? FileManager.default.removeItem(at: transcriptURL)
+            try? FileManager.default.removeItem(at: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+        }
+        let session = FakeDeepgramStreamingSession()
+        let client = FakeDeepgramStreamingClient(session: session)
+        let provider = DeepgramStreamingSpeechTranscriptionProvider(
+            configuration: DeepgramTranscriptionConfiguration(apiKey: "key", model: "nova-3"),
+            client: client
+        )
+        let transcriber = try await provider.start(context: SpeechTranscriptionStreamContext(
+            transcriptURL: transcriptURL,
+            localeIdentifier: "en-US",
+            sampleRate: 48_000,
+            channelCount: 1
+        ))
+
+        session.yieldJSON("""
+        {
+          "is_final": true,
+          "channel": {
+            "alternatives": [
+              { "transcript": "first final", "confidence": 0.9, "words": [] }
+            ]
+          }
+        }
+        """)
+        session.yieldJSON("""
+        {
+          "is_final": true,
+          "channel": {
+            "alternatives": [
+              { "transcript": "second final", "confidence": 0.9, "words": [] }
+            ]
+          }
+        }
+        """)
+        try await Task.sleep(nanoseconds: 30_000_000)
+        transcriber.finish()
+
+        let document = try TranscriptFileWriter.readDocument(
+            from: transcriptURL.deletingPathExtension().appendingPathExtension("json")
+        )
+        XCTAssertEqual(document.segments.map(\.text), ["first final", "second final"])
+        XCTAssertEqual(document.segments.map(\.isFinal), [true, true])
     }
 
     func testStreamingResponseKeepsStableIDWhenInterimWordEndTimeChanges() throws {

--- a/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
@@ -139,6 +139,128 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(document.segments.first?.sourceProvider, "deepgram-transcribe")
     }
 
+    func testStreamingResponseMapsInterimTranscriptToNonFinalSegment() throws {
+        let data = Data("""
+        {
+          "is_final": false,
+          "channel": {
+            "alternatives": [
+              { "transcript": "hello interim", "confidence": 0.6, "words": [] }
+            ]
+          }
+        }
+        """.utf8)
+
+        let segments = DeepgramStreamingResponseMapper.segments(
+            from: data,
+            localeIdentifier: "en-US",
+            providerID: "deepgram-transcribe"
+        )
+
+        XCTAssertEqual(segments.count, 1)
+        XCTAssertEqual(segments.first?.id, "deepgram-transcribe-stream-active")
+        XCTAssertEqual(segments.first?.text, "hello interim")
+        XCTAssertEqual(segments.first?.isFinal, false)
+    }
+
+    func testStreamingProviderReplacesInterimSegmentWithFinalSegment() async throws {
+        let transcriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("deepgram-stream-interim-\(UUID().uuidString)")
+            .appendingPathExtension("txt")
+        defer {
+            try? FileManager.default.removeItem(at: transcriptURL)
+            try? FileManager.default.removeItem(at: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+        }
+        let session = FakeDeepgramStreamingSession()
+        let client = FakeDeepgramStreamingClient(session: session)
+        let provider = DeepgramStreamingSpeechTranscriptionProvider(
+            configuration: DeepgramTranscriptionConfiguration(apiKey: "key", model: "nova-3"),
+            client: client
+        )
+        let transcriber = try await provider.start(context: SpeechTranscriptionStreamContext(
+            transcriptURL: transcriptURL,
+            localeIdentifier: "en-US",
+            sampleRate: 48_000,
+            channelCount: 1
+        ))
+
+        session.yieldJSON("""
+        {
+          "is_final": false,
+          "channel": {
+            "alternatives": [
+              { "transcript": "hello", "confidence": 0.6, "words": [] }
+            ]
+          }
+        }
+        """)
+        session.yieldJSON("""
+        {
+          "is_final": true,
+          "channel": {
+            "alternatives": [
+              { "transcript": "hello world", "confidence": 0.9, "words": [] }
+            ]
+          }
+        }
+        """)
+        try await Task.sleep(nanoseconds: 30_000_000)
+        transcriber.finish()
+
+        let document = try TranscriptFileWriter.readDocument(
+            from: transcriptURL.deletingPathExtension().appendingPathExtension("json")
+        )
+        XCTAssertEqual(document.segments.map(\.id), ["deepgram-transcribe-stream-active"])
+        XCTAssertEqual(document.segments.map(\.text), ["hello world"])
+        XCTAssertEqual(document.segments.map(\.isFinal), [true])
+    }
+
+    func testStreamingResponseKeepsStableIDWhenInterimWordEndTimeChanges() throws {
+        let first = DeepgramStreamingResponseMapper.segments(
+            from: Data("""
+            {
+              "is_final": false,
+              "channel": {
+                "alternatives": [
+                  {
+                    "transcript": "hello",
+                    "confidence": 0.6,
+                    "words": [
+                      { "word": "hello", "punctuated_word": "hello", "start": 0.0, "end": 0.4, "speaker": 0 }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.utf8),
+            localeIdentifier: "en-US",
+            providerID: "deepgram-transcribe"
+        )
+        let updated = DeepgramStreamingResponseMapper.segments(
+            from: Data("""
+            {
+              "is_final": false,
+              "channel": {
+                "alternatives": [
+                  {
+                    "transcript": "hello world",
+                    "confidence": 0.7,
+                    "words": [
+                      { "word": "hello", "punctuated_word": "hello", "start": 0.0, "end": 0.4, "speaker": 0 },
+                      { "word": "world", "punctuated_word": "world", "start": 0.4, "end": 0.8, "speaker": 0 }
+                    ]
+                  }
+                ]
+              }
+            }
+            """.utf8),
+            localeIdentifier: "en-US",
+            providerID: "deepgram-transcribe"
+        )
+
+        XCTAssertEqual(first.first?.id, updated.first?.id)
+    }
+
     func testStreamingResponseSplitsFinalTranscriptByConsecutiveDeepgramSpeakers() async throws {
         let transcriptURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("deepgram-stream-speakers-\(UUID().uuidString)")

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -259,6 +259,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
     func testDrainRecordingFramesRefreshesLiveCaptionTurnsFromStructuredTranscript() async throws {
         let fixture = try ViewModelRecorderFixture()
         let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        var translationFactoryCallCount = 0
         let viewModel = MeetingAgentViewModel(
             store: fixture.store,
             recorder: fixture.recorder,
@@ -269,6 +270,10 @@ final class MeetingAgentViewModelTests: XCTestCase {
                 whisperBinaryPath: nil,
                 whisperModelPath: nil
             ),
+            captionTranslationProviderFactory: { _ in
+                translationFactoryCallCount += 1
+                return nil
+            },
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
@@ -281,9 +286,13 @@ final class MeetingAgentViewModelTests: XCTestCase {
 
         viewModel.drainRecordingFrames()
 
-        XCTAssertEqual(viewModel.liveCaptionTurns.map(\.sourceSegmentID), ["segment-1"])
+        XCTAssertEqual(viewModel.liveCaptionTurns.map(\.sourceSegmentID), ["segment-1", "partial"])
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "Confirm launch owner.")
+        XCTAssertEqual(viewModel.liveCaptionTurns.last?.originalText, "partial")
+        XCTAssertEqual(viewModel.liveCaptionTurns.last?.isFinal, false)
+        XCTAssertEqual(viewModel.liveCaptionTurns.last?.translationHealth, .idle)
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.targetLocale, "zh-CN")
+        XCTAssertEqual(translationFactoryCallCount, 1)
     }
 
     func testDrainRecordingFramesTranslatesFinalCaptionsWithConfiguredOpenRouterModel() async throws {

--- a/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
@@ -154,6 +154,28 @@ final class MeetingRecorderTests: XCTestCase {
         XCTAssertTrue(stopped.transcriptionFailureReason?.contains("Speech recognition failed") == true)
     }
 
+    func testDrainFramesBeforeTranscriberReadyFlushesStartupFramesWhenReady() async throws {
+        let fixture = try RecorderFixture()
+        fixture.transcriberFactory.shouldSuspend = true
+        let frame = AudioFrame(pcm: Data([9, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+        let record = try fixture.recorder.prepareRecord(for: fixture.target)
+
+        let startTask = Task {
+            try await fixture.recorder.startRecording(target: fixture.target, record: record)
+        }
+        try await waitFor { fixture.transcriberFactory.requests.count == 1 }
+        fixture.session.frameBuffer.push(frame)
+
+        try fixture.recorder.drainFrames()
+        XCTAssertEqual(fixture.writer.writtenFrames, [frame])
+        XCTAssertEqual(fixture.transcriber.appendedFrames, [])
+
+        fixture.transcriberFactory.resume()
+        try await startTask.value
+
+        XCTAssertEqual(fixture.transcriber.appendedFrames, [frame])
+    }
+
     func testStartRecordingWritesDiagnosticsWhenCaptureStartFails() async throws {
         let fixture = try RecorderFixture()
         fixture.session.startError = ProbeError.coreAudio("start failed")
@@ -300,7 +322,9 @@ private final class FakeRecorderTranscriberFactory {
 
     var requests: [Request] = []
     var error: Error?
+    var shouldSuspend = false
     private let transcriber: FakeAudioFrameTranscriber
+    private var continuation: CheckedContinuation<Void, Never>?
 
     init(transcriber: FakeAudioFrameTranscriber) {
         self.transcriber = transcriber
@@ -317,11 +341,37 @@ private final class FakeRecorderTranscriberFactory {
             sampleRate: sampleRate,
             channelCount: channelCount
         ))
+        if shouldSuspend {
+            await withCheckedContinuation { continuation in
+                self.continuation = continuation
+            }
+        }
         if let error {
             throw error
         }
         return transcriber
     }
+
+    func resume() {
+        shouldSuspend = false
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
+private func waitFor(
+    timeoutNanoseconds: UInt64 = 1_000_000_000,
+    condition: () -> Bool
+) async throws {
+    let interval: UInt64 = 10_000_000
+    let attempts = max(1, Int(timeoutNanoseconds / interval))
+    for _ in 0..<attempts {
+        if condition() {
+            return
+        }
+        try await Task.sleep(nanoseconds: interval)
+    }
+    XCTAssertTrue(condition(), "Timed out waiting for condition")
 }
 
 private func XCTAssertThrowsErrorAsync(

--- a/Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift
@@ -92,6 +92,28 @@ final class TranscriptFileWriterTests: XCTestCase {
         XCTAssertEqual(TranscriptFileWriter.renderedTranscript(textURL: url, structuredURL: jsonURL), "User A:\nstructured text")
     }
 
+    func testUpsertReplacesExistingSegmentWithSameID() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
+        let jsonURL = url.deletingPathExtension().appendingPathExtension("json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: jsonURL)
+        }
+        let writer = try TranscriptFileWriter(url: url)
+
+        try writer.upsert(TranscriptSegment(id: "active", text: "hello", isFinal: false))
+        try writer.upsert(TranscriptSegment(id: "active", text: "hello world", isFinal: true))
+
+        let document = try TranscriptFileWriter.readDocument(from: jsonURL)
+        XCTAssertEqual(document.segments.map(\.id), ["active"])
+        XCTAssertEqual(document.segments.map(\.text), ["hello world"])
+        XCTAssertEqual(document.segments.map(\.isFinal), [true])
+        XCTAssertEqual(
+            try String(contentsOf: url, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
+            "User A:\nhello world"
+        )
+    }
+
     func testUpdateSpeakerLabelRewritesStructuredAndRenderedTranscript() throws {
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
         let jsonURL = url.deletingPathExtension().appendingPathExtension("json")

--- a/docs/superpowers/plans/2026-04-28-transcript-startup-latency.md
+++ b/docs/superpowers/plans/2026-04-28-transcript-startup-latency.md
@@ -1,0 +1,247 @@
+# Transcript Startup Latency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce initial live subtitle delay by rendering Deepgram interim transcript results and preserving startup audio frames until the transcriber is ready.
+
+**Architecture:** Deepgram streaming responses become structured transcript segments as soon as they contain non-empty text. Segment writes use upsert semantics so interim updates replace the active interim row and final responses replace it with durable text. `MeetingRecorder` separately protects early audio frames by buffering transcription-only copies while the async transcriber starts.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, macOS audio capture abstractions.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentCore/TranscriptFileWriter.swift` to add `upsert(_:)`, preserving existing `append(_:)` for callers that need append-only behavior.
+- Modify `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift` to map interim responses, generate stable streaming ids, and call `upsert(_:)`.
+- Modify `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` to feed interim and final segments into `LiveCaptionStore`.
+- Modify `Sources/MeetingAgentCore/MeetingRecorder.swift` to buffer early transcription frames and flush them after transcriber startup.
+- Modify `Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift` for interim mapping and upsert behavior.
+- Modify `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` for interim caption visibility and final-only translation scheduling.
+- Modify `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift` for startup frame buffering.
+
+### Task 1: Transcript Upsert Primitive
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/TranscriptFileWriter.swift`
+- Test: `Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift`
+
+- [ ] **Step 1: Add failing upsert test**
+
+Add this test to `TranscriptFileWriterTests`:
+
+```swift
+func testUpsertReplacesExistingSegmentWithSameID() throws {
+    let url = temporaryURL("transcript-upsert.txt")
+    defer {
+        try? FileManager.default.removeItem(at: url)
+        try? FileManager.default.removeItem(at: url.deletingPathExtension().appendingPathExtension("json"))
+    }
+    let writer = try TranscriptFileWriter(url: url)
+
+    try writer.upsert(TranscriptSegment(id: "active", text: "hello", isFinal: false))
+    try writer.upsert(TranscriptSegment(id: "active", text: "hello world", isFinal: true))
+
+    let document = try TranscriptFileWriter.readDocument(from: url.deletingPathExtension().appendingPathExtension("json"))
+    XCTAssertEqual(document.segments.map(\.id), ["active"])
+    XCTAssertEqual(document.segments.map(\.text), ["hello world"])
+    XCTAssertEqual(document.segments.map(\.isFinal), [true])
+    XCTAssertEqual(try String(contentsOf: url, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines), "hello world")
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `swift test --filter TranscriptFileWriterTests/testUpsertReplacesExistingSegmentWithSameID`
+
+Expected: compile failure because `TranscriptFileWriter` has no `upsert` method.
+
+- [ ] **Step 3: Implement upsert**
+
+Add this method beside `append(_:)`:
+
+```swift
+public func upsert(_ segment: TranscriptSegment) throws {
+    guard !isClosed else { return }
+    var document = try Self.readDocument(from: structuredURL)
+    if let index = document.segments.firstIndex(where: { $0.id == segment.id }) {
+        document.segments[index] = segment
+    } else {
+        document.segments.append(segment)
+    }
+    try replace(with: document.segments)
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `swift test --filter TranscriptFileWriterTests/testUpsertReplacesExistingSegmentWithSameID`
+
+Expected: PASS.
+
+### Task 2: Deepgram Interim Mapping And Streaming Upsert
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift`
+- Test: `Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift`
+
+- [ ] **Step 1: Add failing mapper test**
+
+Add a test proving interim text maps to a non-final segment:
+
+```swift
+func testStreamingResponseMapsInterimTranscriptToNonFinalSegment() throws {
+    let data = Data("""
+    {
+      "is_final": false,
+      "channel": {
+        "alternatives": [
+          { "transcript": "hello interim", "confidence": 0.6, "words": [] }
+        ]
+      }
+    }
+    """.utf8)
+
+    let segments = DeepgramStreamingResponseMapper.segments(
+        from: data,
+        localeIdentifier: "en-US",
+        providerID: "deepgram-transcribe"
+    )
+
+    XCTAssertEqual(segments.count, 1)
+    XCTAssertEqual(segments.first?.text, "hello interim")
+    XCTAssertEqual(segments.first?.isFinal, false)
+}
+```
+
+- [ ] **Step 2: Add failing streaming replacement test**
+
+Extend `testStreamingProviderSendsAudioFramesAndWritesIncomingTranscriptSegments` or add a new test that yields an interim JSON and then a final JSON with the same active result, then asserts the structured transcript contains one final segment with the final text.
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run: `swift test --filter DeepgramStreamingTranscriptionProviderTests`
+
+Expected: interim mapper test fails because interim responses are dropped; replacement test fails because streaming writes append or does not emit interim.
+
+- [ ] **Step 4: Implement interim mapping and upsert**
+
+Change the mapper guard so it accepts `response.isFinal != nil` instead of only `true`, pass `isFinal: response.isFinal == true` to each `TranscriptSegment`, and assign a stable id for active streaming results. For responses without provider ids from Deepgram, use a deterministic id built from provider and timing when available, falling back to `"deepgram-stream-active"`.
+
+In `DeepgramStreamingTranscriber`, replace `writer.append(segment)` with `writer.upsert(segment)`.
+
+- [ ] **Step 5: Run Deepgram tests**
+
+Run: `swift test --filter DeepgramStreamingTranscriptionProviderTests`
+
+Expected: PASS.
+
+### Task 3: Show Interim Captions In ViewModel
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Add failing view model test**
+
+Add a test that writes a structured transcript with `isFinal: false`, calls the existing refresh path through `drainRecordingFrames()`, and asserts `liveCaptionTurns` contains the interim text with `isFinal == false`.
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `swift test --filter MeetingAgentViewModelTests/<new-test-name>`
+
+Expected: FAIL because refresh currently filters `where segment.isFinal`.
+
+- [ ] **Step 3: Implement refresh change**
+
+Change:
+
+```swift
+for segment in document.segments where segment.isFinal {
+    _ = liveCaptionStore.append(segment)
+}
+```
+
+to:
+
+```swift
+for segment in document.segments {
+    _ = liveCaptionStore.append(segment)
+}
+```
+
+- [ ] **Step 4: Run focused test**
+
+Run: `swift test --filter MeetingAgentViewModelTests/<new-test-name>`
+
+Expected: PASS.
+
+### Task 4: Buffer Startup Frames Until Transcriber Ready
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingRecorder.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift`
+
+- [ ] **Step 1: Add failing recorder test**
+
+Add a test that starts recording with a transcriber factory that suspends, pushes and drains a frame before the factory resumes, then resumes the factory and verifies the transcriber received that early frame.
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `swift test --filter MeetingRecorderTests/<new-test-name>`
+
+Expected: FAIL because frames drained before transcriber assignment are not sent to the transcriber.
+
+- [ ] **Step 3: Implement pending transcription frame buffer**
+
+Add private state:
+
+```swift
+private var pendingTranscriptionFrames: [AudioFrame] = []
+private var isStartingTranscriber = false
+private let pendingTranscriptionFrameLimit = 512
+```
+
+Set `isStartingTranscriber = true` before awaiting the transcriber factory. After assignment, set it false and flush pending frames in order with existing failure handling. In `drainFrames()`, if `transcriber` is nil and `isStartingTranscriber` is true, append frames to the pending buffer with oldest-frame dropping at the limit. If startup fails, clear pending frames.
+
+- [ ] **Step 4: Run focused recorder test**
+
+Run: `swift test --filter MeetingRecorderTests/<new-test-name>`
+
+Expected: PASS.
+
+### Task 5: Full Verification And Commit
+
+**Files:**
+- All changed files from previous tasks.
+
+- [ ] **Step 1: Run focused test group**
+
+Run:
+
+```bash
+swift test --filter TranscriptFileWriterTests/testUpsertReplacesExistingSegmentWithSameID
+swift test --filter DeepgramStreamingTranscriptionProviderTests
+swift test --filter MeetingAgentViewModelTests/<new-test-name>
+swift test --filter MeetingRecorderTests/<new-test-name>
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run required project test command**
+
+Run: `make test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/TranscriptFileWriter.swift Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Sources/MeetingAgentCore/MeetingRecorder.swift Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift docs/superpowers/specs/2026-04-28-transcript-startup-latency-design.md docs/superpowers/plans/2026-04-28-transcript-startup-latency.md
+git commit -m "feat: reduce transcript startup latency (#46)"
+```
+
+Expected: commit succeeds.
+

--- a/docs/superpowers/specs/2026-04-28-transcript-startup-latency-design.md
+++ b/docs/superpowers/specs/2026-04-28-transcript-startup-latency-design.md
@@ -1,0 +1,64 @@
+# Transcript Startup Latency Design
+
+## Context
+
+GitHub issue #46 reports that after the app detects a video stream, starts recording, and enters the meeting page, subtitles have an obvious long delay.
+
+The default transcription path is hosted Deepgram streaming. The app requests `interim_results=true`, but the local Deepgram streaming mapper currently drops every response unless `is_final == true`. The meeting UI then refreshes live captions from the structured transcript document. As a result, Deepgram can return early interim text, but the app does not render it until Deepgram emits a final segment. At meeting startup, a speaker may continue talking for several seconds before a final segment appears, creating the visible initial subtitle delay.
+
+There is also a startup protection gap in `MeetingRecorder`: capture starts before the async streaming transcriber finishes connecting. If the app drains audio frames while `transcriber` is still nil, those frames are written to WAV but not sent to transcription.
+
+## Goal
+
+Show the first live captions as soon as the streaming provider emits usable interim transcript text, and preserve early startup audio for transcription while the transcriber connection is still being established.
+
+## Non-Goals
+
+- Do not change the selected default STT provider or model.
+- Do not add a new transcription provider.
+- Do not trigger translation for interim captions.
+- Do not redesign the meeting UI.
+- Do not change export formats beyond avoiding transient interim duplicates in the structured transcript source.
+
+## Selected Approach
+
+### Deepgram Interim Captions
+
+Update `DeepgramStreamingResponseMapper` so non-empty Deepgram responses produce transcript segments for both interim and final messages. Interim segments should be marked `isFinal: false`; final segments remain `isFinal: true`.
+
+Use a stable segment identifier for active Deepgram streaming results so repeated interim updates replace the previous active interim segment instead of accumulating as duplicate transcript rows. When a final response arrives for the same active range, it should replace the interim segment and become the durable final segment.
+
+`LiveCaptionStore` already tracks `isFinal` and only marks final turns as translation-pending. `MeetingAgentViewModel.refreshLiveCaptionTurnsFromSelectedMeeting()` should append interim and final segments so the UI can show interim captions, while translation scheduling remains final-only.
+
+### Startup Transcription Frame Buffer
+
+Update `MeetingRecorder` to keep a small pending transcription frame buffer for frames drained while the recorder has begun capture but the streaming transcriber is not ready yet. WAV writing and realtime frame fan-out continue immediately.
+
+When the transcriber becomes available, flush pending transcription frames to it in order before normal live appends continue. If transcriber startup fails, discard the pending transcription frames and keep the existing behavior: mark transcription failed while preserving WAV recording.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift`
+  - Map interim responses to non-final `TranscriptSegment`s.
+  - Maintain stable active segment IDs for interim-to-final replacement.
+  - Write streaming segments with replacement semantics.
+- `Sources/MeetingAgentCore/TranscriptFileWriter.swift`
+  - Add a segment upsert path that replaces an existing segment with the same id and appends otherwise.
+- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+  - Refresh live caption turns from all transcript segments, not final-only segments.
+- `Sources/MeetingAgentCore/MeetingRecorder.swift`
+  - Buffer frames drained before transcriber startup completes and flush them once ready.
+- `Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift`
+  - Cover interim response mapping, interim replacement, and final replacement.
+- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+  - Cover interim captions becoming visible without scheduling translation.
+- `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift`
+  - Cover startup-drained frames being delivered to the transcriber after it becomes ready.
+
+## Test Plan
+
+- Run focused Deepgram streaming tests for interim mapping and replacement.
+- Run focused view model tests for interim caption visibility.
+- Run focused recorder tests for startup frame buffering.
+- Run `make test`.
+


### PR DESCRIPTION
## Summary

Fixes #46

- Render Deepgram interim transcription results instead of waiting for final segments only.
- Upsert active streaming transcript segments so interim updates refresh in place and final utterances remain distinct.
- Buffer startup audio frames for transcription while the streaming transcriber is connecting.

## Changes

- `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift` - maps interim responses, stabilizes streaming fallback IDs, and upserts streaming segments.
- `Sources/MeetingAgentCore/TranscriptFileWriter.swift` - adds segment upsert support.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - includes interim transcript segments in live captions while translation stays final-only.
- `Sources/MeetingAgentCore/MeetingRecorder.swift` - buffers early transcription frames until transcriber startup completes.
- `Tests/MeetingAgentCoreTests/*` - adds regression coverage for interim captions, upsert replacement, startup frame buffering, and fallback final segment preservation.

## Test plan

- [x] Build/lint: SwiftPM build via `make test`
- [x] Unit tests: `make test` passed, 387 tests
- [x] E2E/integration: skipped; no E2E convention for core transcription latency path
- [x] Code review: errors-fixed, then `make test` passed again
- [x] Manual verification: root cause traced through Deepgram interim filtering and startup transcriber ordering