### PR TITLE
fix: coalesce draft caption translations

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -349,3 +349,19 @@ When displaying first-item metadata for grouped UI state, preserve that metadata
 For grouped display metadata, trace the data from source segment to store merge to view grouping before treating a group-level test as sufficient.
 
 ---
+
+## [63] Make async coalescing regressions deterministic
+
+**Date**: 2026-04-29
+**Category**: test-mistake
+
+### What went wrong
+The first superseded draft translation regression used a sleeping fake provider and asserted completion state, which could pass or fail based on task scheduling instead of proving the stale request was skipped before provider work.
+
+### Correct approach
+Use a manually delayed provider and assert the pending provider queue shape directly when testing async coalescing or cancellation behavior.
+
+### How to avoid
+For async cancellation tests, assert deterministic intermediate state instead of relying on sleep timing or completion ordering.
+
+---

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -56,6 +56,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     private var realtimeTranslationAttachmentCountsByCaptionID: [String: Int] = [:]
     private var draftTranslationKeysByTurnID: [String: String] = [:]
     private var draftTranslationInFlightByTurnID: [String: Int] = [:]
+    private var draftTranslationTasksByTurnID: [String: Task<Void, Never>] = [:]
     private var draftTranslationCharacterCountsByTurnID: [String: Int] = [:]
     private var draftTranslationAttemptDatesByTurnID: [String: Date] = [:]
     private var finalTranslationKeysByTurnID: [String: String] = [:]
