### PR TITLE
feat: add summary model settings

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -238,6 +238,22 @@ When using upsert for streaming interim data, test both interim-to-final replace
 
 ---
 
+## [57] Avoid public API expansion for injectable defaults
+
+**Date**: 2026-04-28
+**Category**: api-misuse
+
+### What went wrong
+The first summary provider injection made the default provider factory public only because Swift public initializer default arguments cannot reference private helpers.
+
+### Correct approach
+Use an optional injectable closure defaulting to `nil`, then assign the private default factory inside the initializer body.
+
+### How to avoid
+When adding test injection to a public initializer, keep helper factories private unless callers genuinely need them.
+
+---
+
 ## [48] Apply preferred-target test lessons before writing new tests
 
 **Date**: 2026-04-28

--- a/Sources/MeetingAgentApp/SettingsView.swift
+++ b/Sources/MeetingAgentApp/SettingsView.swift
@@ -99,6 +99,12 @@ struct SettingsView: View {
                                 Text(model.displayName).tag(model.id)
                             }
                         }
+
+                        Picker("Hosted Summary Model", selection: $draft.hostedSummaryModelID) {
+                            ForEach(BilingualPipelineFactory.hostedSummaryModelOptions) { model in
+                                Text(model.displayName).tag(model.id)
+                            }
+                        }
                     }
                 }
 

--- a/Sources/MeetingAgentCore/BilingualPipelineFactory.swift
+++ b/Sources/MeetingAgentCore/BilingualPipelineFactory.swift
@@ -24,6 +24,11 @@ public enum BilingualPipelineFactory {
         ModelOption(id: "openai/gpt-4.1-mini", displayName: "GPT-4.1 Mini")
     ]
 
+    public static let hostedSummaryModelOptions: [ModelOption] = [
+        ModelOption(id: "openai/gpt-4.1-mini", displayName: "GPT-4.1 Mini"),
+        ModelOption(id: "google/gemini-2.5-flash", displayName: "Gemini 2.5 Flash")
+    ]
+
     public static let builtInProviderDescriptors: [ProviderDescriptor] = [
         ProviderDescriptor(id: "whisper-local", displayName: "Whisper Local", capability: .audioTranscription, executionMode: .local, supportedSourceLocales: ["*"], supportedTargetLocales: [], requiresNetwork: false, requiresAPIKey: false),
         ProviderDescriptor(id: "macos-speech-local", displayName: "macOS Speech", capability: .audioTranscription, executionMode: .local, supportedSourceLocales: ["*"], supportedTargetLocales: [], requiresNetwork: false, requiresAPIKey: false),

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -62,6 +62,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     private let minDraftTranslationCharacterDelta = 80
     private let minDraftTranslationInterval: TimeInterval = 2
     private let captionTranslationProviderFactory: (SpeechTranscriptionConfiguration) -> TextTranslationProvider?
+    private let summaryProviderFactory: (SpeechTranscriptionConfiguration) -> MeetingSummaryProvider
     private let processTargetsProvider: () -> [AudioCaptureTarget]
     private let processMonitor = MeetingProcessMonitor()
     private var activeTarget: AudioCaptureTarget?
@@ -78,6 +79,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             playbackSink: LocalAudioPlaybackSink()
         ),
         captionTranslationProviderFactory: @escaping (SpeechTranscriptionConfiguration) -> TextTranslationProvider? = MeetingAgentViewModel.openRouterCaptionTranslationProvider,
