### PR TITLE
fix: preserve startup audio for Deepgram replay

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -253,3 +253,19 @@ When `MISTAKES.md` contains a relevant prior lesson, apply it before writing the
 Before adding tests in an area mentioned by `MISTAKES.md`, choose assertions that would fail without the intended behavior and document why.
 
 ---
+
+## [52] Do not publish capture sessions before consumers are ready
+
+**Date**: 2026-04-28
+**Category**: logic-error
+
+### What went wrong
+The first startup replay implementation focused on the Deepgram connection delay but left `captureSession` visible to the app drain loop before the WAV writer and startup spool state were ready.
+
+### Correct approach
+Start Core Audio capture first, but expose the session to drain callers only after local writing and startup transcription buffering have been initialized.
+
+### How to avoid
+When a producer starts before its consumers, test the exact window where external drain or poll loops can observe partially initialized state.
+
+---

--- a/Sources/MeetingAgentCore/CaptureDiagnostics.swift
+++ b/Sources/MeetingAgentCore/CaptureDiagnostics.swift
@@ -27,6 +27,9 @@ public struct CaptureDiagnostics: Codable, Equatable {
     public let silentDurationSeconds: Double
     public let bufferBacklog: Int
     public let droppedFrameCount: Int
+    public let startupReplayFrameCount: Int
+    public let startupReplayDurationSeconds: Double
+    public let startupReplayDroppedFrameCount: Int
     public let targetProcessID: pid_t
     public let targetDisplayName: String
     public let endedReason: CaptureEndedReason?
@@ -43,6 +46,9 @@ public struct CaptureDiagnostics: Codable, Equatable {
         silentDurationSeconds: Double,
         bufferBacklog: Int,
         droppedFrameCount: Int,
+        startupReplayFrameCount: Int = 0,
+        startupReplayDurationSeconds: Double = 0,
+        startupReplayDroppedFrameCount: Int = 0,
         targetProcessID: pid_t,
         targetDisplayName: String,
         endedReason: CaptureEndedReason?,
@@ -58,10 +64,56 @@ public struct CaptureDiagnostics: Codable, Equatable {
         self.silentDurationSeconds = silentDurationSeconds
         self.bufferBacklog = bufferBacklog
         self.droppedFrameCount = droppedFrameCount
+        self.startupReplayFrameCount = startupReplayFrameCount
+        self.startupReplayDurationSeconds = startupReplayDurationSeconds
+        self.startupReplayDroppedFrameCount = startupReplayDroppedFrameCount
         self.targetProcessID = targetProcessID
         self.targetDisplayName = targetDisplayName
         self.endedReason = endedReason
         self.status = status
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case framesCaptured
+        case durationSeconds
+        case lastFrameAt
+        case sampleRate
+        case channelCount
+        case averageLevel
+        case peakLevel
+        case silentDurationSeconds
+        case bufferBacklog
+        case droppedFrameCount
+        case startupReplayFrameCount
+        case startupReplayDurationSeconds
+        case startupReplayDroppedFrameCount
+        case targetProcessID
+        case targetDisplayName
+        case endedReason
+        case status
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            framesCaptured: try container.decode(Int.self, forKey: .framesCaptured),
+            durationSeconds: try container.decode(Double.self, forKey: .durationSeconds),
+            lastFrameAt: try container.decodeIfPresent(Date.self, forKey: .lastFrameAt),
+            sampleRate: try container.decode(Double.self, forKey: .sampleRate),
+            channelCount: try container.decode(Int.self, forKey: .channelCount),
+            averageLevel: try container.decode(Double.self, forKey: .averageLevel),
+            peakLevel: try container.decode(Double.self, forKey: .peakLevel),
+            silentDurationSeconds: try container.decode(Double.self, forKey: .silentDurationSeconds),
+            bufferBacklog: try container.decode(Int.self, forKey: .bufferBacklog),
+            droppedFrameCount: try container.decode(Int.self, forKey: .droppedFrameCount),
+            startupReplayFrameCount: try container.decodeIfPresent(Int.self, forKey: .startupReplayFrameCount) ?? 0,
+            startupReplayDurationSeconds: try container.decodeIfPresent(Double.self, forKey: .startupReplayDurationSeconds) ?? 0,
+            startupReplayDroppedFrameCount: try container.decodeIfPresent(Int.self, forKey: .startupReplayDroppedFrameCount) ?? 0,
+            targetProcessID: try container.decode(pid_t.self, forKey: .targetProcessID),
+            targetDisplayName: try container.decode(String.self, forKey: .targetDisplayName),
+            endedReason: try container.decodeIfPresent(CaptureEndedReason.self, forKey: .endedReason),
+            status: try container.decode(CaptureStatus.self, forKey: .status)
+        )
     }
 
     public func write(to url: URL) throws {
@@ -85,6 +137,9 @@ public final class CaptureDiagnosticsTracker {
     private var silentDurationSeconds = 0.0
     private var bufferBacklog = 0
     private var droppedFrameCount = 0
+    private var startupReplayFrameCount = 0
+    private var startupReplayDurationSeconds = 0.0
+    private var startupReplayDroppedFrameCount = 0
     private var endedReason: CaptureEndedReason?
     private var status: CaptureStatus = .preparingCapture
 
@@ -132,6 +187,20 @@ public final class CaptureDiagnosticsTracker {
         }
     }
 
+    public func recordStartupReplay(frames: [AudioFrame]) {
+        startupReplayFrameCount += frames.count
+        for frame in frames {
+            let sampleCount = frame.pcm.count / MemoryLayout<Int16>.size
+            guard sampleCount > 0, frame.sampleRate > 0 else { continue }
+            let sampleFrames = sampleCount / max(1, frame.channelCount)
+            startupReplayDurationSeconds += Double(sampleFrames) / frame.sampleRate
+        }
+    }
+
+    public func recordDroppedStartupReplayFrames(_ count: Int) {
+        startupReplayDroppedFrameCount += max(0, count)
+    }
+
     public func finish(endedReason: CaptureEndedReason) {
         guard self.endedReason == nil else { return }
         self.endedReason = endedReason
@@ -163,6 +232,9 @@ public final class CaptureDiagnosticsTracker {
             silentDurationSeconds: silentDurationSeconds,
             bufferBacklog: bufferBacklog,
             droppedFrameCount: droppedFrameCount,
+            startupReplayFrameCount: startupReplayFrameCount,
+            startupReplayDurationSeconds: startupReplayDurationSeconds,
+            startupReplayDroppedFrameCount: startupReplayDroppedFrameCount,
             targetProcessID: target.processID,
             targetDisplayName: target.displayName,
             endedReason: endedReason,

--- a/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
@@ -355,17 +355,25 @@ public struct DeepgramStreamingSpeechTranscriptionProvider {
 final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
     private let session: DeepgramStreamingTranscriptionSession
     private let writer: TranscriptFileWriter
+    private let sendQueue: DeepgramFrameSendQueue
+    private let failureLock = NSLock()
     private var receiveTask: Task<Void, Never>?
     private var sendFailure: String?
     private var fallbackSegmentIndex = 0
 
     var failureReason: String? {
-        sendFailure
+        failureLock.lock()
+        defer { failureLock.unlock() }
+        return sendFailure
     }
 
     init(session: DeepgramStreamingTranscriptionSession, writer: TranscriptFileWriter) {
         self.session = session
         self.writer = writer
+        self.sendQueue = DeepgramFrameSendQueue(session: session)
+        self.sendQueue.onFailure = { [weak self] error in
+            self?.recordSendFailure(error)
+        }
         self.receiveTask = Task { [weak self, session] in
             for await segment in session.segments {
                 try? self?.write(segment)
@@ -374,18 +382,13 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
     }
 
     func append(_ frame: AudioFrame) throws {
-        Task { [session] in
-            do {
-                try await session.send(frame)
-            } catch {
-                self.sendFailure = "Deepgram streaming transcription failed: \(error)"
-            }
-        }
+        sendQueue.append(frame)
     }
 
     func finish() {
         receiveTask?.cancel()
-        Task { [session, writer] in
+        Task { [sendQueue, session, writer] in
+            await sendQueue.finish()
             await session.close()
             try? writer.close()
         }
@@ -415,6 +418,93 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
             createdAt: segment.createdAt,
             timingSource: segment.timingSource
         )
+    }
+
+    private func recordSendFailure(_ error: Error) {
+        failureLock.lock()
+        sendFailure = "Deepgram streaming transcription failed: \(error)"
+        failureLock.unlock()
+    }
+}
+
+private final class DeepgramFrameSendQueue {
+    private let session: DeepgramStreamingTranscriptionSession
+    private let lock = NSLock()
+    private var frames: [AudioFrame] = []
+    private var isSending = false
+    private var isFinishing = false
+    var onFailure: ((Error) -> Void)?
+
+    init(session: DeepgramStreamingTranscriptionSession) {
+        self.session = session
+    }
+
+    func append(_ frame: AudioFrame) {
+        var shouldStartSending = false
+        lock.lock()
+        if !isFinishing {
+            frames.append(frame)
+            if !isSending {
+                isSending = true
+                shouldStartSending = true
+            }
+        }
+        lock.unlock()
+
+        if shouldStartSending {
+            Task { await drain() }
+        }
+    }
+
+    func finish() async {
+        markFinishing()
+
+        while true {
+            if isDrained { return }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+    }
+
+    private func markFinishing() {
+        lock.lock()
+        isFinishing = true
+        lock.unlock()
+    }
+
+    private var isDrained: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return frames.isEmpty && !isSending
+    }
+
+    private func drain() async {
+        while let frame = nextFrame() {
+            do {
+                try await session.send(frame)
+            } catch {
+                onFailure?(error)
+                clearAfterFailure()
+                return
+            }
+        }
+    }
+
+    private func nextFrame() -> AudioFrame? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !frames.isEmpty else {
+            isSending = false
+            return nil
+        }
+        return frames.removeFirst()
+    }
+
+    private func clearAfterFailure() {
+        lock.lock()
+        frames.removeAll()
+        isSending = false
+        isFinishing = true
+        lock.unlock()
     }
 }
 

--- a/Sources/MeetingAgentCore/MeetingExportService.swift
+++ b/Sources/MeetingAgentCore/MeetingExportService.swift
@@ -122,6 +122,9 @@ public struct MeetingExportService {
                 "- Peak level: \(format(diagnostics.peakLevel))",
                 "- Silent duration seconds: \(format(diagnostics.silentDurationSeconds))",
                 "- Dropped frames: \(diagnostics.droppedFrameCount)",
+                "- Startup replay frames: \(diagnostics.startupReplayFrameCount)",
+                "- Startup replay duration seconds: \(format(diagnostics.startupReplayDurationSeconds))",
+                "- Startup replay dropped frames: \(diagnostics.startupReplayDroppedFrameCount)",
                 ""
             ])
         } else {

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -18,7 +18,8 @@ public final class MeetingRecorder {
     private var diagnosticsTracker: CaptureDiagnosticsTracker?
     private var pendingTranscriptionFrames: [AudioFrame] = []
     private var isStartingTranscriber = false
-    private let pendingTranscriptionFrameLimit = 512
+    // Keep roughly 30 seconds of common 10 ms Core Audio callbacks while hosted STT connects.
+    private let pendingTranscriptionFrameLimit = 3_000
 
     public private(set) var state: MeetingRecorderState = .idle
     public weak var realtimeFrameConsumer: RealtimeFrameConsumer?
@@ -121,23 +122,33 @@ public final class MeetingRecorder {
             try diagnosticsTracker?.snapshot().writeIfPossible(to: updatedRecord.diagnosticsURL)
             throw error
         }
-        captureSession = session
         diagnosticsTracker?.markRecording(
             sampleRate: session.outputSampleRate,
             channelCount: session.outputChannelCount
         )
 
-        if let audioURL = updatedRecord.audioURL {
-            writer = try wavWriterFactory(
-                audioURL,
-                UInt32(session.outputSampleRate.rounded()),
-                UInt16(session.outputChannelCount)
-            )
+        do {
+            if let audioURL = updatedRecord.audioURL {
+                writer = try wavWriterFactory(
+                    audioURL,
+                    UInt32(session.outputSampleRate.rounded()),
+                    UInt16(session.outputChannelCount)
+                )
+            }
+
+            if updatedRecord.transcriptURL != nil {
+                isStartingTranscriber = true
+            }
+            captureSession = session
+        } catch {
+            session.stop()
+            diagnosticsTracker?.finish(endedReason: .captureFailed)
+            try diagnosticsTracker?.snapshot().writeIfPossible(to: updatedRecord.diagnosticsURL)
+            throw error
         }
 
         if let transcriptURL = updatedRecord.transcriptURL {
             do {
-                isStartingTranscriber = true
                 let startedTranscriber = try await transcriberFactory(
                     effectiveConfiguration,
                     transcriptURL,
@@ -236,6 +247,7 @@ public final class MeetingRecorder {
     private func flushPendingTranscriptionFrames() throws {
         let frames = pendingTranscriptionFrames
         pendingTranscriptionFrames = []
+        diagnosticsTracker?.recordStartupReplay(frames: frames)
         for frame in frames {
             try appendFrameToTranscriber(frame)
         }
@@ -254,7 +266,9 @@ public final class MeetingRecorder {
     private func bufferPendingTranscriptionFrame(_ frame: AudioFrame) {
         pendingTranscriptionFrames.append(frame)
         if pendingTranscriptionFrames.count > pendingTranscriptionFrameLimit {
-            pendingTranscriptionFrames.removeFirst(pendingTranscriptionFrames.count - pendingTranscriptionFrameLimit)
+            let overflow = pendingTranscriptionFrames.count - pendingTranscriptionFrameLimit
+            pendingTranscriptionFrames.removeFirst(overflow)
+            diagnosticsTracker?.recordDroppedStartupReplayFrames(overflow)
         }
     }
 

--- a/Tests/MeetingAgentCoreTests/CaptureDiagnosticsTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptureDiagnosticsTests.swift
@@ -31,10 +31,37 @@ final class CaptureDiagnosticsTests: XCTestCase {
         XCTAssertEqual(diagnostics.silentDurationSeconds, 0)
         XCTAssertEqual(diagnostics.bufferBacklog, 3)
         XCTAssertEqual(diagnostics.droppedFrameCount, 2)
+        XCTAssertEqual(diagnostics.startupReplayFrameCount, 0)
+        XCTAssertEqual(diagnostics.startupReplayDurationSeconds, 0)
+        XCTAssertEqual(diagnostics.startupReplayDroppedFrameCount, 0)
         XCTAssertEqual(diagnostics.targetProcessID, 42)
         XCTAssertEqual(diagnostics.targetDisplayName, "Google Chrome")
         XCTAssertEqual(diagnostics.endedReason, .saved)
         XCTAssertEqual(diagnostics.status, .recordingSaved)
+    }
+
+    func testDiagnosticsTrackStartupReplayFrames() {
+        let tracker = CaptureDiagnosticsTracker(
+            target: AudioCaptureTarget(
+                processID: 42,
+                displayName: "Google Chrome",
+                bundleIdentifier: "com.google.Chrome"
+            )
+        )
+        let frame = AudioFrame(
+            pcm: int16PCM([1, 2, 3, 4]),
+            sampleRate: 8_000,
+            channelCount: 2,
+            timestampNanos: 1
+        )
+
+        tracker.recordStartupReplay(frames: [frame])
+        tracker.recordDroppedStartupReplayFrames(3)
+
+        let diagnostics = tracker.snapshot()
+        XCTAssertEqual(diagnostics.startupReplayFrameCount, 1)
+        XCTAssertEqual(diagnostics.startupReplayDurationSeconds, 2.0 / 8_000.0, accuracy: 0.000001)
+        XCTAssertEqual(diagnostics.startupReplayDroppedFrameCount, 3)
     }
 
     func testDiagnosticsMarkSilentCapturedAudio() {
@@ -129,6 +156,32 @@ final class CaptureDiagnosticsTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let decoded = try JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
         XCTAssertEqual(decoded, diagnostics)
+    }
+
+    func testDiagnosticsDecodesLegacyJSONWithoutStartupReplayFields() throws {
+        let data = Data("""
+        {
+          "framesCaptured": 10,
+          "durationSeconds": 0.1,
+          "sampleRate": 48000,
+          "channelCount": 1,
+          "averageLevel": 0.2,
+          "peakLevel": 0.8,
+          "silentDurationSeconds": 0,
+          "bufferBacklog": 0,
+          "droppedFrameCount": 0,
+          "targetProcessID": 99,
+          "targetDisplayName": "Google Chrome",
+          "endedReason": "saved",
+          "status": "recordingSaved"
+        }
+        """.utf8)
+
+        let decoded = try JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
+
+        XCTAssertEqual(decoded.startupReplayFrameCount, 0)
+        XCTAssertEqual(decoded.startupReplayDurationSeconds, 0)
+        XCTAssertEqual(decoded.startupReplayDroppedFrameCount, 0)
     }
 
     private func int16PCM(_ samples: [Int16]) -> Data {

--- a/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
@@ -263,6 +263,43 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(document.segments.map(\.isFinal), [true, true])
     }
 
+    func testStreamingTranscriberSendsAudioFramesSerially() async throws {
+        let transcriptURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("deepgram-stream-serial-send-\(UUID().uuidString)")
+            .appendingPathExtension("txt")
+        defer {
+            try? FileManager.default.removeItem(at: transcriptURL)
+            try? FileManager.default.removeItem(at: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+        }
+        let session = FakeDeepgramStreamingSession()
+        session.suspendedFramePCM = Data([1])
+        let client = FakeDeepgramStreamingClient(session: session)
+        let provider = DeepgramStreamingSpeechTranscriptionProvider(
+            configuration: DeepgramTranscriptionConfiguration(apiKey: "key", model: "nova-3"),
+            client: client
+        )
+        let transcriber = try await provider.start(context: SpeechTranscriptionStreamContext(
+            transcriptURL: transcriptURL,
+            localeIdentifier: "en-US",
+            sampleRate: 48_000,
+            channelCount: 1
+        ))
+        let first = AudioFrame(pcm: Data([1]), sampleRate: 48_000, channelCount: 1, timestampNanos: 1)
+        let second = AudioFrame(pcm: Data([2]), sampleRate: 48_000, channelCount: 1, timestampNanos: 2)
+
+        try transcriber.append(first)
+        try transcriber.append(second)
+        try await waitFor { session.isSuspendingFrame }
+
+        XCTAssertEqual(session.sentFrames, [])
+
+        session.resumeSuspendedSend()
+        try await waitFor { session.sentFrames.count == 2 }
+        transcriber.finish()
+
+        XCTAssertEqual(session.sentFrames, [first, second])
+    }
+
     func testStreamingResponseKeepsStableIDWhenInterimWordEndTimeChanges() throws {
         let first = DeepgramStreamingResponseMapper.segments(
             from: Data("""
@@ -473,7 +510,13 @@ private final class FakeDeepgramStreamingClient: DeepgramStreamingTranscriptionC
 private final class FakeDeepgramStreamingSession: DeepgramStreamingTranscriptionSession {
     private var continuation: AsyncStream<TranscriptSegment>.Continuation?
     private(set) var sentFrames: [AudioFrame] = []
+    var suspendedFramePCM: Data?
+    private var suspendedSendContinuation: CheckedContinuation<Void, Never>?
     let segments: AsyncStream<TranscriptSegment>
+
+    var isSuspendingFrame: Bool {
+        suspendedSendContinuation != nil
+    }
 
     init() {
         var streamContinuation: AsyncStream<TranscriptSegment>.Continuation!
@@ -484,7 +527,17 @@ private final class FakeDeepgramStreamingSession: DeepgramStreamingTranscription
     }
 
     func send(_ frame: AudioFrame) async throws {
+        if frame.pcm == suspendedFramePCM {
+            await withCheckedContinuation { continuation in
+                suspendedSendContinuation = continuation
+            }
+        }
         sentFrames.append(frame)
+    }
+
+    func resumeSuspendedSend() {
+        suspendedSendContinuation?.resume()
+        suspendedSendContinuation = nil
     }
 
     func close() async {
@@ -503,4 +556,19 @@ private final class FakeDeepgramStreamingSession: DeepgramStreamingTranscription
             continuation?.yield(segment)
         }
     }
+}
+
+private func waitFor(
+    timeoutNanoseconds: UInt64 = 1_000_000_000,
+    condition: () -> Bool
+) async throws {
+    let interval: UInt64 = 10_000_000
+    let attempts = max(1, Int(timeoutNanoseconds / interval))
+    for _ in 0..<attempts {
+        if condition() {
+            return
+        }
+        try await Task.sleep(nanoseconds: interval)
+    }
+    XCTAssertTrue(condition(), "Timed out waiting for condition")
 }

--- a/Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift
@@ -159,6 +159,7 @@ final class MeetingExportServiceTests: XCTestCase {
         XCTAssertTrue(markdown.contains("Transcribed"))
         XCTAssertTrue(markdown.contains("Plain transcript text for validation."))
         XCTAssertTrue(markdown.contains("recordingSaved"))
+        XCTAssertTrue(markdown.contains("Startup replay frames: 0"))
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
@@ -197,6 +197,58 @@ final class MeetingRecorderTests: XCTestCase {
         XCTAssertEqual(fixture.transcriber.appendedFrames, [frame])
     }
 
+    func testDrainDuringWriterSetupDoesNotDropStartupAudio() async throws {
+        let fixture = try RecorderFixture()
+        let frame = AudioFrame(pcm: Data([8, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+        fixture.writerFactory.onMakeWriter = {
+            fixture.session.frameBuffer.push(frame)
+            try? fixture.recorder.drainFrames()
+        }
+        let record = try fixture.recorder.prepareRecord(for: fixture.target)
+
+        try await fixture.recorder.startRecording(target: fixture.target, record: record)
+        try fixture.recorder.drainFrames()
+
+        XCTAssertEqual(fixture.writer.writtenFrames, [frame])
+        XCTAssertEqual(fixture.transcriber.appendedFrames, [frame])
+    }
+
+    func testStartupTranscriptionReplayOverflowIsRecordedInDiagnostics() async throws {
+        let fixture = try RecorderFixture()
+        fixture.transcriberFactory.shouldSuspend = true
+        let record = try fixture.recorder.prepareRecord(for: fixture.target)
+        let frames = (0..<3_008).map { index in
+            AudioFrame(
+                pcm: Data([UInt8(index % 255), 0]),
+                sampleRate: 16_000,
+                channelCount: 1,
+                timestampNanos: UInt64(index + 1)
+            )
+        }
+
+        let startTask = Task {
+            try await fixture.recorder.startRecording(target: fixture.target, record: record)
+        }
+        try await waitFor { fixture.transcriberFactory.requests.count == 1 }
+        for frame in frames {
+            fixture.session.frameBuffer.push(frame)
+            try fixture.recorder.drainFrames()
+        }
+
+        fixture.transcriberFactory.resume()
+        try await startTask.value
+        _ = try fixture.recorder.stopRecording()
+
+        let diagnostics = try JSONDecoder.meetingAgent.decode(
+            CaptureDiagnostics.self,
+            from: Data(contentsOf: XCTUnwrap(record.diagnosticsURL))
+        )
+        XCTAssertEqual(fixture.writer.writtenFrames.count, 3_008)
+        XCTAssertEqual(fixture.transcriber.appendedFrames.count, 3_000)
+        XCTAssertEqual(diagnostics.startupReplayFrameCount, 3_000)
+        XCTAssertEqual(diagnostics.startupReplayDroppedFrameCount, 8)
+    }
+
     func testStartRecordingWritesDiagnosticsWhenCaptureStartFails() async throws {
         let fixture = try RecorderFixture()
         fixture.session.startError = ProbeError.coreAudio("start failed")
@@ -307,6 +359,7 @@ private final class FakeAudioFrameWriterFactory {
     }
 
     var requests: [Request] = []
+    var onMakeWriter: (() -> Void)?
     private let writer: FakeAudioFrameWriter
 
     init(writer: FakeAudioFrameWriter) {
@@ -315,6 +368,7 @@ private final class FakeAudioFrameWriterFactory {
 
     func makeWriter(url: URL, sampleRate: UInt32, channelCount: UInt16) throws -> AudioFrameWriting {
         requests.append(Request(url: url, sampleRate: sampleRate, channelCount: channelCount))
+        onMakeWriter?()
         return writer
     }
 }


### PR DESCRIPTION
## Summary

Fixes #52

- Preserves startup audio captured while Deepgram streaming connects by keeping a larger startup replay spool.
- Prevents the app drain loop from seeing a capture session before the WAV writer and startup spool are ready.
- Serializes Deepgram audio frame sends so replayed startup frames stay ahead of live frames.

## Changes

- `Sources/MeetingAgentCore/MeetingRecorder.swift` - delays capture session publication until consumers are initialized, expands startup replay buffering, and records replay/drop diagnostics.
- `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift` - replaces per-frame send tasks with an ordered send queue.
- `Sources/MeetingAgentCore/CaptureDiagnostics.swift` - adds startup replay counters with legacy JSON decode defaults.
- `Sources/MeetingAgentCore/MeetingExportService.swift` - includes startup replay diagnostics in readiness reports.
- `Tests/MeetingAgentCoreTests/*` - adds regression coverage for startup replay, drain setup race, ordered Deepgram sends, diagnostics, and export output.
- `MISTAKES.md` - records the consumer-readiness lesson from this fix.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `make test` passed, 419 tests, coverage gate passed
- [x] E2E/integration: skipped; no E2E convention for this core audio/transcription unit behavior
- [x] Code review: PASS, manual Swift diff review plus `git diff --check origin/main...HEAD`
- [x] Manual verification: not applicable beyond deterministic unit coverage for the startup race and replay ordering