@@ -834,6 +835,8 @@ public final class MeetingAgentViewModel: ObservableObject {
         realtimeTranslationAttachmentCountsByCaptionID.removeAll()
         draftTranslationKeysByTurnID.removeAll()
         draftTranslationInFlightByTurnID.removeAll()
+        draftTranslationTasksByTurnID.values.forEach { $0.cancel() }
+        draftTranslationTasksByTurnID.removeAll()
         draftTranslationCharacterCountsByTurnID.removeAll()
         draftTranslationAttemptDatesByTurnID.removeAll()
         finalTranslationKeysByTurnID.removeAll()
@@ -1013,7 +1016,7 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     private func scheduleCaptionTextTranslationIfNeeded() {
         completeSameLanguageCaptionTranslationsIfNeeded()
-        let draftCandidates = liveCaptionStore.turns.filter { turn in
+        let initialDraftCandidates = liveCaptionStore.turns.filter { turn in
             guard turn.translationHealth == .pending,
                   shouldScheduleDraftTranslation(for: turn),
                   draftTranslationInFlightByTurnID[turn.id] != turn.translationRevision
@@ -1029,6 +1032,9 @@ public final class MeetingAgentViewModel: ObservableObject {
             let key = finalCaptionTranslationKey(for: turn)
             return finalTranslationKeysByTurnID[turn.id] != key
                 && !finalTranslationInFlightTurnIDs.contains(turn.id)
+        }
+        let draftCandidates = initialDraftCandidates.filter { draft in
+            !isDraftTranslationSupersededByHardFinal(draft, finalCandidates: finalCandidates)
         }
 
         guard !draftCandidates.isEmpty || !finalCandidates.isEmpty else { return }
@@ -1055,6 +1061,7 @@ public final class MeetingAgentViewModel: ObservableObject {
 
         let finalRequests = finalCandidates.map { turn -> CaptionTranslationRequest in
             let key = finalCaptionTranslationKey(for: turn)
+            cancelDraftTranslationsSuperseded(by: turn)
             finalTranslationInFlightTurnIDs.insert(turn.id)
             logTranslationScheduled(
                 turn,
@@ -1072,8 +1079,18 @@ public final class MeetingAgentViewModel: ObservableObject {
 
         let requests = draftRequests + finalRequests
         guard !requests.isEmpty else { return }
-        Task { [weak self, provider, requests] in
-            await self?.translateCaptionTurns(requests, using: provider)
+        for request in draftRequests {
+            draftTranslationTasksByTurnID[request.turn.id]?.cancel()
+            let task = Task { [weak self, provider, request] in
+                guard let self else { return }
+                await self.translateCaptionTurn(request, using: provider)
+            }
+            draftTranslationTasksByTurnID[request.turn.id] = task
+        }
+        if !finalRequests.isEmpty {
+            Task { [weak self, provider, finalRequests] in
+                await self?.translateCaptionTurns(finalRequests, using: provider)
+            }
         }
     }
 
@@ -1119,68 +1136,122 @@ public final class MeetingAgentViewModel: ObservableObject {
         return now.timeIntervalSince(previousAttempt) >= minDraftTranslationInterval
     }
 
+    private func isDraftTranslationSupersededByHardFinal(
+        _ draft: LiveCaptionTurn,
+        finalCandidates: [LiveCaptionTurn]
+    ) -> Bool {
+        finalCandidates.contains { final in
+            final.id == draft.id || (final.speaker == draft.speaker && draft.createdAt <= final.createdAt)
+        }
+    }
+
     private func translateCaptionTurns(_ requests: [CaptionTranslationRequest], using provider: TextTranslationProvider) async {
         for request in requests {
-            let turn = request.turn
-            let sourceText = translationSourceText(for: turn, final: !request.isDraft)
-            let options = TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
-            if options.isSameLanguage {
-                completeCaptionTranslationWithoutProvider(for: turn)
-                liveCaptionTurns = liveCaptionStore.turns
-                continue
-            }
-            let segment = TranscriptSegment(
-                id: turn.sourceSegmentID,
-                speaker: turn.speaker,
-                text: sourceText,
-                language: turn.sourceLocale,
-                isFinal: turn.isFinal,
-                createdAt: turn.createdAt
-            )
-            do {
-                request.performanceEventLogger?.log(
-                    "caption_translation_started",
-                    segmentID: turn.id,
-                    isFinal: !request.isDraft,
-                    textLength: sourceText.count,
-                    metadata: translationMetadata(for: turn, isDraft: request.isDraft)
-                )
-                let translated = try await provider.translate(
-                    transcript: TranscriptDocument(segments: [segment]),
-                    options: options
-                )
-                let translatedText = translated.segments.first { $0.id == turn.sourceSegmentID }?.targetText ?? ""
-                request.performanceEventLogger?.log(
-                    "caption_translation_finished",
-                    segmentID: turn.id,
-                    isFinal: !request.isDraft,
-                    textLength: translatedText.count,
-                    metadata: translationMetadata(for: turn, isDraft: request.isDraft)
-                )
-                if request.isDraft {
-                    acceptDraftTranslation(request, translatedText: translatedText)
-                } else {
-                    acceptFinalTranslation(request, translatedText: translatedText)
-                }
-            } catch {
-                let nsError = error as NSError
-                request.performanceEventLogger?.log(
-                    "caption_translation_failed",
-                    segmentID: turn.id,
-                    isFinal: !request.isDraft,
-                    textLength: sourceText.count,
-                    metadata: translationMetadata(
-                        for: turn,
-                        isDraft: request.isDraft,
-                        extra: ["error": "\(nsError.domain) error \(nsError.code)"]
-                    )
-                )
-                liveCaptionStore.markTranslationFailed(forTurnID: turn.id, message: "\(nsError.domain) error \(nsError.code)")
-                liveCaptionTurns = liveCaptionStore.turns
-                clearTranslationInFlight(request)
-            }
+            await translateCaptionTurn(request, using: provider)
         }
         updateTranslationHealthFromRealtimeStatus()
+    }
+
+    private func translateCaptionTurn(_ request: CaptionTranslationRequest, using provider: TextTranslationProvider) async {
+        defer { updateTranslationHealthFromRealtimeStatus() }
+        let turn = request.turn
+        if request.isDraft {
+            await Task.yield()
+            guard !Task.isCancelled, isCurrentDraftTranslationRequest(request) else {
+                clearTranslationInFlight(request)
+                return
+            }
+        }
+        let sourceText = translationSourceText(for: turn, final: !request.isDraft)
+        let options = TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
+        if options.isSameLanguage {
+            completeCaptionTranslationWithoutProvider(for: turn)
+            liveCaptionTurns = liveCaptionStore.turns
+            return
+        }
+        let segment = TranscriptSegment(
+            id: turn.sourceSegmentID,
+            speaker: turn.speaker,
+            text: sourceText,
+            language: turn.sourceLocale,
+            isFinal: turn.isFinal,
+            createdAt: turn.createdAt
+        )
+        do {
+            request.performanceEventLogger?.log(
+                "caption_translation_started",
+                segmentID: turn.id,
+                isFinal: !request.isDraft,
+                textLength: sourceText.count,
+                metadata: translationMetadata(for: turn, isDraft: request.isDraft)
+            )
+            let translated = try await provider.translate(
+                transcript: TranscriptDocument(segments: [segment]),
+                options: options
+            )
+            let translatedText = translated.segments.first { $0.id == turn.sourceSegmentID }?.targetText ?? ""
+            request.performanceEventLogger?.log(
+                "caption_translation_finished",
+                segmentID: turn.id,
+                isFinal: !request.isDraft,
+                textLength: translatedText.count,
+                metadata: translationMetadata(for: turn, isDraft: request.isDraft)
+            )
+            if request.isDraft {
+                acceptDraftTranslation(request, translatedText: translatedText)
+            } else {
+                acceptFinalTranslation(request, translatedText: translatedText)
+            }
+        } catch is CancellationError {
+            clearTranslationInFlight(request)
+        } catch {
+            if Task.isCancelled {
+                clearTranslationInFlight(request)
+                return
+            }
+            let nsError = error as NSError
+            request.performanceEventLogger?.log(
+                "caption_translation_failed",
+                segmentID: turn.id,
+                isFinal: !request.isDraft,
+                textLength: sourceText.count,
+                metadata: translationMetadata(
+                    for: turn,
+                    isDraft: request.isDraft,
+                    extra: ["error": "\(nsError.domain) error \(nsError.code)"]
+                )
+            )
+            liveCaptionStore.markTranslationFailed(forTurnID: turn.id, message: "\(nsError.domain) error \(nsError.code)")
+            liveCaptionTurns = liveCaptionStore.turns
+            clearTranslationInFlight(request)
+        }
+    }
+
+    private func isCurrentDraftTranslationRequest(_ request: CaptionTranslationRequest) -> Bool {
+        guard request.isDraft,
+              draftTranslationInFlightByTurnID[request.turn.id] == request.revision,
+              let current = liveCaptionStore.turns.first(where: { $0.id == request.turn.id }),
+              current.translationRevision == request.revision,
+              current.translationState != .final,
+              draftCaptionTranslationKey(for: current) == request.key,
+              shouldScheduleDraftTranslation(for: current)
+        else {
+            return false
+        }
+        return true
+    }
+
+    private func cancelDraftTranslationsSuperseded(by final: LiveCaptionTurn) {
+        let supersededTurnIDs = liveCaptionStore.turns
+            .filter { draft in
+                final.id == draft.id || (final.speaker == draft.speaker && draft.createdAt <= final.createdAt)
+            }
+            .map(\.id)
+        for turnID in supersededTurnIDs {
+            draftTranslationTasksByTurnID[turnID]?.cancel()
+            draftTranslationTasksByTurnID.removeValue(forKey: turnID)
+            draftTranslationInFlightByTurnID.removeValue(forKey: turnID)
+        }
     }
 
     private func completeCaptionTranslationWithoutProvider(for turn: LiveCaptionTurn) {
@@ -1261,6 +1332,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         if request.isDraft {
             if draftTranslationInFlightByTurnID[request.turn.id] == request.revision {
                 draftTranslationInFlightByTurnID.removeValue(forKey: request.turn.id)
+                draftTranslationTasksByTurnID.removeValue(forKey: request.turn.id)
             }
         } else {
             finalTranslationInFlightTurnIDs.remove(request.turn.id)

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -693,6 +693,53 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.freezeReason, .speechFinal)
     }
 
+    func testSupersededDraftCaptionTranslationIsCancelledBeforeCompletion() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let record = try store.createMeeting(name: "Meet", startedAt: Date()).record
+        let writer = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL), structuredURL: XCTUnwrap(record.transcriptJSONURL))
+        let provider = DelayedViewModelFakeTextTranslationProvider()
+        let viewModel = MeetingAgentViewModel(
+            store: store,
+            captionTranslationProviderFactory: { _ in provider },
+            processTargetsProvider: { [] }
+        )
+        try viewModel.loadMeetings()
+        viewModel.selectMeeting(record.id)
+
+        try writer.replace(with: [
+            TranscriptSegment(
+                id: "dg-utterance",
+                text: "Now we can select",
+                language: "en-US",
+                sourceProvider: "deepgram-transcribe",
+                isFinal: true,
+                speechFinal: false
+            )
+        ])
+        viewModel.drainRecordingFrames()
+
+        let latestText = "Now we can select German and hear what it sounds like in another automated voice while the interpreter keeps the meeting moving"
+        try writer.replace(with: [
+            TranscriptSegment(
+                id: "dg-utterance",
+                text: latestText,
+                language: "en-US",
+                sourceProvider: "deepgram-transcribe",
+                isFinal: true,
+                speechFinal: false
+            )
+        ])
+        viewModel.drainRecordingFrames()
+
+        try await waitFor { provider.pendingRequestCount >= 1 }
+
+        XCTAssertEqual(provider.pendingRequestCount, 1)
+        XCTAssertEqual(provider.pendingRequestTexts, [[latestText]])
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, latestText)
+    }
+
     func testInterimDeepgramSegmentDisplaysWithDraftTranslationBeforeFinalArrives() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
@@ -2451,6 +2498,10 @@ private final class DelayedViewModelFakeTextTranslationProvider: TextTranslation
 
     var pendingRequestCount: Int {
         pendingRequests.count
+    }
+
+    var pendingRequestTexts: [[String]] {
+        pendingRequests.map { $0.transcript.segments.map(\.text) }
     }
 
     func translate(transcript: TranscriptDocument, options: TranslationOptions) async throws -> TranslatedTranscript {


### PR DESCRIPTION
## Summary

Fixes #63

- Coalesces superseded draft caption translation work per live turn.
- Cancels same-speaker draft translation tasks when a hard final translation supersedes them.
- Adds a regression test for rapid Deepgram draft revisions so stale draft translations do not occupy provider work.

## Changes

- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - tracks cancellable draft translation tasks, validates draft requests before provider calls, skips drafts covered by hard final captions, and keeps translation health updated after single-turn translation tasks.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - adds deterministic delayed-provider coverage for superseded draft translation coalescing.
- `MISTAKES.md` - records the async cancellation test lesson from this fix.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests` passed
- [x] Full verification: `make test` passed, coverage gate passed (line 96.53%, method 95.27%)
- [x] E2E/integration: skipped; no E2E convention for this app-layer scheduling behavior
- [x] Code review: PASS
- [x] Manual verification: not applicable; covered by deterministic scheduling regression test