### PR TITLE
Add meeting performance event logging

### DIFF
--- a/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/DeepgramTranscriptionProvider.swift
@@ -411,13 +411,18 @@ public struct DeepgramStreamingSpeechTranscriptionProvider {
             channelCount: context.channelCount
         )
         let writer = try TranscriptFileWriter(url: context.transcriptURL)
-        return DeepgramStreamingTranscriber(session: session, writer: writer)
+        return DeepgramStreamingTranscriber(
+            session: session,
+            writer: writer,
+            performanceEventLogger: context.performanceEventLogger
+        )
     }
 }
 
 final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
     private let session: DeepgramStreamingTranscriptionSession
     private let writer: TranscriptFileWriter
+    private let performanceEventLogger: PerformanceEventLogger?
     private var receiveTask: Task<Void, Never>?
     private var sendFailure: String?
     private var fallbackSegmentIndex = 0
@@ -427,11 +432,21 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
         sendFailure
     }
 
-    init(session: DeepgramStreamingTranscriptionSession, writer: TranscriptFileWriter) {
+    init(
+        session: DeepgramStreamingTranscriptionSession,
+        writer: TranscriptFileWriter,
+        performanceEventLogger: PerformanceEventLogger? = nil
+    ) {
         self.session = session
         self.writer = writer
+        self.performanceEventLogger = performanceEventLogger
         self.receiveTask = Task { [weak self, session] in
             for await segment in session.segments {
+                self?.performanceEventLogger?.logSegment(
+                    "stt_segment_received",
+                    segment: segment,
+                    metadata: ["sourceProvider": segment.sourceProvider]
+                )
                 try? self?.write(segment)
             }
             try? self?.flushFinalSegmentBuffer(markSpeechFinal: true)
@@ -459,6 +474,7 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
         let segment = stableFallbackSegment(segment)
         guard segment.isFinal else {
             try writer.upsert(segment)
+            performanceEventLogger?.logSegment("transcript_segment_written", segment: segment)
             return
         }
         finalSegmentBuffer.append(segment)
@@ -482,6 +498,7 @@ final class DeepgramStreamingTranscriber: AudioFrameTranscriber {
         )
         for segment in committedSegments {
             try writer.upsert(segment)
+            performanceEventLogger?.logSegment("transcript_segment_written", segment: segment)
         }
     }
 

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -6,6 +6,7 @@ private struct CaptionTranslationRequest {
     let key: String
     let isDraft: Bool
     let revision: Int
+    let performanceEventLogger: PerformanceEventLogger?
 }
 
 @MainActor
@@ -899,11 +900,22 @@ public final class MeetingAgentViewModel: ObservableObject {
             ].joined(separator: "\u{1F}")
             guard processedLiveCaptionSegmentSignaturesByID[segment.id] != signature else { continue }
             processedLiveCaptionSegmentSignaturesByID[segment.id] = signature
+            currentPerformanceEventLogger()?.logSegment(
+                "caption_segment_ingested",
+                segment: segment,
+                metadata: ["path": "final"]
+            )
             for update in liveCaptionChunker.append(segment) {
                 liveCaptionStore.upsert(update.turn)
+                logCaptionTurnUpdate(update.turn)
             }
         }
         for segment in document.segments where !segment.isFinal {
+            currentPerformanceEventLogger()?.logSegment(
+                "caption_segment_ingested",
+                segment: segment,
+                metadata: ["path": "interim"]
+            )
             _ = liveCaptionStore.append(segment)
         }
         liveCaptionTurns = liveCaptionStore.turns
@@ -915,9 +927,73 @@ public final class MeetingAgentViewModel: ObservableObject {
     private func freezeOpenLiveCaptionChunk(reason: LiveCaptionFreezeReason) {
         for update in liveCaptionChunker.flushOpenChunk(reason: reason) {
             liveCaptionStore.upsert(update.turn)
+            logCaptionTurnUpdate(update.turn, metadata: ["flushReason": reason.rawValue])
         }
         liveCaptionTurns = liveCaptionStore.turns
         scheduleCaptionTextTranslationIfNeeded()
+    }
+
+    private func currentPerformanceEventLogger() -> PerformanceEventLogger? {
+        selectedMeeting?.performanceEventsURL.map { PerformanceEventLogger(url: $0) }
+    }
+
+    private func logCaptionTurnUpdate(
+        _ turn: LiveCaptionTurn,
+        metadata extraMetadata: [String: String] = [:]
+    ) {
+        var metadata = translationMetadata(for: turn, isDraft: turn.displayState == .draft)
+        metadata["displayState"] = String(describing: turn.displayState)
+        metadata["chunkState"] = String(describing: turn.chunkState)
+        metadata["translationRevision"] = String(turn.translationRevision)
+        for (key, value) in extraMetadata {
+            metadata[key] = value
+        }
+        currentPerformanceEventLogger()?.log(
+            "caption_turn_updated",
+            segmentID: turn.id,
+            isFinal: turn.isFinal,
+            textLength: turn.originalText.count,
+            metadata: metadata
+        )
+    }
+
+    private func logTranslationScheduled(
+        _ turn: LiveCaptionTurn,
+        isDraft: Bool,
+        logger: PerformanceEventLogger?
+    ) {
+        logger?.log(
+            "caption_translation_scheduled",
+            segmentID: turn.id,
+            isFinal: !isDraft,
+            textLength: turn.originalText.count,
+            metadata: translationMetadata(for: turn, isDraft: isDraft)
+        )
+    }
+
+    private func translationMetadata(
+        for turn: LiveCaptionTurn,
+        isDraft: Bool,
+        extra: [String: String] = [:]
+    ) -> [String: String] {
+        var metadata: [String: String] = [
+            "turnID": turn.id,
+            "sourceSegmentID": turn.sourceSegmentID,
+            "sourceSegmentIDs": turn.sourceSegmentIDs.joined(separator: ","),
+            "sourceLocale": turn.sourceLocale,
+            "targetLocale": turn.targetLocale,
+            "translationKind": isDraft ? "draft" : "final"
+        ]
+        if let boundaryStrength = turn.boundaryStrength {
+            metadata["boundaryStrength"] = String(describing: boundaryStrength)
+        }
+        if let boundaryReason = turn.boundaryReason {
+            metadata["boundaryReason"] = boundaryReason.rawValue
+        }
+        for (key, value) in extra {
+            metadata[key] = value
+        }
+        return metadata
     }
 
     private func scheduleCaptionTextTranslationIfNeeded() {
@@ -942,17 +1018,40 @@ public final class MeetingAgentViewModel: ObservableObject {
         guard !draftCandidates.isEmpty || !finalCandidates.isEmpty else { return }
         guard let provider = captionTranslationProviderFactory(speechConfiguration) else { return }
 
+        let performanceEventLogger = currentPerformanceEventLogger()
         let draftRequests = draftCandidates.map { turn -> CaptionTranslationRequest in
             let key = draftCaptionTranslationKey(for: turn)
             draftTranslationInFlightByTurnID[turn.id] = turn.translationRevision
             draftTranslationAttemptDatesByTurnID[turn.id] = Date()
-            return CaptionTranslationRequest(turn: turn, key: key, isDraft: true, revision: turn.translationRevision)
+            logTranslationScheduled(
+                turn,
+                isDraft: true,
+                logger: performanceEventLogger
+            )
+            return CaptionTranslationRequest(
+                turn: turn,
+                key: key,
+                isDraft: true,
+                revision: turn.translationRevision,
+                performanceEventLogger: performanceEventLogger
+            )
         }
 
         let finalRequests = finalCandidates.map { turn -> CaptionTranslationRequest in
             let key = finalCaptionTranslationKey(for: turn)
             finalTranslationInFlightTurnIDs.insert(turn.id)
-            return CaptionTranslationRequest(turn: turn, key: key, isDraft: false, revision: turn.translationRevision)
+            logTranslationScheduled(
+                turn,
+                isDraft: false,
+                logger: performanceEventLogger
+            )
+            return CaptionTranslationRequest(
+                turn: turn,
+                key: key,
+                isDraft: false,
+                revision: turn.translationRevision,
+                performanceEventLogger: performanceEventLogger
+            )
         }
 
         let requests = draftRequests + finalRequests
@@ -1004,11 +1103,25 @@ public final class MeetingAgentViewModel: ObservableObject {
                 createdAt: turn.createdAt
             )
             do {
+                request.performanceEventLogger?.log(
+                    "caption_translation_started",
+                    segmentID: turn.id,
+                    isFinal: !request.isDraft,
+                    textLength: sourceText.count,
+                    metadata: translationMetadata(for: turn, isDraft: request.isDraft)
+                )
                 let translated = try await provider.translate(
                     transcript: TranscriptDocument(segments: [segment]),
                     options: TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
                 )
                 let translatedText = translated.segments.first { $0.id == turn.sourceSegmentID }?.targetText ?? ""
+                request.performanceEventLogger?.log(
+                    "caption_translation_finished",
+                    segmentID: turn.id,
+                    isFinal: !request.isDraft,
+                    textLength: translatedText.count,
+                    metadata: translationMetadata(for: turn, isDraft: request.isDraft)
+                )
                 if request.isDraft {
                     acceptDraftTranslation(request, translatedText: translatedText)
                 } else {
@@ -1016,6 +1129,17 @@ public final class MeetingAgentViewModel: ObservableObject {
                 }
             } catch {
                 let nsError = error as NSError
+                request.performanceEventLogger?.log(
+                    "caption_translation_failed",
+                    segmentID: turn.id,
+                    isFinal: !request.isDraft,
+                    textLength: sourceText.count,
+                    metadata: translationMetadata(
+                        for: turn,
+                        isDraft: request.isDraft,
+                        extra: ["error": "\(nsError.domain) error \(nsError.code)"]
+                    )
+                )
                 liveCaptionStore.markTranslationFailed(forTurnID: turn.id, message: "\(nsError.domain) error \(nsError.code)")
                 liveCaptionTurns = liveCaptionStore.turns
                 clearTranslationInFlight(request)
@@ -1055,6 +1179,13 @@ public final class MeetingAgentViewModel: ObservableObject {
             return
         }
         liveCaptionStore.attachTranslation(translatedText, toTurnID: request.turn.id)
+        request.performanceEventLogger?.log(
+            "caption_translation_attached",
+            segmentID: request.turn.id,
+            isFinal: false,
+            textLength: translatedText.count,
+            metadata: translationMetadata(for: request.turn, isDraft: true)
+        )
         draftTranslationKeysByTurnID[request.turn.id] = request.key
         draftTranslationCharacterCountsByTurnID[request.turn.id] = current.originalText.count
         liveCaptionTurns = liveCaptionStore.turns
@@ -1071,6 +1202,13 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
         liveCaptionStore.attachTranslation(translatedText, toTurnID: request.turn.id)
         liveCaptionStore.markTranslationFinal(forTurnID: request.turn.id)
+        request.performanceEventLogger?.log(
+            "caption_translation_attached",
+            segmentID: request.turn.id,
+            isFinal: true,
+            textLength: translatedText.count,
+            metadata: translationMetadata(for: request.turn, isDraft: false)
+        )
         finalTranslationKeysByTurnID[request.turn.id] = request.key
         liveCaptionTurns = liveCaptionStore.turns
     }

--- a/Sources/MeetingAgentCore/MeetingRecord.swift
+++ b/Sources/MeetingAgentCore/MeetingRecord.swift
@@ -68,6 +68,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
     public var summaryJSONURL: URL?
     public var summaryMarkdownURL: URL?
     public var diagnosticsURL: URL?
+    public var performanceEventsURL: URL?
     public var transcriptionStatus: TranscriptionStatus
     public var transcriptionFailureReason: String?
     public var speechProvider: SpeechProvider
@@ -92,6 +93,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         summaryJSONURL: URL? = nil,
         summaryMarkdownURL: URL? = nil,
         diagnosticsURL: URL? = nil,
+        performanceEventsURL: URL? = nil,
         transcriptionStatus: TranscriptionStatus = .notStarted,
         transcriptionFailureReason: String? = nil,
         speechProvider: SpeechProvider = .whisper,
@@ -115,6 +117,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         self.summaryJSONURL = summaryJSONURL
         self.summaryMarkdownURL = summaryMarkdownURL ?? summaryURL
         self.diagnosticsURL = diagnosticsURL
+        self.performanceEventsURL = performanceEventsURL
         self.transcriptionStatus = transcriptionStatus
         self.transcriptionFailureReason = transcriptionFailureReason
         self.speechProvider = speechProvider
@@ -143,6 +146,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         case summaryJSONURL
         case summaryMarkdownURL
         case diagnosticsURL
+        case performanceEventsURL
         case transcriptionStatus
         case transcriptionFailureReason
         case speechProvider
@@ -169,6 +173,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         summaryJSONURL = try container.decodeIfPresent(URL.self, forKey: .summaryJSONURL)
         summaryMarkdownURL = try container.decodeIfPresent(URL.self, forKey: .summaryMarkdownURL) ?? summaryURL
         diagnosticsURL = try container.decodeIfPresent(URL.self, forKey: .diagnosticsURL)
+        performanceEventsURL = try container.decodeIfPresent(URL.self, forKey: .performanceEventsURL)
         transcriptionStatus = try container.decodeIfPresent(TranscriptionStatus.self, forKey: .transcriptionStatus) ?? .notStarted
         transcriptionFailureReason = try container.decodeIfPresent(String.self, forKey: .transcriptionFailureReason)
         speechProvider = try container.decodeIfPresent(SpeechProvider.self, forKey: .speechProvider) ?? .whisper

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -11,10 +11,11 @@ public final class MeetingRecorder {
     private var activeRecord: MeetingRecord?
     private let captureSessionFactory: () -> AudioCaptureSessionManaging
     private let wavWriterFactory: (URL, UInt32, UInt16) throws -> AudioFrameWriting
-    private let transcriberFactory: (SpeechTranscriptionConfiguration, URL, Double, Int) async throws -> AudioFrameTranscriber
+    private let transcriberFactory: (SpeechTranscriptionConfiguration, URL, Double, Int, PerformanceEventLogger?) async throws -> AudioFrameTranscriber
     private var captureSession: AudioCaptureSessionManaging?
     private var writer: AudioFrameWriting?
     private var transcriber: AudioFrameTranscriber?
+    private var performanceEventLogger: PerformanceEventLogger?
     private var diagnosticsTracker: CaptureDiagnosticsTracker?
     private var pendingTranscriptionFrames: [AudioFrame] = []
     private var isStartingTranscriber = false
@@ -30,12 +31,13 @@ public final class MeetingRecorder {
             wavWriterFactory: { url, sampleRate, channelCount in
                 try WavFileWriter(url: url, sampleRate: sampleRate, channelCount: channelCount)
             },
-            transcriberFactory: { configuration, transcriptURL, sampleRate, channelCount in
+            transcriberFactory: { configuration, transcriptURL, sampleRate, channelCount, performanceEventLogger in
                 try await StreamingSpeechTranscriberFactory.startTranscriber(
                     configuration: configuration,
                     transcriptURL: transcriptURL,
                     sampleRate: sampleRate,
-                    channelCount: channelCount
+                    channelCount: channelCount,
+                    performanceEventLogger: performanceEventLogger
                 )
             }
         )
@@ -45,7 +47,7 @@ public final class MeetingRecorder {
         store: MeetingStore,
         captureSessionFactory: @escaping () -> AudioCaptureSessionManaging,
         wavWriterFactory: @escaping (URL, UInt32, UInt16) throws -> AudioFrameWriting,
-        transcriberFactory: @escaping (SpeechTranscriptionConfiguration, URL, Double, Int) async throws -> AudioFrameTranscriber
+        transcriberFactory: @escaping (SpeechTranscriptionConfiguration, URL, Double, Int, PerformanceEventLogger?) async throws -> AudioFrameTranscriber
     ) {
         self.store = store
         self.captureSessionFactory = captureSessionFactory
@@ -66,6 +68,14 @@ public final class MeetingRecorder {
             startedAt: startedAt
         )
         activeRecord = stored.record
+        performanceEventLogger = stored.record.performanceEventsURL.map { PerformanceEventLogger(url: $0) }
+        performanceEventLogger?.log(
+            "meeting_prepared",
+            metadata: [
+                "meetingID": stored.record.id.uuidString,
+                "targetDisplayName": target.displayName
+            ]
+        )
         diagnosticsTracker = CaptureDiagnosticsTracker(target: target)
         state = .prepared(stored.record.id)
         return stored.record
@@ -80,6 +90,14 @@ public final class MeetingRecorder {
         }
 
         activeRecord = record
+        performanceEventLogger = record.performanceEventsURL.map { PerformanceEventLogger(url: $0) }
+        performanceEventLogger?.log(
+            "meeting_prepared",
+            metadata: [
+                "meetingID": record.id.uuidString,
+                "targetDisplayName": target.displayName
+            ]
+        )
         diagnosticsTracker = CaptureDiagnosticsTracker(target: target)
         state = .prepared(record.id)
         try store.save(record)
@@ -109,6 +127,17 @@ public final class MeetingRecorder {
         updatedRecord.transcriptionStatus = .transcribing
         updatedRecord.transcriptionFailureReason = nil
         activeRecord = updatedRecord
+        if performanceEventLogger == nil {
+            performanceEventLogger = updatedRecord.performanceEventsURL.map { PerformanceEventLogger(url: $0) }
+        }
+        performanceEventLogger?.log(
+            "recording_starting",
+            metadata: [
+                "meetingID": updatedRecord.id.uuidString,
+                "transcriptionProviderID": updatedRecord.transcriptionProviderID,
+                "speechLocaleIdentifier": updatedRecord.speechLocaleIdentifier
+            ]
+        )
         pendingTranscriptionFrames = []
         isStartingTranscriber = false
         try store.save(updatedRecord)
@@ -126,6 +155,13 @@ public final class MeetingRecorder {
             sampleRate: session.outputSampleRate,
             channelCount: session.outputChannelCount
         )
+        performanceEventLogger?.log(
+            "capture_started",
+            metadata: [
+                "sampleRate": String(session.outputSampleRate),
+                "channelCount": String(session.outputChannelCount)
+            ]
+        )
 
         if let audioURL = updatedRecord.audioURL {
             writer = try wavWriterFactory(
@@ -142,7 +178,8 @@ public final class MeetingRecorder {
                     effectiveConfiguration,
                     transcriptURL,
                     session.outputSampleRate,
-                    session.outputChannelCount
+                    session.outputChannelCount,
+                    performanceEventLogger
                 )
                 transcriber = startedTranscriber
                 isStartingTranscriber = false
@@ -151,11 +188,16 @@ public final class MeetingRecorder {
                 isStartingTranscriber = false
                 pendingTranscriptionFrames = []
                 try markTranscriptionFailed("Speech recognition unavailable: \(error)")
+                performanceEventLogger?.log(
+                    "transcriber_start_failed",
+                    metadata: ["error": String(describing: error)]
+                )
                 transcriber = nil
             }
         }
 
         state = .recording(record.id)
+        performanceEventLogger?.log("recording_started")
     }
 
     public func drainFrames() throws {
@@ -163,6 +205,19 @@ public final class MeetingRecorder {
         let bufferBacklog = session.frameBuffer.count
         let droppedFrameCount = session.frameBuffer.droppedFrameCount
         let frames = session.frameBuffer.drain()
+        if let first = frames.first, let last = frames.last {
+            performanceEventLogger?.log(
+                "audio_frames_drained",
+                audioTimeSeconds: TimeInterval(last.timestampNanos) / 1_000_000_000,
+                metadata: [
+                    "frameCount": String(frames.count),
+                    "firstFrameTimestampNanos": String(first.timestampNanos),
+                    "lastFrameTimestampNanos": String(last.timestampNanos),
+                    "bufferBacklog": String(bufferBacklog),
+                    "droppedFrameCount": String(droppedFrameCount)
+                ]
+            )
+        }
         diagnosticsTracker?.record(
             frames: frames,
             bufferBacklog: bufferBacklog,
@@ -186,6 +241,10 @@ public final class MeetingRecorder {
         try writer?.close()
         let activeTranscriber = transcriber
         activeTranscriber?.finish()
+        performanceEventLogger?.log(
+            "recording_stopping",
+            metadata: ["endedReason": endedReason.rawValue]
+        )
         if let failureReason = activeTranscriber?.failureReason {
             try markTranscriptionFailed(failureReason)
         }
@@ -215,6 +274,15 @@ public final class MeetingRecorder {
         try diagnosticsTracker?.snapshot().writeIfPossible(to: record.diagnosticsURL)
         diagnosticsTracker = nil
         try store.save(record)
+        performanceEventLogger?.log(
+            "recording_stopped",
+            metadata: [
+                "meetingID": record.id.uuidString,
+                "endedReason": endedReason.rawValue,
+                "transcriptionStatus": record.transcriptionStatus.rawValue
+            ]
+        )
+        performanceEventLogger = nil
         activeRecord = nil
         state = .idle
         return record

--- a/Sources/MeetingAgentCore/MeetingStore.swift
+++ b/Sources/MeetingAgentCore/MeetingStore.swift
@@ -46,7 +46,8 @@ public final class MeetingStore {
             summaryURL: directory.appendingPathComponent("summary.md"),
             summaryJSONURL: directory.appendingPathComponent("summary.json"),
             summaryMarkdownURL: directory.appendingPathComponent("summary.md"),
-            diagnosticsURL: directory.appendingPathComponent("diagnostics.json")
+            diagnosticsURL: directory.appendingPathComponent("diagnostics.json"),
+            performanceEventsURL: directory.appendingPathComponent("performance-events.jsonl")
         )
         try save(record)
         return StoredMeeting(
@@ -88,6 +89,10 @@ public final class MeetingStore {
             var didBackfill = false
             if record.meetingProgressJSONURL == nil {
                 record.meetingProgressJSONURL = directory.appendingPathComponent("meeting-progress.json")
+                didBackfill = true
+            }
+            if record.performanceEventsURL == nil {
+                record.performanceEventsURL = directory.appendingPathComponent("performance-events.jsonl")
                 didBackfill = true
             }
             if backfillTranscriptionProviderIDIfNeeded(&record) {

--- a/Sources/MeetingAgentCore/PerformanceEventLogger.swift
+++ b/Sources/MeetingAgentCore/PerformanceEventLogger.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+public struct PerformanceEvent: Codable, Equatable {
+    public let event: String
+    public let wallTime: Date
+    public let audioTimeSeconds: Double?
+    public let segmentID: String?
+    public let isFinal: Bool?
+    public let textLength: Int?
+    public let metadata: [String: String]
+
+    public init(
+        event: String,
+        wallTime: Date = Date(),
+        audioTimeSeconds: Double? = nil,
+        segmentID: String? = nil,
+        isFinal: Bool? = nil,
+        textLength: Int? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        self.event = event
+        self.wallTime = wallTime
+        self.audioTimeSeconds = audioTimeSeconds
+        self.segmentID = segmentID
+        self.isFinal = isFinal
+        self.textLength = textLength
+        self.metadata = metadata
+    }
+}
+
+public final class PerformanceEventLogger {
+    private let url: URL
+    private let encoder: JSONEncoder
+    private let lock = NSLock()
+    private let now: () -> Date
+
+    public init(url: URL, now: @escaping () -> Date = Date.init) {
+        self.url = url
+        self.now = now
+        encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+    }
+
+    public func log(
+        _ event: String,
+        audioTimeSeconds: Double? = nil,
+        segmentID: String? = nil,
+        isFinal: Bool? = nil,
+        textLength: Int? = nil,
+        metadata: [String: String] = [:]
+    ) {
+        append(PerformanceEvent(
+            event: event,
+            wallTime: now(),
+            audioTimeSeconds: audioTimeSeconds,
+            segmentID: segmentID,
+            isFinal: isFinal,
+            textLength: textLength,
+            metadata: metadata
+        ))
+    }
+
+    public func append(_ event: PerformanceEvent) {
+        lock.lock()
+        defer { lock.unlock() }
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let line = try encoder.encode(event) + Data([0x0A])
+            if FileManager.default.fileExists(atPath: url.path) {
+                let handle = try FileHandle(forWritingTo: url)
+                try handle.seekToEnd()
+                try handle.write(contentsOf: line)
+                try handle.close()
+            } else {
+                try line.write(to: url, options: .atomic)
+            }
+        } catch {
+            // Performance logging must never affect recording or transcription.
+        }
+    }
+}
+
+public extension PerformanceEventLogger {
+    func logSegment(_ event: String, segment: TranscriptSegment, metadata: [String: String] = [:]) {
+        log(
+            event,
+            audioTimeSeconds: segment.endTimeSeconds,
+            segmentID: segment.id,
+            isFinal: segment.isFinal,
+            textLength: segment.text.count,
+            metadata: metadata
+        )
+    }
+}

--- a/Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift
@@ -41,22 +41,25 @@ public struct SpeechTranscriptionContext: Equatable {
     }
 }
 
-public struct SpeechTranscriptionStreamContext: Equatable {
+public struct SpeechTranscriptionStreamContext {
     public let transcriptURL: URL
     public let localeIdentifier: String
     public let sampleRate: Double
     public let channelCount: Int
+    public let performanceEventLogger: PerformanceEventLogger?
 
     public init(
         transcriptURL: URL,
         localeIdentifier: String,
         sampleRate: Double,
-        channelCount: Int
+        channelCount: Int,
+        performanceEventLogger: PerformanceEventLogger? = nil
     ) {
         self.transcriptURL = transcriptURL
         self.localeIdentifier = localeIdentifier
         self.sampleRate = sampleRate
         self.channelCount = channelCount
+        self.performanceEventLogger = performanceEventLogger
     }
 }
 
@@ -98,13 +101,15 @@ public enum StreamingSpeechTranscriberFactory {
         configuration: SpeechTranscriptionConfiguration,
         transcriptURL: URL,
         sampleRate: Double,
-        channelCount: Int
+        channelCount: Int,
+        performanceEventLogger: PerformanceEventLogger? = nil
     ) async throws -> AudioFrameTranscriber {
         let context = SpeechTranscriptionStreamContext(
             transcriptURL: transcriptURL,
             localeIdentifier: configuration.localeIdentifier,
             sampleRate: sampleRate,
-            channelCount: channelCount
+            channelCount: channelCount,
+            performanceEventLogger: performanceEventLogger
         )
         if configuration.usesDeepgram {
             return try await DeepgramStreamingSpeechTranscriptionProvider(

--- a/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeepgramStreamingTranscriptionProviderTests.swift
@@ -131,9 +131,13 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         let transcriptURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("deepgram-stream-\(UUID().uuidString)")
             .appendingPathExtension("txt")
+        let performanceURL = transcriptURL.deletingLastPathComponent()
+            .appendingPathComponent("performance-\(UUID().uuidString)")
+            .appendingPathExtension("jsonl")
         defer {
             try? FileManager.default.removeItem(at: transcriptURL)
             try? FileManager.default.removeItem(at: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+            try? FileManager.default.removeItem(at: performanceURL)
         }
         let session = FakeDeepgramStreamingSession()
         let client = FakeDeepgramStreamingClient(session: session)
@@ -146,7 +150,8 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
             transcriptURL: transcriptURL,
             localeIdentifier: "en-US",
             sampleRate: 48_000,
-            channelCount: 1
+            channelCount: 1,
+            performanceEventLogger: PerformanceEventLogger(url: performanceURL)
         ))
         let frame = AudioFrame(pcm: Data([1, 2, 3, 4]), sampleRate: 48_000, channelCount: 1, timestampNanos: 10)
 
@@ -175,6 +180,9 @@ final class DeepgramStreamingTranscriptionProviderTests: XCTestCase {
         )
         XCTAssertEqual(document.segments.first?.text, "hello live")
         XCTAssertEqual(document.segments.first?.sourceProvider, "deepgram-transcribe")
+        let performanceEvents = try performanceEventNames(at: performanceURL)
+        XCTAssertTrue(performanceEvents.contains("stt_segment_received"))
+        XCTAssertTrue(performanceEvents.contains("transcript_segment_written"))
     }
 
     func testStreamingResponseMapsInterimTranscriptToNonFinalSegment() throws {
@@ -617,6 +625,12 @@ private final class RecordingDeepgramRawResponseLogger: DeepgramRawResponseLogge
     func logRawResponse(_ data: Data, context: DeepgramRawResponseContext) {
         entries.append(Entry(data: data, context: context))
     }
+}
+
+private func performanceEventNames(at url: URL) throws -> [String] {
+    try String(contentsOf: url, encoding: .utf8)
+        .split(separator: "\n")
+        .map { try JSONDecoder.meetingAgent.decode(PerformanceEvent.self, from: Data($0.utf8)).event }
 }
 
 private final class FakeDeepgramStreamingSession: DeepgramStreamingTranscriptionSession {

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -2222,7 +2222,8 @@ private final class ViewModelFakeTranscriberFactory {
         configuration: SpeechTranscriptionConfiguration,
         transcriptURL: URL,
         sampleRate: Double,
-        channelCount: Int
+        channelCount: Int,
+        performanceEventLogger: PerformanceEventLogger?
     ) async throws -> AudioFrameTranscriber {
         requests.append(Request(localeIdentifier: configuration.localeIdentifier))
         return transcriber

--- a/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
@@ -92,6 +92,10 @@ final class MeetingRecorderTests: XCTestCase {
         XCTAssertEqual(stopped?.endedAt, Date(timeIntervalSince1970: 200))
         XCTAssertEqual(stopped?.transcriptionStatus, .transcribed)
         XCTAssertEqual(fixture.recorder.state, .idle)
+        let performanceEvents = try performanceEventNames(at: XCTUnwrap(record.performanceEventsURL))
+        XCTAssertTrue(performanceEvents.contains("recording_started"))
+        XCTAssertTrue(performanceEvents.contains("audio_frames_drained"))
+        XCTAssertTrue(performanceEvents.contains("recording_stopped"))
     }
 
     func testPrepareRecordCanReuseExistingAgendaRecord() throws {
@@ -358,7 +362,8 @@ private final class FakeRecorderTranscriberFactory {
         configuration: SpeechTranscriptionConfiguration,
         transcriptURL: URL,
         sampleRate: Double,
-        channelCount: Int
+        channelCount: Int,
+        performanceEventLogger: PerformanceEventLogger?
     ) async throws -> AudioFrameTranscriber {
         requests.append(Request(
             localeIdentifier: configuration.localeIdentifier,
@@ -396,6 +401,12 @@ private func waitFor(
         try await Task.sleep(nanoseconds: interval)
     }
     XCTAssertTrue(condition(), "Timed out waiting for condition")
+}
+
+private func performanceEventNames(at url: URL) throws -> [String] {
+    try String(contentsOf: url, encoding: .utf8)
+        .split(separator: "\n")
+        .map { try JSONDecoder.meetingAgent.decode(PerformanceEvent.self, from: Data($0.utf8)).event }
 }
 
 private func XCTAssertThrowsErrorAsync(

--- a/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
@@ -23,6 +23,7 @@ final class MeetingStoreTests: XCTestCase {
         XCTAssertEqual(created.record.summaryMarkdownURL?.lastPathComponent, "summary.md")
         XCTAssertEqual(created.record.diagnosticsURL?.lastPathComponent, "diagnostics.json")
         XCTAssertEqual(created.record.meetingProgressJSONURL?.lastPathComponent, "meeting-progress.json")
+        XCTAssertEqual(created.record.performanceEventsURL?.lastPathComponent, "performance-events.jsonl")
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.directory.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: created.metadataURL.path))
     }
@@ -168,5 +169,7 @@ final class MeetingStoreTests: XCTestCase {
 
         XCTAssertEqual(loaded.first?.meetingProgressJSONURL?.lastPathComponent, "meeting-progress.json")
         XCTAssertEqual(saved.meetingProgressJSONURL?.lastPathComponent, "meeting-progress.json")
+        XCTAssertEqual(loaded.first?.performanceEventsURL?.lastPathComponent, "performance-events.jsonl")
+        XCTAssertEqual(saved.performanceEventsURL?.lastPathComponent, "performance-events.jsonl")
     }
 }

--- a/Tests/MeetingAgentCoreTests/PerformanceEventLoggerTests.swift
+++ b/Tests/MeetingAgentCoreTests/PerformanceEventLoggerTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class PerformanceEventLoggerTests: XCTestCase {
+    func testAppendsJSONLinesWithoutThrowing() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("performance-events-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let url = root.appendingPathComponent("performance-events.jsonl")
+        var now = Date(timeIntervalSince1970: 1_000)
+        let logger = PerformanceEventLogger(url: url) { now }
+
+        logger.log(
+            "recording_started",
+            audioTimeSeconds: 1.5,
+            segmentID: "segment-1",
+            isFinal: true,
+            textLength: 5,
+            metadata: ["provider": "deepgram-transcribe"]
+        )
+        now = Date(timeIntervalSince1970: 1_001)
+        logger.log("recording_stopped")
+
+        let lines = try String(contentsOf: url, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+        XCTAssertEqual(lines.count, 2)
+
+        let first = try JSONDecoder.meetingAgent.decode(PerformanceEvent.self, from: Data(lines[0].utf8))
+        let second = try JSONDecoder.meetingAgent.decode(PerformanceEvent.self, from: Data(lines[1].utf8))
+        XCTAssertEqual(first.event, "recording_started")
+        XCTAssertEqual(first.audioTimeSeconds, 1.5)
+        XCTAssertEqual(first.segmentID, "segment-1")
+        XCTAssertEqual(first.isFinal, true)
+        XCTAssertEqual(first.textLength, 5)
+        XCTAssertEqual(first.metadata["provider"], "deepgram-transcribe")
+        XCTAssertEqual(second.event, "recording_stopped")
+    }
+}


### PR DESCRIPTION
## Summary
- add per-meeting performance-events.jsonl logging for recording, STT, transcript, captions, and caption translation stages
- persist the performance log URL in meeting metadata and backfill it for legacy meetings
- add tests for JSONL logging, meeting metadata, recorder logging, and Deepgram streaming instrumentation

## Testing
- make test (475 tests, 0 failures; coverage gate passed)

## Notes
For latency analysis, this replaces the need to enable MEETING_AGENT_DEEPGRAM_RAW_RESPONSE_LOG=1 during normal recordings. Keep that flag for raw Deepgram payload debugging.