### PR TITLE
fix: bundle local whisper model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .DS_Store
 .record/
 .superpowers
+Resources/WhisperModels/

--- a/Sources/MeetingAgentApp/SettingsView.swift
+++ b/Sources/MeetingAgentApp/SettingsView.swift
@@ -215,10 +215,8 @@ struct SettingsView: View {
         uniqueNonBlank([
             draft.whisperModelPath,
             configuration.whisperModelPath,
-            ProcessInfo.processInfo.environment["MEETING_AGENT_WHISPER_MODEL"],
-            "/Users/allan/models/ggml-small.bin",
-            "/Users/allan/models/ggml-medium.bin"
-        ])
+            ProcessInfo.processInfo.environment["MEETING_AGENT_WHISPER_MODEL"]
+        ] + WhisperConfigurationResolver.modelPathOptions())
     }
 
     private func uniqueNonBlank(_ values: [String?]) -> [String] {

--- a/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
@@ -177,7 +177,9 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
 
     public func validationStatus(
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        bundledResourceURL: URL? = Bundle.main.resourceURL,
+        developmentResourceSearchRoots: [URL] = [URL(fileURLWithPath: FileManager.default.currentDirectoryPath)]
     ) -> SpeechConfigurationValidationStatus {
         if usesOpenRouter {
             guard Self.normalized(openRouterAPIKey) != nil
@@ -220,7 +222,10 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
         }
         guard let whisperModelPath = WhisperConfigurationResolver.modelPath(
             explicitPath: whisperModelPath,
-            environment: environment
+            environment: environment,
+            fileManager: fileManager,
+            bundledResourceURL: bundledResourceURL,
+            developmentResourceSearchRoots: developmentResourceSearchRoots
         ) else {
             return .unavailable("Whisper model path is not configured")
         }

--- a/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
@@ -7,7 +7,9 @@ struct WhisperConfiguration: Equatable {
     static func fromAppConfiguration(
         _ configuration: SpeechTranscriptionConfiguration,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        bundledResourceURL: URL? = Bundle.main.resourceURL,
+        developmentResourceSearchRoots: [URL] = [URL(fileURLWithPath: FileManager.default.currentDirectoryPath)]
     ) throws -> WhisperConfiguration {
         guard let binaryPath = WhisperConfigurationResolver.binaryPath(
             explicitPath: configuration.whisperBinaryPath,
@@ -18,7 +20,10 @@ struct WhisperConfiguration: Equatable {
         }
         guard let modelPath = WhisperConfigurationResolver.modelPath(
             explicitPath: configuration.whisperModelPath,
-            environment: environment
+            environment: environment,
+            fileManager: fileManager,
+            bundledResourceURL: bundledResourceURL,
+            developmentResourceSearchRoots: developmentResourceSearchRoots
         ) else {
             throw unavailable("Whisper model path is not configured")
         }
@@ -38,7 +43,10 @@ struct WhisperConfiguration: Equatable {
         }
         guard let modelPath = WhisperConfigurationResolver.modelPath(
             explicitPath: nil,
-            environment: environment
+            environment: environment,
+            fileManager: fileManager,
+            bundledResourceURL: nil,
+            developmentResourceSearchRoots: []
         ) else {
             throw unavailable("MEETING_AGENT_WHISPER_MODEL is not set")
         }
@@ -82,7 +90,14 @@ struct WhisperConfiguration: Equatable {
     }
 }
 
-enum WhisperConfigurationResolver {
+public enum WhisperConfigurationResolver {
+    public static let modelsDirectoryName = "WhisperModels"
+    private static let preferredModelFileNames = [
+        "ggml-small.bin",
+        "ggml-small.en.bin",
+        "ggml-medium.bin"
+    ]
+
     static func binaryPath(
         explicitPath: String?,
         environment: [String: String] = ProcessInfo.processInfo.environment,
@@ -99,9 +114,43 @@ enum WhisperConfigurationResolver {
 
     static func modelPath(
         explicitPath: String?,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        bundledResourceURL: URL? = Bundle.main.resourceURL,
+        developmentResourceSearchRoots: [URL] = [URL(fileURLWithPath: FileManager.default.currentDirectoryPath)]
     ) -> String? {
-        nonBlank(explicitPath) ?? nonBlank(environment["MEETING_AGENT_WHISPER_MODEL"])
+        nonBlank(explicitPath)
+            ?? nonBlank(environment["MEETING_AGENT_WHISPER_MODEL"])
+            ?? modelPathOptions(
+                environment: environment,
+                fileManager: fileManager,
+                bundledResourceURL: bundledResourceURL,
+                developmentResourceSearchRoots: developmentResourceSearchRoots
+            ).first
+    }
+
+    public static func modelPathOptions(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        bundledResourceURL: URL? = Bundle.main.resourceURL,
+        developmentResourceSearchRoots: [URL] = [URL(fileURLWithPath: FileManager.default.currentDirectoryPath)]
+    ) -> [String] {
+        var paths = [String?]()
+        paths.append(nonBlank(environment["MEETING_AGENT_WHISPER_MODEL"]))
+        if let bundledResourceURL {
+            paths.append(contentsOf: modelPaths(
+                in: bundledResourceURL.appendingPathComponent(modelsDirectoryName, isDirectory: true),
+                fileManager: fileManager
+            ))
+        }
+        for rootURL in developmentResourceSearchRoots {
+            paths.append(contentsOf: modelPaths(
+                in: rootURL.appendingPathComponent("Resources", isDirectory: true)
+                    .appendingPathComponent(modelsDirectoryName, isDirectory: true),
+                fileManager: fileManager
+            ))
+        }
+        return uniqueExistingModelPaths(paths, fileManager: fileManager)
     }
 
     private static func executablePath(
@@ -117,6 +166,40 @@ enum WhisperConfigurationResolver {
             }
         }
         return nil
+    }
+
+    private static func modelPaths(in directoryURL: URL, fileManager: FileManager) -> [String] {
+        guard let fileNames = try? fileManager.contentsOfDirectory(atPath: directoryURL.path) else {
+            return []
+        }
+        let candidates = fileNames
+            .filter { fileName in
+                fileName.hasPrefix("ggml-") && (fileName.hasSuffix(".bin") || fileName.hasSuffix(".gguf"))
+            }
+        return candidates
+            .sorted { lhs, rhs in
+                let leftRank = preferredModelFileNames.firstIndex(of: lhs) ?? preferredModelFileNames.count
+                let rightRank = preferredModelFileNames.firstIndex(of: rhs) ?? preferredModelFileNames.count
+                if leftRank != rightRank {
+                    return leftRank < rightRank
+                }
+                return lhs < rhs
+            }
+            .map { directoryURL.appendingPathComponent($0).path }
+    }
+
+    private static func uniqueExistingModelPaths(_ paths: [String?], fileManager: FileManager) -> [String] {
+        var seen = Set<String>()
+        return paths.compactMap { path in
+            guard let path = nonBlank(path),
+                  !seen.contains(path),
+                  fileManager.isReadableFile(atPath: URL(fileURLWithPath: path).path)
+            else {
+                return nil
+            }
+            seen.insert(path)
+            return path
+        }
     }
 
     private static func nonBlank(_ value: String?) -> String? {
@@ -139,6 +222,13 @@ enum WhisperLanguageMapper {
         "es-ES": "es"
     ]
 
+    static func languageCode(for localeIdentifier: String, modelURL: URL) -> String? {
+        if isEnglishOnlyModel(modelURL) {
+            return "en"
+        }
+        return languageCode(for: localeIdentifier)
+    }
+
     static func languageCode(for localeIdentifier: String) -> String? {
         let trimmed = localeIdentifier.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
@@ -147,6 +237,11 @@ enum WhisperLanguageMapper {
         }
         let separators = CharacterSet(charactersIn: "-_")
         return trimmed.components(separatedBy: separators).first.flatMap { $0.isEmpty ? nil : $0 }
+    }
+
+    private static func isEnglishOnlyModel(_ modelURL: URL) -> Bool {
+        let fileName = modelURL.lastPathComponent.lowercased()
+        return fileName.hasSuffix(".en.bin") || fileName.hasSuffix(".en.gguf")
     }
 }
 
@@ -283,7 +378,7 @@ enum WhisperFileTranscriber {
             modelURL: configuration.modelURL,
             inputWavURL: inputAudioURL,
             outputBaseURL: outputBaseURL,
-            languageCode: WhisperLanguageMapper.languageCode(for: localeIdentifier)
+            languageCode: WhisperLanguageMapper.languageCode(for: localeIdentifier, modelURL: configuration.modelURL)
         )
         guard FileManager.default.fileExists(atPath: outputTextURL.path) else {
             throw ProbeError.speechRecognition("Whisper transcription unavailable: expected output file was not created")
@@ -363,7 +458,7 @@ final class WhisperCLITranscriber: AudioFrameTranscriber {
             configuration: configuration,
             processRunner: processRunner,
             localeIdentifier: localeIdentifier,
-            languageCode: WhisperLanguageMapper.languageCode(for: localeIdentifier),
+            languageCode: WhisperLanguageMapper.languageCode(for: localeIdentifier, modelURL: configuration.modelURL),
             chunkDurationSeconds: chunkDurationSeconds
         )
     }

--- a/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
+++ b/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
@@ -109,6 +109,51 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         )
     }
 
+    func testWhisperValidationFindsPackagedModelWhenNotExplicitlyConfigured() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("speech-config-packaged-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let binaryURL = directory.appendingPathComponent("whisper-cli")
+        FileManager.default.createFile(atPath: binaryURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+
+        let resourcesURL = directory.appendingPathComponent("Resources", isDirectory: true)
+        let modelsURL = resourcesURL.appendingPathComponent("WhisperModels", isDirectory: true)
+        try FileManager.default.createDirectory(at: modelsURL, withIntermediateDirectories: true)
+        let modelURL = modelsURL.appendingPathComponent("ggml-small.bin")
+        FileManager.default.createFile(atPath: modelURL.path, contents: Data())
+
+        let configuration = SpeechTranscriptionConfiguration(
+            provider: .whisper,
+            localeIdentifier: "zh-CN",
+            whisperBinaryPath: nil,
+            whisperModelPath: nil,
+            translationExecutionMode: .local
+        )
+        let environment = ["PATH": directory.path]
+
+        XCTAssertEqual(
+            configuration.validationStatus(
+                environment: environment,
+                fileManager: .default,
+                bundledResourceURL: resourcesURL,
+                developmentResourceSearchRoots: []
+            ),
+            .available
+        )
+        XCTAssertEqual(
+            try WhisperConfiguration.fromAppConfiguration(
+                configuration,
+                environment: environment,
+                fileManager: .default,
+                bundledResourceURL: resourcesURL,
+                developmentResourceSearchRoots: []
+            ).modelURL,
+            modelURL
+        )
+    }
+
     func testLocalProviderDoesNotRequireWhisperPaths() {
         let configuration = SpeechTranscriptionConfiguration(
             provider: .local,

--- a/Tests/MeetingAgentCoreTests/TranscriptSegmentTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptSegmentTests.swift
@@ -2,6 +2,58 @@ import XCTest
 @testable import MeetingAgentCore
 
 final class TranscriptSegmentTests: XCTestCase {
+    func testTranscriptSpeakerAndDocumentInitializersNormalizeDefaults() {
+        let speaker = TranscriptSpeaker(identifier: " speaker-1 ", label: " Alice ")
+        let document = TranscriptDocument(segments: [
+            TranscriptSegment(speaker: speaker, text: "hello")
+        ])
+
+        XCTAssertEqual(speaker.identifier, "speaker-1")
+        XCTAssertEqual(speaker.label, "Alice")
+        XCTAssertEqual(document.version, 1)
+        XCTAssertEqual(document.segments.first?.speaker, speaker)
+    }
+
+    func testTranscriptDocumentCodableRoundTripPreservesSegmentMetadata() throws {
+        let document = TranscriptDocument(version: 2, segments: [
+            TranscriptSegment(
+                id: "segment-1",
+                speaker: TranscriptSpeaker(identifier: "speaker-1", label: "Alice"),
+                startTimeSeconds: 1.25,
+                endTimeSeconds: 2.5,
+                text: "hello",
+                language: "en-US",
+                sourceProvider: "deepgram-transcribe",
+                isFinal: false,
+                speechFinal: true,
+                confidence: 0.92,
+                createdAt: Date(timeIntervalSince1970: 1_777_000_000),
+                timingSource: .precise
+            )
+        ])
+
+        let data = try JSONEncoder.meetingAgent.encode(document)
+        let decoded = try JSONDecoder.meetingAgent.decode(TranscriptDocument.self, from: data)
+
+        XCTAssertEqual(decoded, document)
+    }
+
+    func testLegacyTranscriptSegmentDecodingAppliesDefaults() throws {
+        let json = """
+        {
+          "id": "segment-1",
+          "text": "hello"
+        }
+        """
+
+        let decoded = try JSONDecoder.meetingAgent.decode(TranscriptSegment.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.sourceProvider, "unknown")
+        XCTAssertTrue(decoded.isFinal)
+        XCTAssertFalse(decoded.speechFinal)
+        XCTAssertEqual(decoded.timingSource, .unavailable)
+    }
+
     func testDefaultSpeakerRendersAsUserA() {
         let output = TranscriptFormatter.render([
             TranscriptSegment(text: "hello")

--- a/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
@@ -10,6 +10,25 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(WhisperLanguageMapper.languageCode(for: "ko-KR"), "ko")
     }
 
+    func testLanguageMapperForcesEnglishForEnglishOnlyModel() {
+        let directory = FileManager.default.temporaryDirectory
+
+        XCTAssertEqual(
+            WhisperLanguageMapper.languageCode(
+                for: "zh-CN",
+                modelURL: directory.appendingPathComponent("ggml-small.en.bin")
+            ),
+            "en"
+        )
+        XCTAssertEqual(
+            WhisperLanguageMapper.languageCode(
+                for: "zh-CN",
+                modelURL: directory.appendingPathComponent("ggml-small.bin")
+            ),
+            "zh"
+        )
+    }
+
     func testLanguageMapperFallsBackToPrimaryLanguageComponent() {
         XCTAssertEqual(WhisperLanguageMapper.languageCode(for: "pt-BR"), "pt")
         XCTAssertEqual(WhisperLanguageMapper.languageCode(for: "de_DE"), "de")
@@ -289,6 +308,39 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(runner.inputWavURL, audioURL)
     }
 
+    func testTranscribesExistingAudioFileWithEnglishLanguageWhenModelIsEnglishOnly() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-retry-en-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let audioURL = directory.appendingPathComponent("audio.wav")
+        let transcriptURL = directory.appendingPathComponent("transcript.txt")
+        FileManager.default.createFile(atPath: audioURL.path, contents: Data([0x52, 0x49, 0x46, 0x46]))
+        let configuration = WhisperConfiguration(
+            binaryURL: directory.appendingPathComponent("whisper-cli"),
+            modelURL: directory.appendingPathComponent("ggml-small.en.bin")
+        )
+        let runner = OutputWritingWhisperProcessRunner(outputText: "english transcript\n")
+
+        try await WhisperSpeechTranscriptionProvider(
+            configuration: configuration,
+            processRunner: runner
+        )
+        .transcribeExistingAudio(
+            context: SpeechTranscriptionContext(
+                inputAudioURL: audioURL,
+                transcriptURL: transcriptURL,
+                localeIdentifier: "zh-CN",
+                meetingID: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!,
+                previousTranscript: nil
+            )
+        )
+
+        XCTAssertEqual(runner.languageCode, "en")
+        let document = try TranscriptFileWriter.readDocument(from: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+        XCTAssertEqual(document.segments.first?.language, "zh-CN")
+    }
+
     func testTranscriberRunsWhisperAndWritesTranscript() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-transcriber-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -324,6 +376,33 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(document.segments.first?.timingSource, .approximate)
         XCTAssertEqual(runner.languageCode, "en")
         XCTAssertNotNil(runner.inputWavURL)
+    }
+
+    func testTranscriberUsesEnglishLanguageWhenModelIsEnglishOnly() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-transcriber-en-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let transcriptURL = directory.appendingPathComponent("capture.txt")
+        let configuration = WhisperConfiguration(
+            binaryURL: directory.appendingPathComponent("whisper-cli"),
+            modelURL: directory.appendingPathComponent("ggml-small.en.bin")
+        )
+        let runner = OutputWritingWhisperProcessRunner(outputText: "hello from whisper\n")
+        let transcriber = try WhisperCLITranscriber.start(
+            transcriptURL: transcriptURL,
+            localeIdentifier: "zh-CN",
+            configuration: configuration,
+            processRunner: runner,
+            workingDirectory: directory
+        )
+
+        try transcriber.append(AudioFrame(pcm: Data([0x01, 0x00, 0x02, 0x00]), sampleRate: 16_000, channelCount: 1, timestampNanos: 1))
+        transcriber.finish()
+
+        XCTAssertEqual(runner.languageCode, "en")
+        let document = try TranscriptFileWriter.readDocument(from: transcriptURL.deletingPathExtension().appendingPathExtension("json"))
+        XCTAssertEqual(document.segments.first?.language, "zh-CN")
     }
 
     func testTranscriberRunsWhisperBeforeFinishWhenChunkThresholdIsReached() throws {

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -13,6 +13,8 @@ INFO_PLIST="$REPO_ROOT/Sources/MeetingAgentApp/Resources/Info.plist"
 RELEASE_EXECUTABLE="$REPO_ROOT/.build/release/$EXECUTABLE_NAME"
 ENV_FILE="$REPO_ROOT/.env"
 DEFAULT_CREDENTIALS="$RESOURCES_DIR/DefaultSpeechTranscriptionCredentials.json"
+WHISPER_MODELS_SOURCE="$REPO_ROOT/Resources/WhisperModels"
+WHISPER_MODELS_DESTINATION="$RESOURCES_DIR/WhisperModels"
 
 if [ ! -f "$INFO_PLIST" ]; then
     echo "Missing app Info.plist at $INFO_PLIST" >&2
@@ -29,6 +31,24 @@ mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 cp "$RELEASE_EXECUTABLE" "$MACOS_DIR/$EXECUTABLE_NAME"
 cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
 printf "APPL????" > "$CONTENTS_DIR/PkgInfo"
+
+if [ -d "$WHISPER_MODELS_SOURCE" ]; then
+    mkdir -p "$WHISPER_MODELS_DESTINATION"
+    copied_models=0
+    for model_path in "$WHISPER_MODELS_SOURCE"/ggml-*.bin "$WHISPER_MODELS_SOURCE"/ggml-*.gguf; do
+        if [ -f "$model_path" ]; then
+            cp "$model_path" "$WHISPER_MODELS_DESTINATION"/
+            copied_models=$((copied_models + 1))
+        fi
+    done
+    if [ "$copied_models" -gt 0 ]; then
+        echo "Embedded $copied_models Whisper models from $WHISPER_MODELS_SOURCE"
+    else
+        echo "No Whisper models embedded; no ggml model files found in $WHISPER_MODELS_SOURCE"
+    fi
+else
+    echo "No Whisper models embedded; missing $WHISPER_MODELS_SOURCE"
+fi
 
 env_value() {
     key="$1"


### PR DESCRIPTION
## Summary
- Resolve local Whisper model lookup from bundled app resources or project Resources/WhisperModels instead of hardcoded user paths.
- Package ignored Whisper runtime assets into MeetingAgent.app: whisper-cli, its required dylibs, and ggml-small.en.bin.
- Remove the Whisper CLI path picker from Settings; the app now defaults to the bundled/project CLI while retaining env/config fallback for developer flows.
- Force whisper.cpp language to English when the selected model is English-only (.en.bin/.en.gguf), while keeping transcript segment locale metadata unchanged.
- Update Settings and configuration tests for packaged binary/model discovery.

## Test plan
- [x] swift test --filter SettingsViewLayoutTests/testSettingsViewUsesPickersForAllEditableFields
- [x] swift test --filter SpeechTranscriptionConfigurationTests
- [x] swift test --filter WhisperTranscriptionProviderTests
- [x] MEETING_AGENT_COVERAGE_SCRATCH_PATH=/tmp/meeting-agent-coverage-current make test (501 tests, 0 failures; coverage gate passed)
- [x] make package-app (embedded Whisper CLI, 3 Whisper libraries, and 1 Whisper model)
- [x] dist/MeetingAgent.app/Contents/Resources/WhisperBin/whisper-cli --help exits successfully from the packaged app bundle

## Notes
- Whisper runtime files remain git-ignored under Resources/WhisperBin/, Resources/WhisperLib/, and Resources/WhisperModels/ and are packaged only into the local app bundle.