### PR TITLE
feat: show subtitle group times

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -333,3 +333,19 @@ Live caption translation skip logic should compare each turn's actual source loc
 When a setting is redefined or removed, audit behavior against the runtime data that now represents that concept instead of the old configuration field.
 
 ---
+
+## [58] Trace display metadata through pre-render coalescing
+
+**Date**: 2026-04-29
+**Category**: logic-error
+
+### What went wrong
+The first subtitle timestamp design put `startedAt` on speaker groups, but review found that same-speaker caption turns could already be merged by `LiveCaptionStore`, with `createdAt` overwritten by the latest segment before grouping.
+
+### Correct approach
+When displaying first-item metadata for grouped UI state, preserve that metadata at every earlier coalescing layer, not only in the final view grouping type.
+
+### How to avoid
+For grouped display metadata, trace the data from source segment to store merge to view grouping before treating a group-level test as sufficient.
+
+---

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -1020,6 +1020,10 @@ private struct BilingualTranscriptGroup: View {
         group.speaker.label ?? group.speaker.identifier ?? "Speaker"
     }
 
+    private var speakerStartTimeText: String {
+        group.startedAt.formatted(date: .omitted, time: .standard)
+    }
+
     @ViewBuilder
     private var speakerLabel: some View {
         if let editSpeaker {
@@ -1029,8 +1033,13 @@ private struct BilingualTranscriptGroup: View {
                 }
             } label: {
                 HStack(spacing: 4) {
-                    Text(speakerDisplayName)
-                        .commandCenterMono()
+                    HStack(spacing: 6) {
+                        Text(speakerDisplayName)
+                            .commandCenterMono()
+                        Text(speakerStartTimeText)
+                            .font(CommandCenterTypography.caption)
+                            .foregroundStyle(CommandCenterPalette.secondaryText)
+                    }
                     Image(systemName: "chevron.down")
                         .font(CommandCenterTypography.caption)
                         .foregroundStyle(CommandCenterPalette.secondaryText)
@@ -1040,8 +1049,13 @@ private struct BilingualTranscriptGroup: View {
             .buttonStyle(.plain)
             .help("Edit speaker name")
         } else {
-            Text(speakerDisplayName)
-                .commandCenterMono()
+            HStack(spacing: 6) {
+                Text(speakerDisplayName)
+                    .commandCenterMono()
+                Text(speakerStartTimeText)
+                    .font(CommandCenterTypography.caption)
+                    .foregroundStyle(CommandCenterPalette.secondaryText)
+            }
         }
     }
 }

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -452,7 +452,6 @@ public struct LiveCaptionStore: Equatable {
         merged.isFinal = turn.isFinal
         merged.captionHealth = turn.captionHealth
         merged.translationHealth = .pending
-        merged.createdAt = turn.createdAt
         merged.displayState = turn.displayState
         merged.translationState = turn.translationState
         merged.boundaryReason = turn.boundaryReason
@@ -469,7 +468,6 @@ public struct LiveCaptionStore: Equatable {
         merged.isFinal = false
         merged.captionHealth = turn.captionHealth
         merged.translationHealth = .pending
-        merged.createdAt = turn.createdAt
         merged.chunkState = .draft
         merged.translationRevision += 1
         merged.freezeReason = nil

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -271,11 +271,13 @@ public struct LiveCaptionSpeakerGroup: Equatable, Identifiable {
     public var id: String
     public var speaker: TranscriptSpeaker
     public var turns: [LiveCaptionTurn]
+    public var startedAt: Date
 
-    public init(id: String, speaker: TranscriptSpeaker, turns: [LiveCaptionTurn]) {
+    public init(id: String, speaker: TranscriptSpeaker, turns: [LiveCaptionTurn], startedAt: Date) {
         self.id = id
         self.speaker = speaker
         self.turns = turns
+        self.startedAt = startedAt
     }
 
     public static func groups(from turns: [LiveCaptionTurn]) -> [LiveCaptionSpeakerGroup] {
@@ -285,7 +287,7 @@ public struct LiveCaptionSpeakerGroup: Equatable, Identifiable {
                groups[lastIndex].speaker == turn.speaker {
                 groups[lastIndex].turns.append(turn)
             } else {
-                groups.append(LiveCaptionSpeakerGroup(id: turn.id, speaker: turn.speaker, turns: [turn]))
+                groups.append(LiveCaptionSpeakerGroup(id: turn.id, speaker: turn.speaker, turns: [turn], startedAt: turn.createdAt))
             }
         }
         return groups

--- a/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
@@ -209,7 +209,7 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(merged.targetLocale, "en-US")
         XCTAssertTrue(merged.isFinal)
         XCTAssertEqual(merged.translationHealth, .pending)
-        XCTAssertEqual(merged.createdAt, Date(timeIntervalSince1970: 120))
+        XCTAssertEqual(merged.createdAt, Date(timeIntervalSince1970: 100))
     }
 
     func testAppendingFinalSegmentFromDifferentSpeakerCreatesNewTurn() {

--- a/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
@@ -86,6 +86,21 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(groups[1].turns.map(\.sourceSegmentID), ["s3"])
     }
 
+    func testSpeakerGroupStartedAtUsesFirstTurnTimestamp() {
+        let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User A")
+        let firstTime = Date(timeIntervalSince1970: 100)
+        let secondTime = Date(timeIntervalSince1970: 140)
+
+        let groups = LiveCaptionSpeakerGroup.groups(from: [
+            LiveCaptionTurn(sourceSegmentID: "s1", speaker: speaker, originalText: "First block.", isFinal: true, createdAt: firstTime),
+            LiveCaptionTurn(sourceSegmentID: "s2", speaker: speaker, originalText: "Second block.", isFinal: true, createdAt: secondTime)
+        ])
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].startedAt, firstTime)
+        XCTAssertEqual(groups[0].turns.map(\.createdAt), [firstTime, secondTime])
+    }
+
     func testSpeakerGroupsStartNewGroupWhenSameSpeakerReturnsAfterDifferentSpeaker() {
         let userA = TranscriptSpeaker(identifier: "speaker-1", label: "User A")
         let userB = TranscriptSpeaker(identifier: "speaker-2", label: "User B")

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -311,6 +311,14 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("Save Caption"))
     }
 
+    func testUnifiedTranscriptRendersSpeakerGroupStartTimeBesideSpeakerName() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("speakerStartTimeText"))
+        XCTAssertTrue(source.contains("group.startedAt.formatted(date: .omitted, time: .standard)"))
+        XCTAssertTrue(source.contains("Text(speakerStartTimeText)"))
+    }
+
     func testMainWindowRemovesUnimplementedMeetingGoalComposer() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")

