### PR TITLE
feat: log raw Deepgram responses

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -269,3 +269,19 @@ If `origin/HEAD` is absent or empty, query `git remote show origin` or fall back
 Validate the resolved default branch is non-empty before passing it to `git fetch` or `git worktree add`.
 
 ---
+
+## [54] Keep awaited actor values out of XCTest autoclosures
+
+**Date**: 2026-04-28
+**Category**: test-mistake
+
+### What went wrong
+The first streaming raw-response logging test placed `await received.texts` directly inside `XCTAssertEqual`, which Swift rejects because XCTest assertions use non-async autoclosures.
+
+### Correct approach
+Await actor-isolated values into local constants before passing them to XCTest assertions.
+
+### How to avoid
+When asserting actor state in XCTest, split `let value = await actor.value` from `XCTAssertEqual(value, expected)`.
+
+---

--- a/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
@@ -37,6 +37,51 @@ public enum DeepgramTranscriptionConfiguration: Equatable {
     }
 }
 
+public enum DeepgramRawResponseTransport: String, Equatable {
+    case http
+    case webSocket
+}
+
+public struct DeepgramRawResponseContext: Equatable {
+    public let providerID: String
+    public let transport: DeepgramRawResponseTransport
+
+    public init(providerID: String, transport: DeepgramRawResponseTransport) {
+        self.providerID = providerID
+        self.transport = transport
+    }
+}
+
+public protocol DeepgramRawResponseLogger {
+    func logRawResponse(_ data: Data, context: DeepgramRawResponseContext)
+}
+
+public final class DeepgramEnvironmentRawResponseLogger: DeepgramRawResponseLogger {
+    private let isEnabled: Bool
+    private let errorOutput: FileHandle
+
+    public init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        errorOutput: FileHandle = .standardError
+    ) {
+        self.isEnabled = environment["MEETING_AGENT_DEEPGRAM_RAW_RESPONSE_LOG"] == "1"
+        self.errorOutput = errorOutput
+    }
+
+    public func logRawResponse(_ data: Data, context: DeepgramRawResponseContext) {
+        guard isEnabled else { return }
+        let text = String(data: data, encoding: .utf8) ?? data.base64EncodedString()
+        let message = """
+        [MeetingAgent] Deepgram raw \(context.transport.rawValue) response (\(data.count) bytes, provider: \(context.providerID)):
+        \(text)
+
+        """
+        if let output = message.data(using: .utf8) {
+            try? errorOutput.write(contentsOf: output)
+        }
+    }
+}
+
 public protocol DeepgramTranscriptionClient {
     func transcribe(
         configuration: DeepgramTranscriptionConfiguration,
@@ -108,16 +153,25 @@ public final class URLSessionDeepgramTranscriptionClient: DeepgramTranscriptionC
 
 public final class URLSessionDeepgramStreamingTranscriptionClient: DeepgramStreamingTranscriptionClient {
     private let webSocketFactory: (URLRequest) -> DeepgramWebSocketTask
+    private let rawResponseLogger: DeepgramRawResponseLogger
 
     public convenience init() {
-        self.init(webSocketFactory: { request in
-            URLSession.shared.webSocketTask(with: request)
-        })
+        self.init(
+            rawResponseLogger: DeepgramEnvironmentRawResponseLogger(),
+            webSocketFactory: { request in
+                URLSession.shared.webSocketTask(with: request)
+            }
+        )
     }
 
-    init(webSocketFactory: @escaping (URLRequest) -> DeepgramWebSocketTask) {
+    init(
+        rawResponseLogger: DeepgramRawResponseLogger = DeepgramEnvironmentRawResponseLogger(),
+        webSocketFactory: @escaping (URLRequest) -> DeepgramWebSocketTask
+    ) {
+        self.rawResponseLogger = rawResponseLogger
         self.webSocketFactory = webSocketFactory
     }
+
     public func connect(
         configuration: DeepgramTranscriptionConfiguration,
         sampleRate: Double,
@@ -147,7 +201,7 @@ public final class URLSessionDeepgramStreamingTranscriptionClient: DeepgramStrea
         var request = URLRequest(url: url)
         request.setValue("Token \(apiKey)", forHTTPHeaderField: "Authorization")
         let task = webSocketFactory(request)
-        let session = URLSessionDeepgramStreamingSession(task: task)
+        let session = URLSessionDeepgramStreamingSession(task: task, rawResponseLogger: rawResponseLogger)
         task.resume()
         return session
     }
@@ -164,10 +218,15 @@ extension URLSessionWebSocketTask: DeepgramWebSocketTask {}
 
 final class URLSessionDeepgramStreamingSession: DeepgramStreamingTranscriptionSession {
     private let task: DeepgramWebSocketTask
+    private let rawResponseLogger: DeepgramRawResponseLogger
     private var continuation: AsyncStream<TranscriptSegment>.Continuation?
 
-    init(task: DeepgramWebSocketTask) {
+    init(
+        task: DeepgramWebSocketTask,
+        rawResponseLogger: DeepgramRawResponseLogger = DeepgramEnvironmentRawResponseLogger()
+    ) {
         self.task = task
+        self.rawResponseLogger = rawResponseLogger
     }
 
     var segments: AsyncStream<TranscriptSegment> {
@@ -207,6 +266,10 @@ final class URLSessionDeepgramStreamingSession: DeepgramStreamingTranscriptionSe
     }
 
     private func yieldSegments(from data: Data) {
+        rawResponseLogger.logRawResponse(
+            data,
+            context: DeepgramRawResponseContext(providerID: "deepgram-transcribe", transport: .webSocket)
+        )
         for segment in DeepgramStreamingResponseMapper.segments(
             from: data,
             providerID: "deepgram-transcribe"
@@ -432,21 +495,26 @@ public struct DeepgramAudioTranscriptionProvider: AudioTranscriptionProvider {
 
     private let configuration: DeepgramTranscriptionConfiguration
     private let client: DeepgramTranscriptionClient
+    private let rawResponseLogger: DeepgramRawResponseLogger
 
     public init(
         configuration: DeepgramTranscriptionConfiguration,
-        client: DeepgramTranscriptionClient = URLSessionDeepgramTranscriptionClient()
+        client: DeepgramTranscriptionClient = URLSessionDeepgramTranscriptionClient(),
+        rawResponseLogger: DeepgramRawResponseLogger = DeepgramEnvironmentRawResponseLogger()
     ) {
         self.configuration = configuration
         self.client = client
+        self.rawResponseLogger = rawResponseLogger
     }
 
     public init(
         appConfiguration: SpeechTranscriptionConfiguration = .default,
-        client: DeepgramTranscriptionClient = URLSessionDeepgramTranscriptionClient()
+        client: DeepgramTranscriptionClient = URLSessionDeepgramTranscriptionClient(),
+        rawResponseLogger: DeepgramRawResponseLogger = DeepgramEnvironmentRawResponseLogger()
     ) {
         self.configuration = .app(appConfiguration)
         self.client = client
+        self.rawResponseLogger = rawResponseLogger
     }
 
     public func transcribe(audio: AudioInput, options: TranscriptionOptions) async throws -> TranscriptDocument {
@@ -459,6 +527,10 @@ public struct DeepgramAudioTranscriptionProvider: AudioTranscriptionProvider {
         let data = try await client.transcribe(
             configuration: configuration,
             wavURL: wavURL
+        )
+        rawResponseLogger.logRawResponse(
+            data,
+            context: DeepgramRawResponseContext(providerID: descriptor.id, transport: .http)
         )
         let response = try JSONDecoder.meetingAgent.decode(DeepgramResponse.self, from: data)
         return TranscriptDocument(segments: Self.segments(from: response, providerID: descriptor.id))

--- a/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
@@ -88,6 +88,45 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(task.cancelCloseCode, .normalClosure)
     }
 
+    func testURLSessionStreamingSessionLogsRawWebSocketResponsesBeforeMapping() async throws {
+        let task = FakeDeepgramWebSocketTask()
+        let logger = RecordingDeepgramRawResponseLogger()
+        let session = URLSessionDeepgramStreamingSession(task: task, rawResponseLogger: logger)
+        let received = TranscriptSegmentCollector()
+        let receiveTask = Task {
+            for await segment in session.segments {
+                await received.append(segment)
+            }
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+
+        let stringPayload = """
+        {
+          "is_final": true,
+          "channel": {
+            "alternatives": [
+              { "transcript": "string payload", "confidence": 0.7, "words": [] }
+            ]
+          }
+        }
+        """
+        let dataPayload = Data(#"{"is_final":false}"#.utf8)
+        task.completeReceive(.success(.string(stringPayload)))
+        task.completeReceive(.success(.data(dataPayload)))
+        task.completeReceive(.failure(ProbeError.speechRecognition("closed")))
+        try await Task.sleep(nanoseconds: 10_000_000)
+        await session.close()
+        await receiveTask.value
+
+        let receivedTexts = await received.texts
+        XCTAssertEqual(receivedTexts, ["string payload"])
+        XCTAssertEqual(logger.entries.count, 2)
+        XCTAssertEqual(logger.entries.map(\.context.providerID), ["deepgram-transcribe", "deepgram-transcribe"])
+        XCTAssertEqual(logger.entries.map(\.context.transport), [.webSocket, .webSocket])
+        XCTAssertEqual(String(data: logger.entries[0].data, encoding: .utf8), stringPayload)
+        XCTAssertEqual(logger.entries[1].data, dataPayload)
+    }
+
     func testStreamingProviderSendsAudioFramesAndWritesIncomingTranscriptSegments() async throws {
         let transcriptURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("deepgram-stream-\(UUID().uuidString)")
@@ -467,6 +506,19 @@ private final class FakeDeepgramStreamingClient: DeepgramStreamingTranscriptionC
             channelCount: channelCount
         ))
         return session
+    }
+}
+
+private final class RecordingDeepgramRawResponseLogger: DeepgramRawResponseLogger {
+    struct Entry {
+        let data: Data
+        let context: DeepgramRawResponseContext
+    }
+
+    private(set) var entries: [Entry] = []
+
+    func logRawResponse(_ data: Data, context: DeepgramRawResponseContext) {
+        entries.append(Entry(data: data, context: context))
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/DeepgramTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeepgramTranscriptionProviderTests.swift
@@ -180,6 +180,35 @@ final class DeepgramTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(output.segments.first?.sourceProvider, "deepgram-transcribe")
     }
 
+    func testProviderLogsRawDeepgramResponseBeforeMapping() async throws {
+        let response = """
+        {
+          "results": {
+            "utterances": [
+              { "id": "utt-raw", "transcript": "raw hello", "speaker": 1 }
+            ]
+          }
+        }
+        """
+        let logger = RecordingDeepgramRawResponseLogger()
+        let provider = DeepgramAudioTranscriptionProvider(
+            configuration: DeepgramTranscriptionConfiguration(apiKey: "key", model: "nova-3"),
+            client: RecordingDeepgramClient(response: response),
+            rawResponseLogger: logger
+        )
+
+        let output = try await provider.transcribe(
+            audio: AudioInput(wavURL: URL(fileURLWithPath: "/tmp/capture.wav"), localeIdentifier: "en-US"),
+            options: TranscriptionOptions(sourceLocale: "en-US")
+        )
+
+        XCTAssertEqual(output.segments.first?.text, "raw hello")
+        XCTAssertEqual(logger.entries.count, 1)
+        XCTAssertEqual(logger.entries.first?.context.providerID, "deepgram-transcribe")
+        XCTAssertEqual(logger.entries.first?.context.transport, .http)
+        XCTAssertEqual(String(data: try XCTUnwrap(logger.entries.first?.data), encoding: .utf8), response)
+    }
+
     func testProviderWritesDeepgramSpeakersIntoUserLabelsThroughTranscriptWriter() async throws {
         let transcriptURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("deepgram-users-\(UUID().uuidString)")
@@ -471,6 +500,19 @@ private final class RecordingDeepgramClient: DeepgramTranscriptionClient {
             wavURL: wavURL
         ))
         return Data(response.utf8)
+    }
+}
+
+private final class RecordingDeepgramRawResponseLogger: DeepgramRawResponseLogger {
+    struct Entry {
+        let data: Data
+        let context: DeepgramRawResponseContext
+    }
+
+    private(set) var entries: [Entry] = []
+
+    func logRawResponse(_ data: Data, context: DeepgramRawResponseContext) {
+        entries.append(Entry(data: data, context: context))
     }
 }
 

--- a/docs/superpowers/plans/2026-04-28-deepgram-raw-response-logging.md
+++ b/docs/superpowers/plans/2026-04-28-deepgram-raw-response-logging.md
@@ -1,0 +1,43 @@
+# Deepgram Raw Response Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in raw Deepgram response logging for hosted and streaming transcription paths.
+
+**Architecture:** Introduce an injectable logger protocol in the Deepgram provider file. Hosted providers log client response data before decoding, and URLSession streaming sessions log websocket payloads before mapping.
+
+**Tech Stack:** Swift 5.9, Foundation, XCTest, SwiftPM.
+
+---
+
+### Task 1: Hosted Raw Response Logging
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift`
+- Modify: `Tests/MeetingAgentCoreTests/DeepgramTranscriptionProviderTests.swift`
+
+- [ ] Add a failing hosted-provider test with a recording logger.
+- [ ] Add `DeepgramRawResponseLogger`, context types, no-op logger, and env-gated stderr logger.
+- [ ] Inject the logger into `DeepgramAudioTranscriptionProvider`.
+- [ ] Call the logger before decoding the hosted response.
+- [ ] Run `swift test --filter DeepgramTranscriptionProviderTests`.
+
+### Task 2: Streaming Raw Response Logging
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift`
+- Modify: `Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift`
+
+- [ ] Add a failing websocket session test with a recording logger.
+- [ ] Inject the logger into `URLSessionDeepgramStreamingTranscriptionClient` and `URLSessionDeepgramStreamingSession`.
+- [ ] Log websocket string and data payloads before `DeepgramStreamingResponseMapper.segments`.
+- [ ] Run `swift test --filter DeepgramStreamingTranscriptionProviderTests`.
+
+### Task 3: Verification
+
+**Files:**
+- Modify: changed source, tests, docs
+
+- [ ] Run `make test`.
+- [ ] Review the diff for accidental request credential logging.
+- [ ] Commit the implementation with `feat: log raw Deepgram responses (#54)`.

--- a/docs/superpowers/specs/2026-04-28-deepgram-raw-response-logging-design.md
+++ b/docs/superpowers/specs/2026-04-28-deepgram-raw-response-logging-design.md
@@ -1,0 +1,31 @@
+# Deepgram Raw Response Logging Design
+
+## Intent
+
+Issue #54 asks for Deepgram raw return data logging to make provider debugging easier. The implementation should capture the raw JSON payloads returned by Deepgram before any decoding or transcript mapping, without exposing API keys or request headers.
+
+## Requirements
+
+- Log hosted Deepgram transcription response bodies before `DeepgramResponse` decoding.
+- Log streaming Deepgram websocket text and data messages before `DeepgramStreamingResponseMapper` mapping.
+- Keep normal app runs private by disabling raw response logging unless explicitly enabled.
+- Provide an injectable logger so tests and future meeting-artifact logging can capture payloads without relying on process stderr.
+- Preserve existing transcription behavior when logging is disabled.
+
+## Non-Requirements
+
+- No UI setting in this change.
+- No request body, audio frame, API key, or header logging.
+- No new persisted meeting artifact format.
+
+## Selected Approach
+
+Add a small `DeepgramRawResponseLogger` boundary in `DeepgramTranscriptionProvider.swift`. Hosted transcription providers call it after receiving client data and before decoding. URLSession streaming sessions call it for each websocket text or data message before mapping segments.
+
+The default logger is environment-gated: `MEETING_AGENT_DEEPGRAM_RAW_RESPONSE_LOG=1` enables stderr logging; all other values use a no-op logger. Tests inject a recording logger to assert the payload and source path.
+
+## Test Plan
+
+- Add a hosted transcription test proving the raw response is captured before normal utterance mapping.
+- Add a streaming session test proving websocket string and data payloads are captured before mapping.
+- Run focused Deepgram tests, then `make test`.


### PR DESCRIPTION
## Summary

Fixes #54

- Add opt-in raw Deepgram response logging for hosted HTTP transcription and streaming websocket responses.
- Keep normal runs private by enabling stderr raw logs only when MEETING_AGENT_DEEPGRAM_RAW_RESPONSE_LOG=1.
- Add focused tests for hosted and streaming raw payload capture before mapping.

## Changes

- `Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift` - adds raw response logger context, environment-gated stderr logger, and hosted/streaming logging hooks.
- `Tests/MeetingAgentCoreTests/DeepgramTranscriptionProviderTests.swift` - covers hosted raw payload capture.
- `Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift` - covers websocket string/data payload capture.
- `docs/superpowers/specs/2026-04-28-deepgram-raw-response-logging-design.md` and `docs/superpowers/plans/2026-04-28-deepgram-raw-response-logging.md` - capture design and plan.
- `MISTAKES.md` - records XCTest actor assertion lesson.

## Test plan

- [x] Build/lint: `make test`, passed with coverage gate
- [x] Unit tests: `swift test --filter DeepgramTranscriptionProviderTests`, passed; `swift test --filter DeepgramStreamingTranscriptionProviderTests`, passed
- [x] E2E/integration: skipped, provider-level behavior is covered by unit tests and no E2E convention applies
- [x] Code review: PASS, manual Swift fallback review
- [x] Manual verification: reviewed diff for credential/audio request logging; only response payloads are logged behind explicit env flag
