### PR TITLE
fix: refresh meeting transcription state on start

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -397,3 +397,19 @@ Patch repeated test setup with nearby behavior-specific context, then inspect th
 When a test file repeats the same initializer shape, include the test name or adjacent setup lines in the patch context.
 
 ---
+
+## [69] Refresh view-model metadata after recorder startup persistence
+
+**Date**: 2026-04-29
+**Category**: logic-error
+
+### What went wrong
+Starting a detected meeting let `MeetingRecorder` persist the record as transcribing, but `MeetingAgentViewModel` kept the pre-start in-memory record, so the meeting page could still show transcription as not started.
+
+### Correct approach
+After async recorder startup completes, refresh the affected meeting from the store so UI state reflects recorder-owned transcription metadata, including startup failures.
+
+### How to avoid
+When a lower-level service mutates persisted model state during an async operation, update the caller's in-memory model before returning to the UI.
+
+---

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -245,6 +245,7 @@ public final class MeetingAgentViewModel: ObservableObject {
                 record: record,
                 speechConfiguration: recordingConfiguration
             )
+            refreshMeetingFromStore(record.id)
         } catch {
             if let stopped = try? recorder.stopRecording(),
                let index = meetings.firstIndex(where: { $0.id == stopped.id }) {
@@ -255,6 +256,14 @@ public final class MeetingAgentViewModel: ObservableObject {
             throw error
         }
         statusText = "Recording \(record.name)"
+    }
+
+    private func refreshMeetingFromStore(_ id: UUID) {
+        guard let refreshed = try? store.loadMeetings().first(where: { $0.id == id }),
+              let index = meetings.firstIndex(where: { $0.id == id })
+        else { return }
+
+        meetings[index] = refreshed
     }
 
     public func setRecordingStartError(_ error: Error) {

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -130,6 +130,47 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, "Meeting detected: zoom.us")
     }
 
+    func testSecondDetectedMeetingShowsTranscribingAfterFirstMeetingStops() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        var currentTarget = AudioCaptureTarget(
+            processID: 10,
+            displayName: "zoom.us",
+            bundleIdentifier: "us.zoom.xos",
+            isAudioOutputActive: true
+        )
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            processTargetsProvider: { [currentTarget] }
+        )
+
+        XCTAssertEqual(viewModel.pollForMeetingCandidates(), currentTarget)
+        try await viewModel.startRecordingForPendingCandidate()
+        viewModel.stopRecording(at: Date(timeIntervalSince1970: 200))
+
+        currentTarget = AudioCaptureTarget(
+            processID: 11,
+            displayName: "Google Meet",
+            bundleIdentifier: "com.google.Chrome",
+            isAudioOutputActive: true
+        )
+        XCTAssertEqual(viewModel.pollForMeetingCandidates(), currentTarget)
+        try await viewModel.startRecordingForPendingCandidate()
+
+        XCTAssertEqual(viewModel.selectedMeeting?.name, "Google Meet")
+        XCTAssertEqual(viewModel.selectedMeeting?.transcriptionStatus, .transcribing)
+        XCTAssertEqual(fixture.session.startedTargets, [
+            AudioCaptureTarget(
+                processID: 10,
+                displayName: "zoom.us",
+                bundleIdentifier: "us.zoom.xos",
+                isAudioOutputActive: true
+            ),
+            currentTarget
+        ])
+        XCTAssertEqual(fixture.transcriberFactory.requests.count, 2)
+    }
+
     func testStopRecordingAndGenerateSummaryWritesArtifacts() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary

Fixes #69

- Refresh the selected meeting from persisted recorder state after recording startup.
- Add a regression test for a second detected meeting after stopping the first one.

## Changes

- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - refreshes in-memory meeting metadata after recorder startup persists transcription state.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - covers first-stop then second-detected-meeting transcription startup.
- `MISTAKES.md` - records the reusable metadata-sync lesson.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed.
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests/testSecondDetectedMeetingShowsTranscribingAfterFirstMeetingStops` passed; `make test` passed, 489 tests, coverage gate passed.
- [x] E2E/integration: skipped; no E2E convention for this view-model state bug.
- [x] Code review: PASS manual Swift review; code-review skill is TypeScript/Java-only.
- [x] Manual verification: regression test reproduces stale `notStarted` before the fix and passes after.
