### PR TITLE
feat: filter silent audio before transcription

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -318,6 +318,22 @@ When asserting actor state in XCTest, split `let value = await actor.value` from
 
 ---
 
+## [56] Keep internal helpers out of the public API
+
+**Date**: 2026-04-29
+**Category**: api-misuse
+
+### What went wrong
+The first silence detector implementation made the new detector public even though only `MeetingRecorder` and `@testable` unit tests needed it.
+
+### Correct approach
+Default new helper types to internal and expose them publicly only when external package callers need them.
+
+### How to avoid
+Before committing a new `public` type or member, verify it is part of the intended package API rather than only an injectable implementation detail.
+
+---
+
 ## [43] Use detected transcript language after source setting removal
 
 **Date**: 2026-04-29

--- a/Sources/MeetingAgentCore/AudioSilenceDetector.swift
+++ b/Sources/MeetingAgentCore/AudioSilenceDetector.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public struct AudioSilenceDetector: Equatable {
+    public let amplitudeThreshold: Int16
+
+    public init(amplitudeThreshold: Int16 = 32) {
+        self.amplitudeThreshold = max(0, amplitudeThreshold)
+    }
+
+    public func isSilent(_ frame: AudioFrame) -> Bool {
+        guard !frame.pcm.isEmpty,
+              frame.pcm.count.isMultiple(of: MemoryLayout<Int16>.size)
+        else {
+            return false
+        }
+
+        let threshold = Int(amplitudeThreshold)
+        var index = 0
+        while index < frame.pcm.count {
+            let low = UInt16(frame.pcm[index])
+            let high = UInt16(frame.pcm[index + 1]) << 8
+            let sample = Int(Int16(bitPattern: high | low))
+            if abs(sample) > threshold {
+                return false
+            }
+            index += MemoryLayout<Int16>.size
+        }
+        return true
+    }
+}