+        summaryProviderFactory: ((SpeechTranscriptionConfiguration) -> MeetingSummaryProvider)? = nil,
         processTargetsProvider: @escaping () -> [AudioCaptureTarget] = RunningProcessDiscovery.currentTargets
     ) {
         self.store = store
@@ -86,6 +88,9 @@ public final class MeetingAgentViewModel: ObservableObject {
         self.exportService = exportService
         self.realtimeTranslationController = realtimeTranslationController
         self.captionTranslationProviderFactory = captionTranslationProviderFactory
+        self.summaryProviderFactory = summaryProviderFactory ?? { configuration in
+            Self.summaryProvider(for: configuration)
+        }
         self.processTargetsProvider = processTargetsProvider
         self.recorder.realtimeFrameConsumer = realtimeTranslationController
         if let speechConfiguration {
@@ -427,7 +432,7 @@ public final class MeetingAgentViewModel: ObservableObject {
                 generatedAt: generatedAt
             )
         } else {
-            let provider = Self.summaryProvider()
+            let provider = summaryProviderFactory(speechConfiguration)
             summary = try await provider.generateSummary(
                 input: MeetingSummaryInput(
                     meetingName: meeting.name,
@@ -754,16 +759,19 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
     }
 
-    private static func summaryProvider(
+    private nonisolated static func summaryProvider(
+        for configuration: SpeechTranscriptionConfiguration,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> MeetingSummaryProvider {
         let provider = environment["MEETING_AGENT_SUMMARY_PROVIDER"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         if provider == "openrouter" {
-            return OpenRouterMeetingSummaryProvider(configuration: .environment(
-                model: environment["MEETING_AGENT_OPENROUTER_MODEL"],
-                environment: environment
+            return OpenRouterMeetingSummaryProvider(configuration: OpenRouterChatConfiguration(
+                apiKey: SpeechTranscriptionConfiguration.normalized(configuration.openRouterAPIKey)
+                    ?? environment["MEETING_AGENT_OPENROUTER_API_KEY"],
+                model: SpeechTranscriptionConfiguration.normalized(configuration.hostedSummaryModelID)
+                    ?? environment["MEETING_AGENT_OPENROUTER_MODEL"]
             ))
         }
         return ExtractiveMeetingSummaryProvider()

--- a/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
@@ -13,6 +13,7 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
     public static let defaultHostedTranslationProviderID = "openrouter-translation"
     public static let defaultHostedTranscriptionModelID = "google/gemini-2.5-flash"
     public static let defaultHostedTranslationModelID = "google/gemini-2.5-flash"
+    public static let defaultHostedSummaryModelID = "openai/gpt-4.1-mini"
     public static let defaultDeepgramTranscriptionProviderID = "deepgram-transcribe"
     public static let defaultDeepgramModelID = "nova-3"
     public static let defaultOpenAIRealtimeTranscriptionProviderID = "openai-realtime-transcribe"
@@ -32,6 +33,7 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
     public var hostedTranslationProviderID: String
     public var hostedTranscriptionModelID: String
     public var hostedTranslationModelID: String
+    public var hostedSummaryModelID: String
     public var openRouterAPIKey: String?
     public var openAIRealtimeAPIKey: String?
     public var deepgramAPIKey: String?
@@ -52,6 +54,7 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
         hostedTranslationProviderID: defaultHostedTranslationProviderID,
         hostedTranscriptionModelID: defaultHostedTranscriptionModelID,
         hostedTranslationModelID: defaultHostedTranslationModelID,
+        hostedSummaryModelID: defaultHostedSummaryModelID,
         openRouterAPIKey: nil,
         openAIRealtimeAPIKey: nil,
         deepgramAPIKey: nil,
@@ -73,6 +76,7 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
         hostedTranslationProviderID: String = defaultHostedTranslationProviderID,
         hostedTranscriptionModelID: String = defaultHostedTranscriptionModelID,
         hostedTranslationModelID: String = defaultHostedTranslationModelID,
+        hostedSummaryModelID: String = defaultHostedSummaryModelID,
         openRouterAPIKey: String? = nil,
         openAIRealtimeAPIKey: String? = nil,
         deepgramAPIKey: String? = nil,
@@ -113,6 +117,10 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
             hostedTranslationModelID,
             fallback: Self.defaultHostedTranslationModelID
         ) ?? Self.defaultHostedTranslationModelID
+        self.hostedSummaryModelID = Self.normalized(
+            hostedSummaryModelID,
+            fallback: Self.defaultHostedSummaryModelID
+        ) ?? Self.defaultHostedSummaryModelID
         self.openRouterAPIKey = Self.normalized(openRouterAPIKey)
         self.openAIRealtimeAPIKey = Self.normalized(openAIRealtimeAPIKey)
         self.deepgramAPIKey = Self.normalized(deepgramAPIKey)
@@ -135,6 +143,7 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
         case hostedTranslationProviderID
         case hostedTranscriptionModelID
         case hostedTranslationModelID
+        case hostedSummaryModelID
         case openRouterAPIKey
         case openAIRealtimeAPIKey
         case deepgramAPIKey
@@ -158,6 +167,7 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
             hostedTranslationProviderID: try container.decodeIfPresent(String.self, forKey: .hostedTranslationProviderID) ?? Self.defaultHostedTranslationProviderID,
             hostedTranscriptionModelID: try container.decodeIfPresent(String.self, forKey: .hostedTranscriptionModelID) ?? Self.defaultHostedTranscriptionModelID,
             hostedTranslationModelID: try container.decodeIfPresent(String.self, forKey: .hostedTranslationModelID) ?? Self.defaultHostedTranslationModelID,
+            hostedSummaryModelID: try container.decodeIfPresent(String.self, forKey: .hostedSummaryModelID) ?? Self.defaultHostedSummaryModelID,
             openRouterAPIKey: try container.decodeIfPresent(String.self, forKey: .openRouterAPIKey),
             openAIRealtimeAPIKey: try container.decodeIfPresent(String.self, forKey: .openAIRealtimeAPIKey),
             deepgramAPIKey: try container.decodeIfPresent(String.self, forKey: .deepgramAPIKey),

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -1179,6 +1179,50 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, "Summary generated")
     }
 
+    func testGenerateSummaryUsesConfiguredSummaryModelIndependentlyFromTranslationModel() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let stored = try store.createMeeting(
+            name: "Launch Review",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000)
+        )
+        let transcriptWriter = try TranscriptFileWriter(url: stored.record.transcriptURL!)
+        try transcriptWriter.replace(with: [
+            TranscriptSegment(id: "segment-1", text: "We decided to launch on May 1.", language: "en-US")
+        ])
+        try transcriptWriter.close()
+        let configuration = SpeechTranscriptionConfiguration(
+            provider: .whisper,
+            localeIdentifier: "en-US",
+            whisperBinaryPath: nil,
+            whisperModelPath: nil,
+            translationExecutionMode: .hosted,
+            hostedTranslationProviderID: "openrouter-translation",
+            hostedTranslationModelID: "google/gemini-2.5-flash",
+            hostedSummaryModelID: "openai/gpt-4.1-mini",
+            openRouterAPIKey: "test-key"
+        )
+        let viewModel = MeetingAgentViewModel(
+            store: store,
+            speechConfiguration: configuration,
+            summaryProviderFactory: { configuration in
+                CapturingSummaryProvider(providerName: "openrouter:\(configuration.hostedSummaryModelID)")
+            },
+            processTargetsProvider: { [] }
+        )
+        try viewModel.loadMeetings()
+
+        try await viewModel.generateSummary(
+            for: stored.record.id,
+            generatedAt: Date(timeIntervalSince1970: 1_777_000_700)
+        )
+
+        let summary = try MeetingSummaryWriter.read(from: stored.record.summaryJSONURL!)
+        XCTAssertEqual(summary.status, .succeeded)
+        XCTAssertEqual(summary.provider, "openrouter:openai/gpt-4.1-mini")
+    }
+
     func testRetryTranscriptionClearsDownstreamSummaryArtifacts() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -1948,6 +1992,28 @@ private final class DelayedViewModelFakeTextTranslationProvider: TextTranslation
             ],
             provenance: PipelineProvenance(profileID: "delayed-view-model-translation")
         ))
+    }
+}
+
+private struct CapturingSummaryProvider: MeetingSummaryProvider {
+    let providerName: String
+
+    func generateSummary(input: MeetingSummaryInput) async throws -> MeetingSummary {
+        MeetingSummary(
+            overview: "The team aligned on launch scope.",
+            keyTopics: ["Launch"],
+            decisions: [],
+            actionItems: [],
+            openQuestions: [],
+            risks: [],
+            followUps: [],
+            language: input.language,
+            sourceSegmentIDs: input.segments.map(\.id),
+            generatedAt: input.generatedAt,
+            provider: providerName,
+            status: .succeeded,
+            failureReason: nil
+        )
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/SettingsViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/SettingsViewLayoutTests.swift
@@ -23,6 +23,7 @@ final class SettingsViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("openAIRealtimeAPIKeyBinding"))
         XCTAssertTrue(source.contains("usesOpenRouter"))
         XCTAssertTrue(source.contains("Picker(\"Hosted Translation Model\""))
+        XCTAssertTrue(source.contains("Picker(\"Hosted Summary Model\""))
         XCTAssertFalse(source.contains("Picker(\"Translation Mode\""))
         XCTAssertFalse(source.contains("Picker(\"Local Translation Provider\""))
         XCTAssertFalse(source.contains("Picker(\"Hosted Translation Provider\""))

--- a/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
+++ b/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
@@ -14,6 +14,8 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.hostedTranslationProviderID, "openrouter-translation")
         XCTAssertEqual(configuration.hostedTranslationModelID, "google/gemini-2.5-flash")
         XCTAssertEqual(BilingualPipelineFactory.hostedTranslationModelOptions.first?.id, "google/gemini-2.5-flash")