--- a/docs/superpowers/plans/2026-04-29-subtitle-group-time.md
+++ b/docs/superpowers/plans/2026-04-29-subtitle-group-time.md
@@ -1,0 +1,173 @@
+# Subtitle Group Time Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show local hour-minute-second time beside each live subtitle speaker group label, using the first subtitle in that group.
+
+**Architecture:** The grouping model owns the first-subtitle timestamp because it already defines consecutive speaker-group boundaries. The SwiftUI transcript header formats that timestamp for display while preserving the existing speaker edit menu.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest, Swift Package Manager.
+
+---
+
+### Task 1: Add First-Turn Timestamp To Speaker Groups
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+
+- [ ] **Step 1: Write the failing grouping test**
+
+Add this test near the existing `LiveCaptionSpeakerGroup` tests in `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`:
+
+```swift
+func testSpeakerGroupStartedAtUsesFirstTurnTimestamp() {
+    let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User A")
+    let firstTime = Date(timeIntervalSince1970: 100)
+    let secondTime = Date(timeIntervalSince1970: 140)
+
+    let groups = LiveCaptionSpeakerGroup.groups(from: [
+        LiveCaptionTurn(sourceSegmentID: "s1", speaker: speaker, originalText: "First block.", isFinal: true, createdAt: firstTime),
+        LiveCaptionTurn(sourceSegmentID: "s2", speaker: speaker, originalText: "Second block.", isFinal: true, createdAt: secondTime)
+    ])
+
+    XCTAssertEqual(groups.count, 1)
+    XCTAssertEqual(groups[0].startedAt, firstTime)
+    XCTAssertEqual(groups[0].turns.map(\.createdAt), [firstTime, secondTime])
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `swift test --filter LiveCaptionStoreTests/testSpeakerGroupStartedAtUsesFirstTurnTimestamp`
+
+Expected: compile failure because `LiveCaptionSpeakerGroup` has no `startedAt` member.
+
+- [ ] **Step 3: Add the model field and grouping behavior**
+
+In `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`, update `LiveCaptionSpeakerGroup`:
+
+```swift
+public struct LiveCaptionSpeakerGroup: Equatable, Identifiable {
+    public var id: String
+    public var speaker: TranscriptSpeaker
+    public var turns: [LiveCaptionTurn]
+    public var startedAt: Date
+
+    public init(id: String, speaker: TranscriptSpeaker, turns: [LiveCaptionTurn], startedAt: Date) {
+        self.id = id
+        self.speaker = speaker
+        self.turns = turns
+        self.startedAt = startedAt
+    }
+
+    public static func groups(from turns: [LiveCaptionTurn]) -> [LiveCaptionSpeakerGroup] {
+        var groups: [LiveCaptionSpeakerGroup] = []
+        for turn in turns {
+            if let lastIndex = groups.indices.last,
+               groups[lastIndex].speaker == turn.speaker {
+                groups[lastIndex].turns.append(turn)
+            } else {
+                groups.append(LiveCaptionSpeakerGroup(
+                    id: turn.id,
+                    speaker: turn.speaker,
+                    turns: [turn],
+                    startedAt: turn.createdAt
+                ))
+            }
+        }
+        return groups
+    }
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run: `swift test --filter LiveCaptionStoreTests/testSpeakerGroupStartedAtUsesFirstTurnTimestamp`
+
+Expected: PASS.
+
+### Task 2: Render Group Time Beside Speaker Label
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write the failing layout guard**
+
+Add this test near the existing unified transcript tests:
+
+```swift
+func testUnifiedTranscriptRendersSpeakerGroupStartTimeBesideSpeakerName() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("speakerStartTimeText"))
+    XCTAssertTrue(source.contains("group.startedAt.formatted(date: .omitted, time: .standard)"))
+    XCTAssertTrue(source.contains("Text(speakerStartTimeText)"))
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testUnifiedTranscriptRendersSpeakerGroupStartTimeBesideSpeakerName`
+
+Expected: FAIL because the timestamp renderer is not present.
+
+- [ ] **Step 3: Update the speaker header UI**
+
+In `Sources/MeetingAgentApp/MainWindowView.swift`, add this helper inside `BilingualTranscriptGroup`:
+
+```swift
+private var speakerStartTimeText: String {
+    group.startedAt.formatted(date: .omitted, time: .standard)
+}
+```
+
+Then update both editable and non-editable branches of `speakerLabel` so the speaker name and timestamp appear together:
+
+```swift
+HStack(spacing: 6) {
+    Text(speakerDisplayName)
+        .commandCenterMono()
+    Text(speakerStartTimeText)
+        .font(CommandCenterTypography.caption)
+        .foregroundStyle(CommandCenterPalette.secondaryText)
+}
+```
+
+Keep the menu chevron only in the editable menu label.
+
+- [ ] **Step 4: Run the focused layout test and verify it passes**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testUnifiedTranscriptRendersSpeakerGroupStartTimeBesideSpeakerName`
+
+Expected: PASS.
+
+### Task 3: Full Verification And Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+
+Expected: PASS with coverage check passing.
+
+- [ ] **Step 2: Review diff**
+
+Run: `git diff -- Sources/MeetingAgentCore/LiveMeetingCockpit.swift Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+Expected: diff only includes the speaker group timestamp model, UI rendering, and regression tests.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/LiveMeetingCockpit.swift Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: show subtitle group times (#58)"
+```

--- a/docs/superpowers/specs/2026-04-29-subtitle-group-time-design.md
+++ b/docs/superpowers/specs/2026-04-29-subtitle-group-time-design.md
@@ -1,0 +1,39 @@
+# Subtitle Group Time Design
+
+## Context
+
+Issue #58 asks to show the local time after the subtitle speaker label, for example after `User A`. The current live transcript UI groups consecutive subtitle turns by speaker in `LiveCaptionSpeakerGroup` and renders one speaker header above the grouped subtitle blocks.
+
+## Requirements
+
+- Show a local time beside each live subtitle speaker group header.
+- Use the first subtitle turn in the group as the displayed time.
+- Format the time with hour, minute, and second precision.
+- Preserve existing speaker editing behavior from the speaker header menu.
+- Do not change transcript export, summary generation, or persisted transcript formats.
+
+## Non-Requirements
+
+- Do not show a different timestamp per subtitle line inside the group.
+- Do not update the group timestamp when later turns are appended to the same speaker group.
+- Do not add settings for time format in this change.
+
+## Approach
+
+Add a `startedAt` field to `LiveCaptionSpeakerGroup`. `groups(from:)` sets `startedAt` from the first turn when creating a group and leaves it unchanged when later consecutive turns from the same speaker are appended. `BilingualTranscriptGroup` formats `group.startedAt` with local time, showing hours, minutes, and seconds beside the speaker display name.
+
+This keeps the timing rule in the grouping model, where the "first subtitle in this speaker group" boundary already lives. The UI only formats and displays that model value.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`: add `startedAt` to speaker groups and preserve first-turn timestamp during grouping.
+- `Sources/MeetingAgentApp/MainWindowView.swift`: render the group timestamp in the speaker header.
+- `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`: verify speaker groups use the first turn timestamp.
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`: guard that the speaker header includes timestamp rendering.
+
+## Test Plan
+
+- Add a unit test that creates two consecutive same-speaker turns with different `createdAt` values and asserts the group `startedAt` is the first value.
+- Add a unit test or extend an existing grouping test to assert separate groups get their own first-turn timestamp.
+- Add a source layout guard for the timestamp formatter and speaker header rendering.
+- Run `make test`.


### PR DESCRIPTION
## Summary

Fixes #58

- Show local hour-minute-second time beside each live subtitle speaker group label.
- Preserve the first subtitle timestamp when same-speaker caption turns are merged before rendering.
- Document the design/plan and record the merge-layer lesson learned.

## Changes

- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift` - Add `startedAt` to live caption speaker groups and preserve first-turn `createdAt` during same-speaker merges.
- `Sources/MeetingAgentApp/MainWindowView.swift` - Render the group start time beside the speaker name while keeping the edit menu.
- `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift` - Cover first-turn group timestamps and merged-caption timestamp preservation.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - Guard the speaker header timestamp rendering.
- `docs/superpowers/` and `MISTAKES.md` - Add design, plan, and lesson documentation.

## Test plan

- [x] Build/lint: Swift package build covered by `make test`; no separate lint command in repo conventions.
- [x] Unit tests: `swift test --filter LiveCaptionStoreTests/testSpeakerGroupStartedAtUsesFirstTurnTimestamp` PASS; `swift test --filter MainWindowViewLayoutTests/testUnifiedTranscriptRendersSpeakerGroupStartTimeBesideSpeakerName` PASS; `swift test --filter LiveCaptionStoreTests` PASS.
- [x] Full verification: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/tmp/meeting-agent-coverage-issue-58-review make test` PASS, 466 tests, line coverage 96.72%, method coverage 95.12%.
- [x] E2E/integration: skipped; no E2E convention needed for this model/view display change.
- [x] Code review: PASS after manual Swift review; plovr code-review skill is Java/TypeScript-oriented.
- [x] Manual verification: not applicable; behavior covered by focused model and layout regression tests.
