### PR TITLE
feat: move pipeline details into hover

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -413,3 +413,19 @@ After async recorder startup completes, refresh the affected meeting from the st
 When a lower-level service mutates persisted model state during an async operation, update the caller's in-memory model before returning to the UI.
 
 ---
+
+## [73] Match latency calculations to event time bases
+
+**Date**: 2026-04-29
+**Category**: wrong-assumption
+
+### What went wrong
+The first pipeline hover latency summary reused the transcript audio-time latency calculation for caption translation events, but caption translation events only carry wall-clock times and request metadata.
+
+### Correct approach
+Transcript latency can compare event wall time against meeting start plus audio time. Translation latency should match events by `translationRequestID` and calculate scheduled or started wall-clock time to attached wall-clock time.
+
+### How to avoid
+Before summarizing performance events, inspect each event family for its actual timestamp fields and correlation keys instead of applying one latency formula globally.
+
+---

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -736,7 +736,6 @@ private struct TranscriptPaneView: View {
                 if let endedAt = meeting.endedAt {
                     CommandCenterChip(title: "Ended \(endedAt.formatted(date: .omitted, time: .shortened))")
                 }
-                CommandCenterChip(title: pipelineDisplayName, tint: CommandCenterPalette.primary)
             }
         }
     }
@@ -788,11 +787,96 @@ private struct TranscriptPaneView: View {
 
     private var pipelineDebugHelpText: String {
         [
+            "Pipeline: \(pipelineDisplayName)",
             "Actual STT Source: \(actualTranscriptionSourceText)",
             "Transcription Link: \(transcriptionLinkText)",
             "Transcription Model: \(transcriptionModelText)",
-            "Preflight: \(preflightText)"
+            "Preflight: \(preflightText)",
+            "Transcript Latency: \(transcriptLatencyText)",
+            "Translation Latency: \(translationLatencyText)"
         ].joined(separator: "\n")
+    }
+
+    private var transcriptLatencyText: String {
+        PipelineLatencySummary(meeting: meeting).transcriptLatencyText
+    }
+
+    private var translationLatencyText: String {
+        PipelineLatencySummary(meeting: meeting).translationLatencyText
+    }
+}
+
+private struct PipelineLatencySummary {
+    let meeting: MeetingRecord
+
+    var transcriptLatencyText: String {
+        guard let event = latestTranscriptEvent,
+              let latency = latencySeconds(for: event) else {
+            return "unavailable"
+        }
+        return format(seconds: latency)
+    }
+
+    var translationLatencyText: String {
+        let events = performanceEvents
+        if let attached = events.last(where: { $0.event == "caption_translation_attached" }),
+           let latency = translationLatencySeconds(for: attached, in: events) {
+            return format(seconds: latency)
+        }
+        if events.contains(where: { $0.event.hasPrefix("caption_translation_") }) {
+            return "attach latency unavailable"
+        }
+        return "unavailable"
+    }
+
+    private var latestTranscriptEvent: PerformanceEvent? {
+        performanceEvents.last(where: { $0.event == "transcript_segment_written" && $0.audioTimeSeconds != nil })
+            ?? performanceEvents.last(where: { $0.event == "stt_segment_received" && $0.audioTimeSeconds != nil })
+    }
+
+    private var performanceEvents: [PerformanceEvent] {
+        guard let url = meeting.performanceEventsURL,
+              let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return []
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return content
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line in
+                try? decoder.decode(PerformanceEvent.self, from: Data(line.utf8))
+            }
+    }
+
+    private func latencySeconds(for event: PerformanceEvent) -> TimeInterval? {
+        guard let audioTimeSeconds = event.audioTimeSeconds else {
+            return nil
+        }
+        let expectedWallTime = meeting.startedAt.addingTimeInterval(audioTimeSeconds)
+        return max(0, event.wallTime.timeIntervalSince(expectedWallTime))
+    }
+
+    private func translationLatencySeconds(for attached: PerformanceEvent, in events: [PerformanceEvent]) -> TimeInterval? {
+        let matchingEvents = translationRequestEvents(matching: attached, in: events)
+        guard let start = matchingEvents.last(where: { $0.event == "caption_translation_scheduled" })
+                ?? matchingEvents.last(where: { $0.event == "caption_translation_started" }) else {
+            return nil
+        }
+        return max(0, attached.wallTime.timeIntervalSince(start.wallTime))
+    }
+
+    private func translationRequestEvents(matching attached: PerformanceEvent, in events: [PerformanceEvent]) -> [PerformanceEvent] {
+        guard let requestID = attached.metadata["translationRequestID"] else {
+            return events.filter { $0.wallTime <= attached.wallTime }
+        }
+        return events.filter { $0.metadata["translationRequestID"] == requestID }
+    }
+
+    private func format(seconds: TimeInterval) -> String {
+        if seconds < 1 {
+            return "\(Int((seconds * 1_000).rounded())) ms"
+        }
+        return String(format: "%.1f s", seconds)
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -71,11 +71,19 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(metadataSource.contains("Image(systemName: \"exclamationmark.circle\")"))
         XCTAssertTrue(metadataSource.contains(".help(pipelineDebugHelpText)"))
         XCTAssertTrue(metadataSource.contains("CommandCenterChip(title: transcriptionStatusText"))
-        XCTAssertTrue(metadataSource.contains("CommandCenterChip(title: pipelineDisplayName"))
+        XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: pipelineDisplayName"))
         XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Actual STT Source:"))
         XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Transcription Link:"))
         XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Transcription Model:"))
         XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Preflight:"))
+        XCTAssertTrue(source.contains("\"Pipeline: \\(pipelineDisplayName)\""))
+        XCTAssertTrue(source.contains("\"Transcript Latency: \\(transcriptLatencyText)\""))
+        XCTAssertTrue(source.contains("\"Translation Latency: \\(translationLatencyText)\""))
+        XCTAssertTrue(source.contains("meeting.performanceEventsURL"))
+        XCTAssertTrue(source.contains("PerformanceEvent.self"))
+        XCTAssertTrue(source.contains("translationRequestID"))
+        XCTAssertTrue(source.contains("caption_translation_scheduled"))
+        XCTAssertTrue(source.contains("caption_translation_attached"))
     }
 
     func testRecordingAndRetryButtonsShareActionRow() throws {

--- a/docs/superpowers/plans/2026-04-29-current-pipeline-hover.md
+++ b/docs/superpowers/plans/2026-04-29-current-pipeline-hover.md
@@ -1,0 +1,214 @@
+# Current Pipeline Hover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate current pipeline details and latency summaries into the native tooltip on the Current Pipeline icon.
+
+**Architecture:** Keep the change inside the existing SwiftUI meeting detail view. Use `MeetingRecord.performanceEventsURL` to derive a read-only latency summary from existing `PerformanceEvent` JSONL entries, and format it into the existing `.help(pipelineDebugHelpText)` text.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout guards, existing `PerformanceEvent` Codable model.
+
+---
+
+### Task 1: Guard The UI Contract
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Update the existing metadata layout test**
+
+Change `testCurrentPipelineMovesDebugDetailsBehindHoverIcon` so it expects the pipeline chip to be absent and the tooltip to include pipeline plus latency details:
+
+```swift
+XCTAssertTrue(metadataSource.contains("Image(systemName: \"exclamationmark.circle\")"))
+XCTAssertTrue(metadataSource.contains(".help(pipelineDebugHelpText)"))
+XCTAssertTrue(metadataSource.contains("CommandCenterChip(title: transcriptionStatusText"))
+XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: pipelineDisplayName"))
+XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Actual STT Source:"))
+XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Transcription Link:"))
+XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Transcription Model:"))
+XCTAssertFalse(metadataSource.contains("CommandCenterChip(title: \"Preflight:"))
+XCTAssertTrue(source.contains("\"Pipeline: \\(pipelineDisplayName)\""))
+XCTAssertTrue(source.contains("\"Transcript Latency: \\(transcriptLatencyText)\""))
+XCTAssertTrue(source.contains("\"Translation Latency: \\(translationLatencyText)\""))
+XCTAssertTrue(source.contains("meeting.performanceEventsURL"))
+XCTAssertTrue(source.contains("PerformanceEvent.self"))
+XCTAssertTrue(source.contains("translationRequestID"))
+XCTAssertTrue(source.contains("caption_translation_scheduled"))
+XCTAssertTrue(source.contains("caption_translation_attached"))
+```
+
+- [ ] **Step 2: Run the focused test and confirm failure**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testCurrentPipelineMovesDebugDetailsBehindHoverIcon`
+
+Expected: FAIL because `CommandCenterChip(title: pipelineDisplayName` is still present and the new tooltip latency rows do not exist.
+
+### Task 2: Expand Tooltip And Remove Visible Pipeline Chip
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Remove the visible pipeline chip**
+
+In `private var metadata: some View`, delete this chip from the metadata `HStack`:
+
+```swift
+CommandCenterChip(title: pipelineDisplayName, tint: CommandCenterPalette.primary)
+```
+
+- [ ] **Step 2: Add pipeline and latency rows to tooltip text**
+
+Replace `pipelineDebugHelpText` with:
+
+```swift
+private var pipelineDebugHelpText: String {
+    [
+        "Pipeline: \(pipelineDisplayName)",
+        "Actual STT Source: \(actualTranscriptionSourceText)",
+        "Transcription Link: \(transcriptionLinkText)",
+        "Transcription Model: \(transcriptionModelText)",
+        "Preflight: \(preflightText)",
+        "Transcript Latency: \(transcriptLatencyText)",
+        "Translation Latency: \(translationLatencyText)"
+    ].joined(separator: "\n")
+}
+```
+
+- [ ] **Step 3: Add latency computed properties**
+
+Add these properties near `pipelineDebugHelpText`:
+
+```swift
+private var transcriptLatencyText: String {
+    PipelineLatencySummary(meeting: meeting).transcriptLatencyText
+}
+
+private var translationLatencyText: String {
+    PipelineLatencySummary(meeting: meeting).translationLatencyText
+}
+```
+
+### Task 3: Implement Read-Only Latency Summary
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Add a private summary helper**
+
+Add a private helper near the other private view support types in `MainWindowView.swift`:
+
+```swift
+private struct PipelineLatencySummary {
+    let meeting: MeetingRecord
+
+    var transcriptLatencyText: String {
+        guard let event = latestTranscriptEvent,
+              let latency = latencySeconds(for: event) else {
+            return "unavailable"
+        }
+        return format(seconds: latency)
+    }
+
+    var translationLatencyText: String {
+        let events = performanceEvents
+        if let attached = events.last(where: { $0.event == "caption_translation_attached" }),
+           let latency = translationLatencySeconds(for: attached, in: events) {
+            return format(seconds: latency)
+        }
+        if events.contains(where: { $0.event.hasPrefix("caption_translation_") }) {
+            return "attach latency unavailable"
+        }
+        return "unavailable"
+    }
+
+    private var latestTranscriptEvent: PerformanceEvent? {
+        performanceEvents.last(where: { $0.event == "transcript_segment_written" && $0.audioTimeSeconds != nil })
+            ?? performanceEvents.last(where: { $0.event == "stt_segment_received" && $0.audioTimeSeconds != nil })
+    }
+
+    private var performanceEvents: [PerformanceEvent] {
+        guard let url = meeting.performanceEventsURL,
+              let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return []
+        }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return content
+            .split(whereSeparator: \.isNewline)
+            .compactMap { line in
+                try? decoder.decode(PerformanceEvent.self, from: Data(line.utf8))
+            }
+    }
+
+    private func latencySeconds(for event: PerformanceEvent) -> TimeInterval? {
+        guard let audioTimeSeconds = event.audioTimeSeconds else {
+            return nil
+        }
+        let expectedWallTime = meeting.startedAt.addingTimeInterval(audioTimeSeconds)
+        return max(0, event.wallTime.timeIntervalSince(expectedWallTime))
+    }
+
+    private func translationLatencySeconds(for attached: PerformanceEvent, in events: [PerformanceEvent]) -> TimeInterval? {
+        let matchingEvents = translationRequestEvents(matching: attached, in: events)
+        guard let start = matchingEvents.last(where: { $0.event == "caption_translation_scheduled" })
+                ?? matchingEvents.last(where: { $0.event == "caption_translation_started" }) else {
+            return nil
+        }
+        return max(0, attached.wallTime.timeIntervalSince(start.wallTime))
+    }
+
+    private func translationRequestEvents(matching attached: PerformanceEvent, in events: [PerformanceEvent]) -> [PerformanceEvent] {
+        guard let requestID = attached.metadata["translationRequestID"] else {
+            return events.filter { $0.wallTime <= attached.wallTime }
+        }
+        return events.filter { $0.metadata["translationRequestID"] == requestID }
+    }
+
+    private func format(seconds: TimeInterval) -> String {
+        if seconds < 1 {
+            return "\(Int((seconds * 1_000).rounded())) ms"
+        }
+        return String(format: "%.1f s", seconds)
+    }
+}
+```
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testCurrentPipelineMovesDebugDetailsBehindHoverIcon`
+
+Expected: PASS.
+
+### Task 4: Verify And Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+- Create: `docs/superpowers/specs/2026-04-29-current-pipeline-hover-design.md`
+- Create: `docs/superpowers/plans/2026-04-29-current-pipeline-hover.md`
+
+- [ ] **Step 1: Run full verification**
+
+Run: `make test`
+
+Expected: PASS.
+
+- [ ] **Step 2: Check git status**
+
+Run: `git status --short`
+
+Expected changed files only in the paths listed above.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/specs/2026-04-29-current-pipeline-hover-design.md docs/superpowers/plans/2026-04-29-current-pipeline-hover.md
+git commit -m "feat: move pipeline details into hover (#73)"
+```
+
+## Self-Review
+
+- Spec coverage: the plan removes the visible pipeline chip, expands the native tooltip, and adds transcript/translation latency summaries from existing performance events.
+- Placeholder scan: no placeholder implementation steps remain.
+- Type consistency: `PipelineLatencySummary`, `PerformanceEvent`, and `meeting.performanceEventsURL` match existing project types.

--- a/docs/superpowers/specs/2026-04-29-current-pipeline-hover-design.md
+++ b/docs/superpowers/specs/2026-04-29-current-pipeline-hover-design.md
@@ -1,0 +1,63 @@
+# Current Pipeline Hover Design
+
+## Goal
+
+Move current pipeline details out of the visible metadata tags and into the native hover tooltip on the warning/info icon beside "Current Pipeline".
+
+## Context
+
+The meeting detail metadata area already has a "Current Pipeline" label, an `exclamationmark.circle` icon, and a native SwiftUI `.help(pipelineDebugHelpText)` tooltip. It also still renders `pipelineDisplayName` as a visible chip. Issue #73 asks for the pipeline information shown in tags to stop being duplicated there and to be consolidated in hover. The hover should include the meeting model chain, concrete models, transcript latency, and translation latency.
+
+Performance events are already written to `performance-events.jsonl` through `PerformanceEventLogger`. Existing event names include transcription events such as `stt_segment_received` and `transcript_segment_written`, and caption translation events from the latency work. The UI can read this file on demand for a lightweight summary without changing recording or provider behavior.
+
+## Requirements
+
+- Keep the native macOS tooltip behavior using SwiftUI `.help(...)`.
+- Keep the right-side `exclamationmark.circle` icon as the hover target.
+- Remove the visible pipeline name chip from the metadata tag row.
+- Include these details in the tooltip:
+  - Pipeline display name.
+  - Actual STT source.
+  - Transcription link.
+  - Transcription model.
+  - Preflight status.
+  - Transcript latency summary.
+  - Translation latency summary.
+- If latency data is missing, show an explicit unavailable state instead of hiding the row.
+- Do not add new user settings or provider behavior.
+
+## Non-Requirements
+
+- Do not build a custom popover or hover panel.
+- Do not change the pipeline selection model.
+- Do not change performance event logging semantics.
+- Do not add live polling for tooltip updates beyond the existing view refresh cycle.
+
+## Selected Approach
+
+Use the existing native tooltip and expand `pipelineDebugHelpText`. Add a small formatting helper in `MainWindowView.swift` that reads the current meeting's `performanceEventsURL`, decodes line-delimited `PerformanceEvent` values, and computes simple latest-latency summaries.
+
+The metadata row will keep status and meeting time chips. The pipeline name chip will be removed, because the issue asks for tag-displayed pipeline information to live only in hover.
+
+## Latency Semantics
+
+Transcript latency should use the latest final transcript segment with both audio time and wall time available. It should report the wall-clock delay from meeting start plus audio timestamp to event wall time, using `transcript_segment_written` when available and falling back to `stt_segment_received`.
+
+Translation latency should use caption translation events where possible. It should prefer attached events, because that is what the user sees. Since caption translation events do not carry audio timestamps, calculate this as wall-clock time from the matching `caption_translation_scheduled` event to `caption_translation_attached` using `translationRequestID`, falling back to `caption_translation_started` when scheduled is absent. If attached events are not available, or if the matching start event cannot be found, the tooltip should report that visible attach latency is unavailable.
+
+## Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`: remove visible pipeline chip and expand tooltip text.
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`: update layout guard tests so the removed chip stays removed and the new tooltip rows stay covered.
+- `docs/superpowers/plans/2026-04-29-current-pipeline-hover.md`: implementation plan.
+
+## Tests
+
+Use source-layout tests because the current UI tests already guard this SwiftUI layout by source scanning. Add assertions that:
+
+- The metadata section still contains the icon and `.help(pipelineDebugHelpText)`.
+- The metadata section no longer contains `CommandCenterChip(title: pipelineDisplayName`.
+- `pipelineDebugHelpText` includes pipeline name and latency rows.
+- Tooltip construction references `performanceEventsURL` and `PerformanceEvent`.
+
+Run `make test` after implementation.


### PR DESCRIPTION
## Summary

Fixes #73

- Moves the visible current pipeline chip into the native hover tooltip on the Current Pipeline icon.
- Adds pipeline/model/preflight details plus transcript and translation latency summaries to the tooltip.
- Reads existing performance event JSONL data without changing provider or logging behavior.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - removes the visible pipeline chip and expands `.help(pipelineDebugHelpText)` with pipeline and latency details.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - updates the source-layout regression guard for the native tooltip contract.
- `docs/superpowers/specs/2026-04-29-current-pipeline-hover-design.md` - records the approved native tooltip design.
- `docs/superpowers/plans/2026-04-29-current-pipeline-hover.md` - records the implementation plan.
- `MISTAKES.md` - records the latency event time-base lesson from review.

## Test plan

- [x] Build/lint: `git diff --check` passed.
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testCurrentPipelineMovesDebugDetailsBehindHoverIcon` passed.
- [x] Full verification: `make test` passed; 499 tests, coverage gate passed at line 96.56%, method 95.26%.
- [x] E2E/integration: skipped; no E2E convention for native tooltip/source-layout behavior.
- [x] Code review: PASS after fixing translation latency to use `translationRequestID` wall-clock correlation instead of transcript audio-time logic.
- [x] Manual verification: reviewed SwiftUI metadata diff and tooltip rows.