--- a/Sources/MeetingAgentCore/AudioSilenceDetector.swift
+++ b/Sources/MeetingAgentCore/AudioSilenceDetector.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public struct AudioSilenceDetector: Equatable {
-    public let amplitudeThreshold: Int16
+struct AudioSilenceDetector: Equatable {
+    let amplitudeThreshold: Int16
 
-    public init(amplitudeThreshold: Int16 = 32) {
+    init(amplitudeThreshold: Int16 = 32) {
         self.amplitudeThreshold = max(0, amplitudeThreshold)
     }
 
-    public func isSilent(_ frame: AudioFrame) -> Bool {
+    func isSilent(_ frame: AudioFrame) -> Bool {
         guard !frame.pcm.isEmpty,
               frame.pcm.count.isMultiple(of: MemoryLayout<Int16>.size)
         else {

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -12,6 +12,7 @@ public final class MeetingRecorder {
     private let captureSessionFactory: () -> AudioCaptureSessionManaging
     private let wavWriterFactory: (URL, UInt32, UInt16) throws -> AudioFrameWriting
     private let transcriberFactory: (SpeechTranscriptionConfiguration, URL, Double, Int, PerformanceEventLogger?) async throws -> AudioFrameTranscriber
+    private let silenceDetector: AudioSilenceDetector
     private var captureSession: AudioCaptureSessionManaging?
     private var writer: AudioFrameWriting?
     private var transcriber: AudioFrameTranscriber?
@@ -48,12 +49,14 @@ public final class MeetingRecorder {
         store: MeetingStore,
         captureSessionFactory: @escaping () -> AudioCaptureSessionManaging,
         wavWriterFactory: @escaping (URL, UInt32, UInt16) throws -> AudioFrameWriting,
-        transcriberFactory: @escaping (SpeechTranscriptionConfiguration, URL, Double, Int, PerformanceEventLogger?) async throws -> AudioFrameTranscriber
+        transcriberFactory: @escaping (SpeechTranscriptionConfiguration, URL, Double, Int, PerformanceEventLogger?) async throws -> AudioFrameTranscriber,
+        silenceDetector: AudioSilenceDetector = AudioSilenceDetector()
     ) {
         self.store = store
         self.captureSessionFactory = captureSessionFactory
         self.wavWriterFactory = wavWriterFactory
         self.transcriberFactory = transcriberFactory
+        self.silenceDetector = silenceDetector
     }
 
     public func prepareRecord(
@@ -322,6 +325,7 @@ public final class MeetingRecorder {
     }
 
     private func appendFrameToTranscriber(_ frame: AudioFrame) throws {
+        guard !silenceDetector.isSilent(frame) else { return }
         do {
             try transcriber?.append(frame)
         } catch {

--- a/Tests/MeetingAgentCoreTests/AudioSilenceDetectorTests.swift
+++ b/Tests/MeetingAgentCoreTests/AudioSilenceDetectorTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class AudioSilenceDetectorTests: XCTestCase {
+    func testDetectsZeroPCMAsSilent() {
+        let detector = AudioSilenceDetector()
+        let frame = AudioFrame(pcm: pcm([0, 0, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+
+        XCTAssertTrue(detector.isSilent(frame))
+    }
+
+    func testDetectsLowAmplitudePCMAsSilent() {
+        let detector = AudioSilenceDetector(amplitudeThreshold: 4)
+        let frame = AudioFrame(pcm: pcm([-4, 0, 4]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+
+        XCTAssertTrue(detector.isSilent(frame))
+    }
+
+    func testDetectsVoicedPCMAsNonSilent() {
+        let detector = AudioSilenceDetector(amplitudeThreshold: 4)
+        let frame = AudioFrame(pcm: pcm([0, 5]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+
+        XCTAssertFalse(detector.isSilent(frame))
+    }
+
+    func testTreatsEmptyOrMalformedPCMAsNonSilent() {
+        let detector = AudioSilenceDetector()
+
+        XCTAssertFalse(detector.isSilent(AudioFrame(pcm: Data(), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)))
+        XCTAssertFalse(detector.isSilent(AudioFrame(pcm: Data([0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)))
+    }
+}
+
+private func pcm(_ samples: [Int16]) -> Data {
+    var data = Data()
+    for sample in samples {
+        var littleEndian = sample.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+    return data
+}

--- a/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
@@ -63,7 +63,7 @@ final class MeetingRecorderTests: XCTestCase {
 
     func testStartDrainAndStopRecordingWithInjectedCapturePipeline() async throws {
         let fixture = try RecorderFixture()
-        let frame = AudioFrame(pcm: Data([1, 0, 2, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 9)
+        let frame = AudioFrame(pcm: Data([64, 0, 65, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 9)
         fixture.session.frameBuffer.push(frame)
         let consumer = CapturingRealtimeFrameConsumer()
         fixture.recorder.realtimeFrameConsumer = consumer
@@ -96,6 +96,24 @@ final class MeetingRecorderTests: XCTestCase {
         XCTAssertTrue(performanceEvents.contains("recording_started"))
         XCTAssertTrue(performanceEvents.contains("audio_frames_drained"))
         XCTAssertTrue(performanceEvents.contains("recording_stopped"))
+    }
+
+    func testDrainFramesSkipsSilentAudioOnlyForTranscription() async throws {
+        let fixture = try RecorderFixture()
+        let silentFrame = AudioFrame(pcm: Data([0, 0, 2, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+        let voicedFrame = AudioFrame(pcm: Data([64, 0, 0, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 2)
+        let consumer = CapturingRealtimeFrameConsumer()
+        fixture.recorder.realtimeFrameConsumer = consumer
+        fixture.session.frameBuffer.push(silentFrame)
+        fixture.session.frameBuffer.push(voicedFrame)
+        let record = try fixture.recorder.prepareRecord(for: fixture.target)
+
+        try await fixture.recorder.startRecording(target: fixture.target, record: record)
+        try fixture.recorder.drainFrames()
+
+        XCTAssertEqual(fixture.writer.writtenFrames, [silentFrame, voicedFrame])
+        XCTAssertEqual(fixture.transcriber.appendedFrames, [voicedFrame])
+        XCTAssertEqual(consumer.receivedFrames, [silentFrame, voicedFrame])
     }
 
     func testPrepareRecordCanReuseExistingAgendaRecord() throws {
@@ -164,7 +182,7 @@ final class MeetingRecorderTests: XCTestCase {
 
     func testDrainFramesPersistsTranscriptionFailureAndContinuesWritingAudio() async throws {
         let fixture = try RecorderFixture()
-        let frame = AudioFrame(pcm: Data([1, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+        let frame = AudioFrame(pcm: Data([64, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
         fixture.session.frameBuffer.push(frame)
         fixture.transcriber.appendError = ProbeError.speechRecognition("append failed")
         let record = try fixture.recorder.prepareRecord(for: fixture.target)
@@ -182,7 +200,7 @@ final class MeetingRecorderTests: XCTestCase {
     func testDrainFramesBeforeTranscriberReadyFlushesStartupFramesWhenReady() async throws {
         let fixture = try RecorderFixture()
         fixture.transcriberFactory.shouldSuspend = true
-        let frame = AudioFrame(pcm: Data([9, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+        let frame = AudioFrame(pcm: Data([64, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
         let record = try fixture.recorder.prepareRecord(for: fixture.target)
 
         let startTask = Task {
@@ -203,7 +221,7 @@ final class MeetingRecorderTests: XCTestCase {
 
     func testDrainDuringWriterSetupDoesNotDropStartupAudio() async throws {
         let fixture = try RecorderFixture()
-        let frame = AudioFrame(pcm: Data([8, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+        let frame = AudioFrame(pcm: Data([64, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
         fixture.writerFactory.onMakeWriter = {
             fixture.session.frameBuffer.push(frame)
             try? fixture.recorder.drainFrames()
@@ -223,7 +241,7 @@ final class MeetingRecorderTests: XCTestCase {
         let record = try fixture.recorder.prepareRecord(for: fixture.target)
         let frames = (0..<3_008).map { index in
             AudioFrame(
-                pcm: Data([UInt8(index % 255), 0]),
+                pcm: Data([UInt8(64 + (index % 128)), 0]),
                 sampleRate: 16_000,
                 channelCount: 1,
                 timestampNanos: UInt64(index + 1)

--- a/docs/superpowers/plans/2026-04-29-silence-audio-filter.md
+++ b/docs/superpowers/plans/2026-04-29-silence-audio-filter.md
@@ -1,0 +1,171 @@
+# Silence Audio Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Skip silent captured audio frames before streaming transcription provider calls while preserving complete WAV recordings.
+
+**Architecture:** Add a small `AudioSilenceDetector` for little-endian signed 16-bit PCM and inject it into `MeetingRecorder`. The recorder continues to write every frame to the WAV writer and realtime consumer, but gates `AudioFrameTranscriber.append(_:)`.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, macOS 14.2+.
+
+---
+
+## File Structure
+
+- Create `Sources/MeetingAgentCore/AudioSilenceDetector.swift`: contains PCM silence classification.
+- Modify `Sources/MeetingAgentCore/MeetingRecorder.swift`: stores an injected detector and skips silent frames in `appendFrameToTranscriber(_:)`.
+- Create `Tests/MeetingAgentCoreTests/AudioSilenceDetectorTests.swift`: covers detector edge cases.
+- Modify `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift`: adds a recorder-level regression test.
+
+### Task 1: Add Silence Detector
+
+**Files:**
+- Create: `Sources/MeetingAgentCore/AudioSilenceDetector.swift`
+- Test: `Tests/MeetingAgentCoreTests/AudioSilenceDetectorTests.swift`
+
+- [ ] **Step 1: Write detector tests**
+
+```swift
+import XCTest
+@testable import MeetingAgentCore
+
+final class AudioSilenceDetectorTests: XCTestCase {
+    func testDetectsZeroPCMAsSilent() {
+        let detector = AudioSilenceDetector()
+        let frame = AudioFrame(pcm: pcm([0, 0, 0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+
+        XCTAssertTrue(detector.isSilent(frame))
+    }
+
+    func testDetectsLowAmplitudePCMAsSilent() {
+        let detector = AudioSilenceDetector(amplitudeThreshold: 4)
+        let frame = AudioFrame(pcm: pcm([-4, 0, 4]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+
+        XCTAssertTrue(detector.isSilent(frame))
+    }
+
+    func testDetectsVoicedPCMAsNonSilent() {
+        let detector = AudioSilenceDetector(amplitudeThreshold: 4)
+        let frame = AudioFrame(pcm: pcm([0, 5]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)
+
+        XCTAssertFalse(detector.isSilent(frame))
+    }
+
+    func testTreatsEmptyOrMalformedPCMAsNonSilent() {
+        let detector = AudioSilenceDetector()
+
+        XCTAssertFalse(detector.isSilent(AudioFrame(pcm: Data(), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)))
+        XCTAssertFalse(detector.isSilent(AudioFrame(pcm: Data([0]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1)))
+    }
+}
+
+private func pcm(_ samples: [Int16]) -> Data {
+    var data = Data()
+    for sample in samples {
+        var littleEndian = sample.littleEndian
+        withUnsafeBytes(of: &littleEndian) { data.append(contentsOf: $0) }
+    }
+    return data
+}
+```
+
+- [ ] **Step 2: Run focused tests to verify failure**
+
+Run: `swift test --filter AudioSilenceDetectorTests`
+
+Expected: FAIL because `AudioSilenceDetector` is not defined.
+
+- [ ] **Step 3: Implement detector**
+
+```swift
+import Foundation
+
+public struct AudioSilenceDetector: Equatable {
+    public let amplitudeThreshold: Int16
+
+    public init(amplitudeThreshold: Int16 = 32) {
+        self.amplitudeThreshold = max(0, amplitudeThreshold)
+    }
+
+    public func isSilent(_ frame: AudioFrame) -> Bool {
+        guard !frame.pcm.isEmpty, frame.pcm.count.isMultiple(of: MemoryLayout<Int16>.size) else {
+            return false
+        }
+
+        let threshold = Int(amplitudeThreshold)
+        var index = 0
+        while index < frame.pcm.count {
+            let low = UInt16(frame.pcm[index])
+            let high = UInt16(frame.pcm[index + 1]) << 8
+            let sample = Int(Int16(bitPattern: high | low))
+            if abs(sample) > threshold {
+                return false
+            }
+            index += 2
+        }
+        return true
+    }
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run: `swift test --filter AudioSilenceDetectorTests`
+
+Expected: PASS.
+
+### Task 2: Gate Transcriber Frames
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingRecorder.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift`
+
+- [ ] **Step 1: Write recorder regression test**
+
+Add a test that pushes a silent frame and a voiced frame, drains them, and asserts:
+
+```swift
+XCTAssertEqual(fixture.writer.writtenFrames, [silentFrame, voicedFrame])
+XCTAssertEqual(fixture.transcriber.appendedFrames, [voicedFrame])
+XCTAssertEqual(consumer.receivedFrames, [silentFrame, voicedFrame])
+```
+
+- [ ] **Step 2: Run focused test to verify failure**
+
+Run: `swift test --filter MeetingRecorderTests/testDrainFramesSkipsSilentAudioOnlyForTranscription`
+
+Expected: FAIL because the recorder still sends silent frames to the transcriber.
+
+- [ ] **Step 3: Inject and apply detector**
+
+Modify the internal recorder initializer to accept `silenceDetector: AudioSilenceDetector = AudioSilenceDetector()`. Store it on the recorder. In `appendFrameToTranscriber(_:)`, return early when `silenceDetector.isSilent(frame)` is true.
+
+- [ ] **Step 4: Run focused recorder test**
+
+Run: `swift test --filter MeetingRecorderTests/testDrainFramesSkipsSilentAudioOnlyForTranscription`
+
+Expected: PASS.
+
+### Task 3: Verify and Commit
+
+**Files:**
+- All changed source, test, spec, and plan files.
+
+- [ ] **Step 1: Run full required verification**
+
+Run: `make test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Inspect diff**
+
+Run: `git diff --stat && git diff --check`
+
+Expected: only issue-related files changed and no whitespace errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MeetingAgentCore/AudioSilenceDetector.swift Sources/MeetingAgentCore/MeetingRecorder.swift Tests/MeetingAgentCoreTests/AudioSilenceDetectorTests.swift Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift docs/superpowers/specs/2026-04-29-silence-audio-filter-design.md docs/superpowers/plans/2026-04-29-silence-audio-filter.md
+git commit -m "feat: filter silent audio before transcription (#56)"
+```

--- a/docs/superpowers/specs/2026-04-29-silence-audio-filter-design.md
+++ b/docs/superpowers/specs/2026-04-29-silence-audio-filter-design.md
@@ -1,0 +1,59 @@
+# Silence Audio Filter Design
+
+## Issue
+
+GitHub issue #56 asks for filtering blank audio during meetings so long silent periods, such as preparation time or pauses, do not trigger unnecessary model calls or token usage.
+
+## Goal
+
+Preserve complete meeting recordings while preventing silent captured frames from being sent to streaming transcription providers.
+
+## Requirements
+
+- The saved meeting WAV must continue to include all captured audio frames, including silence.
+- Realtime frame consumers must continue receiving all captured frames so UI and diagnostics behavior stays unchanged.
+- Streaming transcription must skip frames whose signed 16-bit PCM samples are below a conservative silence threshold.
+- The filter must apply during normal recording and during startup replay while a hosted streaming transcriber is still connecting.
+- The detector must be unit-testable without Core Audio or network providers.
+
+## Non-Requirements
+
+- Do not remove silence from the saved `audio.wav`.
+- Do not add a settings UI in this first pass.
+- Do not post-process existing recorded WAV files.
+- Do not change provider-specific APIs or Deepgram/OpenAI request formats.
+
+## Options Considered
+
+### Provider-Level Filtering
+
+Each transcription provider could inspect frames before sending them to its backend. This keeps filtering close to the network call, but duplicates logic across Deepgram, OpenAI realtime, macOS Speech, and any future provider.
+
+### Recorder-Level Transcription Gate
+
+`MeetingRecorder` already fans out each captured frame to the WAV writer, the transcriber, and the realtime consumer. Gating only the transcriber append path keeps saved audio and UI behavior intact while covering every streaming transcription provider through one boundary.
+
+### Capture-Level Filtering
+
+The capture session could stop producing silent frames. This would also remove silence from recordings and realtime consumers, which conflicts with the product decision to preserve the full meeting audio.
+
+## Selected Approach
+
+Use recorder-level transcription gating backed by a small reusable `AudioSilenceDetector`.
+
+`AudioSilenceDetector` reads little-endian signed 16-bit PCM samples from `AudioFrame.pcm`. A frame is silent when it contains at least one complete sample and every sample's absolute amplitude is less than or equal to a conservative threshold. Empty or malformed PCM is treated as non-silent so data problems are not hidden by the filter.
+
+`MeetingRecorder.appendFrameToTranscriber(_:)` skips silent frames before calling `AudioFrameTranscriber.append(_:)`. This path is used both for live draining and for startup replay, so silent frames are filtered consistently without affecting WAV writes.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/AudioSilenceDetector.swift` creates the detector.
+- `Sources/MeetingAgentCore/MeetingRecorder.swift` injects and applies the detector in the transcriber-only path.
+- `Tests/MeetingAgentCoreTests/AudioSilenceDetectorTests.swift` covers PCM classification.
+- `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift` covers recorder fan-out behavior.
+
+## Testing
+
+- Unit-test the detector with zero, low-amplitude, voiced, empty, and malformed PCM.
+- Unit-test the recorder to prove silent frames are still written to WAV and delivered to realtime consumers, but skipped for the transcriber.
+- Run `make test` as the required repository verification entrypoint.


### PR DESCRIPTION
## Summary

Fixes #56

- Adds a signed 16-bit PCM silence detector for captured audio frames.
- Gates only streaming transcription appends so silent audio does not reach model-backed STT providers.
- Preserves complete WAV recording and realtime frame consumer delivery.

## Changes

- `Sources/MeetingAgentCore/AudioSilenceDetector.swift` - classifies little-endian signed 16-bit PCM frames as silent or voiced.
- `Sources/MeetingAgentCore/MeetingRecorder.swift` - skips silent frames only in the transcriber append path.
- `Tests/MeetingAgentCoreTests/AudioSilenceDetectorTests.swift` - covers detector silence, voiced, empty, and malformed PCM cases.
- `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift` - covers recorder fan-out behavior and updates voiced fixtures above the threshold.
- `docs/superpowers/specs/2026-04-29-silence-audio-filter-design.md` and `docs/superpowers/plans/2026-04-29-silence-audio-filter.md` - capture the approved design and implementation plan.
- `MISTAKES.md` - records the public API review lesson.

## Test plan

- [x] Build/lint: `git diff --check origin/main...HEAD` passed
- [x] Unit tests: `swift test --filter AudioSilenceDetectorTests` passed; `swift test --filter MeetingRecorderTests` passed; `make test` passed with 479 tests and coverage gate passed
- [x] E2E/integration: skipped; no applicable E2E convention for this core audio frame gate
- [x] Code review: PASS after fixing one public API visibility issue
- [x] Manual verification: diff reviewed to confirm WAV writer/realtime consumer paths are untouched while only transcriber append is gated