### PR TITLE
feat: detect Feishu meetings for system audio capture

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -237,3 +237,19 @@ Use a stateful fallback ID in the streaming transcriber: keep one active fallbac
 When using upsert for streaming interim data, test both interim-to-final replacement and multiple final utterances that lack provider timing IDs.
 
 ---
+
+## [48] Apply preferred-target test lessons before writing new tests
+
+**Date**: 2026-04-28
+**Category**: test-mistake
+
+### What went wrong
+The first Feishu display-name sorting regression test used an ordering assertion that was too close to the existing preferred-target test mistake pattern, so manual review had to tighten it after implementation.
+
+### Correct approach
+When `MISTAKES.md` contains a relevant prior lesson, apply it before writing the new test rather than relying on review to catch the repeated pattern.
+
+### How to avoid
+Before adding tests in an area mentioned by `MISTAKES.md`, choose assertions that would fail without the intended behavior and document why.
+
+---

--- a/Sources/MeetingAgentCore/MeetingProcessMonitor.swift
+++ b/Sources/MeetingAgentCore/MeetingProcessMonitor.swift
@@ -13,7 +13,7 @@ public final class MeetingProcessMonitor {
         guard !isRecording else { return [] }
 
         let candidates = targets.filter { target in
-            let isPreferred = target.bundleIdentifier.map(RunningProcessDiscovery.preferredBundleIDs.contains) ?? false
+            let isPreferred = RunningProcessDiscovery.isPreferredMeetingTarget(target)
             guard isPreferred else { return false }
             guard target.isAudioOutputActive else { return false }
             guard !promptedProcessIDs.contains(target.processID) else { return false }

--- a/Sources/MeetingAgentCore/RunningProcessDiscovery.swift
+++ b/Sources/MeetingAgentCore/RunningProcessDiscovery.swift
@@ -15,6 +15,12 @@ public struct RunningProcessDiscovery {
         "com.tencent.meeting"
     ]
 
+    private static let preferredDisplayNamePrefixes = [
+        "feishu",
+        "飞书",
+        "lark"
+    ]
+
     public static func currentTargets() -> [AudioCaptureTarget] {
         let apps = NSWorkspace.shared.runningApplications.map {
             RunningAppSnapshot(
@@ -46,8 +52,8 @@ public struct RunningProcessDiscovery {
             )
         }
         .sorted { lhs, rhs in
-            let lhsPreferred = lhs.bundleIdentifier.map(preferredBundleIDs.contains) ?? false
-            let rhsPreferred = rhs.bundleIdentifier.map(preferredBundleIDs.contains) ?? false
+            let lhsPreferred = isPreferredMeetingTarget(lhs)
+            let rhsPreferred = isPreferredMeetingTarget(rhs)
 
             if lhsPreferred != rhsPreferred {
                 return lhsPreferred && !rhsPreferred
@@ -59,8 +65,21 @@ public struct RunningProcessDiscovery {
 
     public static func automaticTarget(from targets: [AudioCaptureTarget]) -> AudioCaptureTarget? {
         targets.first { target in
-            (target.bundleIdentifier.map(preferredBundleIDs.contains) ?? false)
-                && target.isAudioOutputActive
+            isPreferredMeetingTarget(target) && target.isAudioOutputActive
+        }
+    }
+
+    public static func isPreferredMeetingTarget(_ target: AudioCaptureTarget) -> Bool {
+        if target.bundleIdentifier.map(preferredBundleIDs.contains) ?? false {
+            return true
+        }
+
+        let displayName = target.displayName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        return preferredDisplayNamePrefixes.contains { prefix in
+            displayName == prefix || displayName.hasPrefix("\(prefix) ")
         }
     }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift
@@ -81,6 +81,20 @@ final class MeetingProcessMonitorTests: XCTestCase {
         XCTAssertEqual(candidates, [feishu])
     }
 
+    func testDetectsFeishuDisplayNameWhenAudioOutputIsActive() {
+        let feishu = AudioCaptureTarget(
+            processID: 321,
+            displayName: "飞书",
+            bundleIdentifier: "com.unknown.desktop",
+            isAudioOutputActive: true
+        )
+        let monitor = MeetingProcessMonitor()
+
+        let candidates = monitor.detectNewCandidates(in: [feishu], isRecording: false)
+
+        XCTAssertEqual(candidates, [feishu])
+    }
+
     func testDetectsRunningProcessIDFromTargets() {
         let monitor = MeetingProcessMonitor()
         let zoom = AudioCaptureTarget(processID: 123, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")

--- a/Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift
+++ b/Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift
@@ -78,6 +78,36 @@ final class RunningProcessDiscoveryTests: XCTestCase {
         XCTAssertEqual(selected?.processID, 201)
     }
 
+    func testFeishuDisplayNameSortsBeforeOtherAppsWithoutKnownBundleIdentifier() {
+        let apps = [
+            RunningAppSnapshot(processID: 200, displayName: "Aardvark", bundleIdentifier: "com.example.aardvark"),
+            RunningAppSnapshot(processID: 201, displayName: "Feishu", bundleIdentifier: "com.unknown.desktop")
+        ]
+
+        let targets = RunningProcessDiscovery.targets(from: apps, currentProcessID: 999)
+
+        XCTAssertEqual(targets.map(\.displayName), ["Feishu", "Aardvark"])
+    }
+
+    func testAutomaticallySelectsLarkDisplayNameOnlyWhenAudioOutputIsActive() {
+        let inactiveLark = AudioCaptureTarget(
+            processID: 201,
+            displayName: "Lark Meeting",
+            bundleIdentifier: "com.unknown.desktop",
+            isAudioOutputActive: false
+        )
+        let activeLark = AudioCaptureTarget(
+            processID: 202,
+            displayName: "Lark",
+            bundleIdentifier: nil,
+            isAudioOutputActive: true
+        )
+
+        let selected = RunningProcessDiscovery.automaticTarget(from: [inactiveLark, activeLark])
+
+        XCTAssertEqual(selected?.processID, 202)
+    }
+
     func testAutomaticallySelectsFirstPreferredTarget() {
         let targets = [
             AudioCaptureTarget(processID: 200, displayName: "Notes", bundleIdentifier: "com.apple.Notes"),

--- a/docs/superpowers/plans/2026-04-28-feishu-system-audio-capture.md
+++ b/docs/superpowers/plans/2026-04-28-feishu-system-audio-capture.md
@@ -1,0 +1,82 @@
+# Feishu System Audio Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Meeting Agent detect Feishu/Lark desktop meetings as system-audio capture targets.
+
+**Architecture:** Keep capture, recording, STT, subtitles, translation, summaries, and exports unchanged. Centralize preferred meeting-target classification in `RunningProcessDiscovery` and use it from process sorting, automatic target selection, and prompt detection.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, macOS process discovery via `NSWorkspace` and Core Audio activity checks.
+
+---
+
+### Task 1: Add Feishu/Lark Classification Tests
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift`
+
+- [ ] **Step 1: Write failing process-discovery tests**
+
+Add tests asserting that display-name-only Feishu/Lark targets are treated as preferred targets and still require active audio for automatic selection.
+
+- [ ] **Step 2: Run focused tests to verify RED**
+
+Run: `swift test --filter RunningProcessDiscoveryTests`
+
+Expected: at least one new test fails because unknown-bundle Feishu/Lark names are not preferred yet.
+
+- [ ] **Step 3: Write failing prompt-detection test**
+
+Add a `MeetingProcessMonitorTests` case asserting that an active `飞书` target with an unknown bundle ID is detected as a new candidate.
+
+- [ ] **Step 4: Run focused tests to verify RED**
+
+Run: `swift test --filter MeetingProcessMonitorTests`
+
+Expected: the new Feishu display-name prompt test fails because prompt detection currently checks only preferred bundle IDs.
+
+### Task 2: Centralize Preferred Target Classification
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/RunningProcessDiscovery.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingProcessMonitor.swift`
+
+- [ ] **Step 1: Add `isPreferredMeetingTarget`**
+
+Implement `RunningProcessDiscovery.isPreferredMeetingTarget(_:)` using known bundle IDs first, then exact or prefix display-name matches for `Feishu`, `飞书`, and `Lark`.
+
+- [ ] **Step 2: Use the helper everywhere**
+
+Replace direct `preferredBundleIDs.contains` checks in sorting, automatic target selection, and `MeetingProcessMonitor.detectNewCandidates` with the helper.
+
+- [ ] **Step 3: Run focused tests to verify GREEN**
+
+Run:
+
+```bash
+swift test --filter RunningProcessDiscoveryTests
+swift test --filter MeetingProcessMonitorTests
+```
+
+Expected: both focused suites pass.
+
+### Task 3: Full Verification And Commit
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run required verification**
+
+Run: `make test`
+
+Expected: command exits 0 with repository coverage checks passing.
+
+- [ ] **Step 2: Commit**
+
+Commit source, tests, spec, and plan with:
+
+```bash
+git add Sources/MeetingAgentCore/RunningProcessDiscovery.swift Sources/MeetingAgentCore/MeetingProcessMonitor.swift Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift docs/superpowers/specs/2026-04-28-feishu-system-audio-capture-design.md docs/superpowers/plans/2026-04-28-feishu-system-audio-capture.md
+git commit -m "feat: detect Feishu meetings for system audio capture (#48)"
+```

--- a/docs/superpowers/specs/2026-04-28-feishu-system-audio-capture-design.md
+++ b/docs/superpowers/specs/2026-04-28-feishu-system-audio-capture-design.md
@@ -1,0 +1,34 @@
+# Feishu System Audio Capture Design
+
+GitHub issue #48 asks Meeting Agent to listen to Feishu meetings. The confirmed scope is the same system audio capture path already used for Zoom, Teams, browsers, and Tencent Meeting. This is not a Feishu Open Platform integration.
+
+## Intent
+
+When the Feishu or Lark desktop app is producing meeting audio, Meeting Agent should treat that process as a meeting capture target, prompt the user, and then reuse the existing `AudioCaptureSession`, `MeetingRecorder`, transcription, bilingual subtitle, translation, summary, and export workflows.
+
+## Requirements
+
+- Prefer native Feishu and Lark desktop app processes during running-process discovery.
+- Prompt only when the process has active audio output, matching the current meeting app behavior.
+- Keep non-audio Feishu/Lark processes from prompting.
+- Preserve the existing recorder and transcription pipeline unchanged.
+- Add regression coverage for bundle-ID and display-name based Feishu/Lark detection.
+
+## Non-Requirements
+
+- Do not add Feishu API, OAuth, bot, calendar, or meeting-record integration.
+- Do not add a new capture backend.
+- Do not change meeting persistence formats.
+- Do not weaken active-audio gating for preferred meeting apps.
+
+## Approach
+
+Add a small classification helper in `RunningProcessDiscovery` so preferred meeting targets are recognized by either known bundle identifier or tightly-scoped Feishu/Lark display names. `targets(from:currentProcessID:)`, `automaticTarget(from:)`, and `MeetingProcessMonitor.detectNewCandidates` should all use the same helper so sorting, automatic target selection, and prompt detection stay consistent.
+
+Known bundle identifiers already include `com.larksuite.Lark` and `com.electron.larkFeishu`. The fallback should match display names such as `Feishu`, `飞书`, `Lark`, and `Lark Meeting`, but should avoid broad substring matching that could promote unrelated helper apps.
+
+## Testing
+
+- Add `RunningProcessDiscovery` tests showing Feishu/Lark display names sort before non-meeting apps and automatically select only when audio is active.
+- Add `MeetingProcessMonitor` tests showing an active Feishu/Lark display-name target prompts even with an unknown bundle ID.
+- Run `make test` as the required repository verification command.


### PR DESCRIPTION
## Summary

Fixes #48

- Detect Feishu/Lark desktop meeting targets through the existing system audio capture flow.
- Centralize preferred meeting target classification for sorting, automatic selection, and prompt detection.
- Document the feature design and implementation plan.

## Changes

- `Sources/MeetingAgentCore/RunningProcessDiscovery.swift` - adds shared preferred target classification with known bundle IDs and constrained Feishu/Lark display-name fallback.
- `Sources/MeetingAgentCore/MeetingProcessMonitor.swift` - uses the shared classifier while preserving active-audio gating.
- `Tests/MeetingAgentCoreTests/RunningProcessDiscoveryTests.swift` - covers display-name based Feishu/Lark sorting and automatic selection.
- `Tests/MeetingAgentCoreTests/MeetingProcessMonitorTests.swift` - covers active Feishu prompt detection with an unknown bundle ID.
- `docs/superpowers/specs/2026-04-28-feishu-system-audio-capture-design.md` and `docs/superpowers/plans/2026-04-28-feishu-system-audio-capture.md` - record design and plan.
- `MISTAKES.md` - records the repeated test-design lesson.

## Test plan

- [x] Build/lint: `make test` passed
- [x] Unit tests: `swift test --filter RunningProcessDiscoveryTests`, `swift test --filter MeetingProcessMonitorTests`, and `make test` passed
- [x] E2E/integration: skipped; no E2E convention for process classification
- [x] Code review: PASS after manual Swift review and test tightening
- [x] Manual verification: not applicable; no local Feishu/Lark app installed to inspect