+        XCTAssertEqual(configuration.hostedSummaryModelID, "openai/gpt-4.1-mini")
+        XCTAssertEqual(BilingualPipelineFactory.hostedSummaryModelOptions.first?.id, "openai/gpt-4.1-mini")
         XCTAssertEqual(configuration.deepgramModelID, "nova-3")
     }
 
@@ -139,6 +141,7 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
             hostedTranslationProviderID: "openrouter-translation",
             hostedTranscriptionModelID: "google/gemini-2.5-flash",
             hostedTranslationModelID: "openai/gpt-4.1-mini",
+            hostedSummaryModelID: "google/gemini-2.5-flash",
             openRouterAPIKey: "settings-key",
             openAIRealtimeAPIKey: " realtime-key ",
             deepgramAPIKey: " deepgram-key ",
@@ -251,6 +254,7 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         XCTAssertNil(configuration.openAIRealtimeAPIKey)
         XCTAssertNil(configuration.deepgramAPIKey)
         XCTAssertEqual(configuration.deepgramModelID, "nova-3")
+        XCTAssertEqual(configuration.hostedSummaryModelID, "openai/gpt-4.1-mini")
     }
 
     func testDeepgramHostedValidationRequiresAPIKey() {

--- a/docs/superpowers/plans/2026-04-28-summary-model-settings.md
+++ b/docs/superpowers/plans/2026-04-28-summary-model-settings.md
@@ -1,0 +1,201 @@
+# Summary Model Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add independent OpenRouter summary model configuration in Settings and use it for meeting summary generation.
+
+**Architecture:** Store the summary model beside the existing transcription and translation settings in `SpeechTranscriptionConfiguration`. Expose curated summary model options from `BilingualPipelineFactory`, render a separate Settings picker, and pass the configured model into `OpenRouterMeetingSummaryProvider` from `MeetingAgentViewModel`.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Package Manager, XCTest.
+
+---
+
+### Task 1: Configuration Model And Settings Picker
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift`
+- Modify: `Sources/MeetingAgentCore/BilingualPipelineFactory.swift`
+- Modify: `Sources/MeetingAgentApp/SettingsView.swift`
+- Test: `Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift`
+- Test: `Tests/MeetingAgentCoreTests/SettingsViewLayoutTests.swift`
+
+- [ ] **Step 1: Write failing configuration and layout assertions**
+
+Add assertions that:
+
+```swift
+XCTAssertEqual(configuration.hostedSummaryModelID, "openai/gpt-4.1-mini")
+XCTAssertEqual(BilingualPipelineFactory.hostedSummaryModelOptions.first?.id, "openai/gpt-4.1-mini")
+```
+
+Update round-trip test setup with:
+
+```swift
+hostedSummaryModelID: "google/gemini-2.5-flash",
+```
+
+Add decode fallback assertion:
+
+```swift
+XCTAssertEqual(configuration.hostedSummaryModelID, "openai/gpt-4.1-mini")
+```
+
+Add layout assertion:
+
+```swift
+XCTAssertTrue(source.contains("Picker(\"Hosted Summary Model\""))
+```
+
+- [ ] **Step 2: Run focused failing tests**
+
+Run:
+
+```bash
+swift test --filter SpeechTranscriptionConfigurationTests --filter SettingsViewLayoutTests
+```
+
+Expected: FAIL because `hostedSummaryModelID` and the summary picker do not exist yet.
+
+- [ ] **Step 3: Implement summary model configuration**
+
+In `SpeechTranscriptionConfiguration`, add:
+
+```swift
+public static let defaultHostedSummaryModelID = "openai/gpt-4.1-mini"
+public var hostedSummaryModelID: String
+```
+
+Add an initializer parameter:
+
+```swift
+hostedSummaryModelID: String = defaultHostedSummaryModelID,
+```
+
+Normalize it in `init`:
+
+```swift
+self.hostedSummaryModelID = Self.normalized(
+    hostedSummaryModelID,
+    fallback: Self.defaultHostedSummaryModelID
+) ?? Self.defaultHostedSummaryModelID
+```
+
+Add it to `CodingKeys` and decode with default fallback.
+
+- [ ] **Step 4: Implement summary model options and Settings picker**
+
+In `BilingualPipelineFactory`, add:
+
+```swift
+public static let hostedSummaryModelOptions: [ModelOption] = [
+    ModelOption(id: "openai/gpt-4.1-mini", displayName: "GPT-4.1 Mini"),
+    ModelOption(id: "google/gemini-2.5-flash", displayName: "Gemini 2.5 Flash")
+]
+```
+
+In `SettingsView`, add a picker in the OpenRouter panel:
+
+```swift
+Picker("Hosted Summary Model", selection: $draft.hostedSummaryModelID) {
+    ForEach(BilingualPipelineFactory.hostedSummaryModelOptions) { model in
+        Text(model.displayName).tag(model.id)
+    }
+}
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+swift test --filter SpeechTranscriptionConfigurationTests --filter SettingsViewLayoutTests
+```
+
+Expected: PASS.
+
+### Task 2: Summary Provider Uses Configured Model
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Write failing model-selection test**
+
+Add or update view-model summary coverage so a configuration with:
+
+```swift
+hostedTranslationModelID: "google/gemini-2.5-flash",
+hostedSummaryModelID: "openai/gpt-4.1-mini",
+openRouterAPIKey: "test-key"
+```
+
+generates an OpenRouter summary whose provider is:
+
+```swift
+XCTAssertEqual(summary.provider, "openrouter:openai/gpt-4.1-mini")
+```
+
+Use `MEETING_AGENT_SUMMARY_PROVIDER=openrouter` and a fake `OpenRouterChatClient`.
+
+- [ ] **Step 2: Run the failing focused test**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests
+```
+
+Expected: FAIL because the view model still gets the summary model only from `MEETING_AGENT_OPENROUTER_MODEL`.
+
+- [ ] **Step 3: Pass configuration into summary provider creation**
+
+Update `generateSummary` to call a provider factory that accepts `speechConfiguration`. Update the static factory to prefer:
+
+```swift
+configuration.hostedSummaryModelID
+```
+
+and fall back to:
+
+```swift
+environment["MEETING_AGENT_OPENROUTER_MODEL"]
+```
+
+Keep the OpenRouter API key resolution behavior unchanged.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests
+```
+
+Expected: PASS.
+
+### Task 3: Full Verification And Commit
+
+**Files:**
+- All files changed in Tasks 1 and 2.
+
+- [ ] **Step 1: Run full unit verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS with coverage enforcement.
+
+- [ ] **Step 2: Commit implementation**
+
+Run:
+
+```bash
+git add docs/superpowers/specs/2026-04-28-summary-model-settings-design.md docs/superpowers/plans/2026-04-28-summary-model-settings.md Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift Sources/MeetingAgentCore/BilingualPipelineFactory.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Sources/MeetingAgentApp/SettingsView.swift Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift Tests/MeetingAgentCoreTests/SettingsViewLayoutTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+git commit -m "feat: add summary model settings (#57)"
+```
+
+Expected: commit succeeds.
+

--- a/docs/superpowers/specs/2026-04-28-summary-model-settings-design.md
+++ b/docs/superpowers/specs/2026-04-28-summary-model-settings-design.md
@@ -1,0 +1,61 @@
+# Summary Model Settings Design
+
+## Context
+
+Issue #57 asks for real meeting summary model configuration in Settings. Summary generation should continue to use the OpenRouter provider, but the selected model must be independent from the translation model. The app already stores speech, transcription, translation, provider credential, and Deepgram settings in `SpeechTranscriptionConfiguration`.
+
+## Goals
+
+- Add an independent OpenRouter summary model setting.
+- Show the summary model in Settings separately from the translation model.
+- Persist the selected summary model across app launches.
+- Use the configured summary model when OpenRouter summary generation runs.
+- Keep the existing environment-variable fallback for development and existing users.
+
+## Non-Goals
+
+- Add a new summary provider.
+- Change the translation model setting.
+- Change the summary JSON schema.
+- Add network model discovery.
+
+## Selected Approach
+
+Add `hostedSummaryModelID` to `SpeechTranscriptionConfiguration`, with `openai/gpt-4.1-mini` as the default. This keeps summary configuration separate from transcription and translation while following the existing app settings pattern. `BilingualPipelineFactory` will expose a small curated `hostedSummaryModelOptions` list for Settings.
+
+`MeetingAgentViewModel` will pass the selected summary model to `OpenRouterMeetingSummaryProvider` when `MEETING_AGENT_SUMMARY_PROVIDER=openrouter`. The provider will still fall back to `MEETING_AGENT_OPENROUTER_MODEL` when no app configuration model is supplied, preserving current environment-driven behavior.
+
+## Model Options
+
+The default summary model is `openai/gpt-4.1-mini`. It is already documented in the repository for OpenRouter summaries and is a reasonable low-cost default for structured JSON meeting summaries.
+
+Initial options:
+
+- `openai/gpt-4.1-mini` - GPT-4.1 Mini
+- `google/gemini-2.5-flash` - Gemini 2.5 Flash
+
+## UI
+
+The OpenRouter Settings panel will contain:
+
+- `SecureField("OpenRouter API Key", ...)`
+- `Picker("Hosted Translation Model", ...)`
+- `Picker("Hosted Summary Model", ...)`
+
+This keeps all OpenRouter-backed settings together while making summary and translation model choices visibly distinct.
+
+## Data Flow
+
+1. Settings edits `draft.hostedSummaryModelID`.
+2. Saving Settings persists `SpeechTranscriptionConfiguration`.
+3. `MeetingAgentViewModel.generateSummary` reads the current app configuration.
+4. If `MEETING_AGENT_SUMMARY_PROVIDER=openrouter`, the view model creates `OpenRouterMeetingSummaryProvider` with the configured API key and summary model.
+5. The summary artifact records the provider as `openrouter:<model>`.
+
+## Testing
+
+- Add default and round-trip coverage for `hostedSummaryModelID`.
+- Add backward decoding coverage so older saved settings get the default summary model.
+- Add a Settings source-layout assertion for `Picker("Hosted Summary Model"`.
+- Add summary provider/view-model coverage proving the selected model is used independently from translation.
+


### PR DESCRIPTION
## Summary

Fixes #57

- Add an independent hosted summary model setting with GPT-4.1 Mini as the default.
- Show a separate Hosted Summary Model picker in the OpenRouter Settings panel.
- Route OpenRouter summary generation through the configured summary model and Settings OpenRouter API key.

## Changes

- `Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift` - persists `hostedSummaryModelID` with backward-compatible defaults.
- `Sources/MeetingAgentCore/BilingualPipelineFactory.swift` - adds curated summary model options.
- `Sources/MeetingAgentApp/SettingsView.swift` - adds the summary model picker.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - injects summary provider construction and uses configured OpenRouter summary settings.
- `Tests/MeetingAgentCoreTests/*` - adds coverage for defaults, Settings layout, persistence, and model routing.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `make test` passed, 418 tests, coverage gate passed
- [x] E2E/integration: skipped; no E2E convention for this settings/model-routing change
- [x] Code review: PASS, fixed public API surface warning
- [x] Manual verification: source-level Settings picker assertion added