### PR TITLE
Fix repeated interim caption refresh translations

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -931,9 +931,17 @@ public final class MeetingAgentViewModel: ObservableObject {
             } else {
                 signatureSpeakerLabel = ""
             }
+            let signatureFinalState = "final"
+            let signatureSpeechState: String
+            if segment.speechFinal {
+                signatureSpeechState = "speechFinal"
+            } else {
+                signatureSpeechState = "open"
+            }
             let signature = [
                 segment.text,
-                segment.speechFinal ? "speechFinal" : "open",
+                signatureFinalState,
+                signatureSpeechState,
                 signatureSpeakerID,
                 signatureSpeakerLabel
             ].joined(separator: "\u{1F}")
@@ -950,6 +958,34 @@ public final class MeetingAgentViewModel: ObservableObject {
             }
         }
         for segment in document.segments where !segment.isFinal {
+            let signatureSpeakerID: String
+            if let speakerID = segment.speakerID {
+                signatureSpeakerID = speakerID
+            } else {
+                signatureSpeakerID = ""
+            }
+            let signatureSpeakerLabel: String
+            if let speakerLabel = segment.speakerLabel {
+                signatureSpeakerLabel = speakerLabel
+            } else {
+                signatureSpeakerLabel = ""
+            }
+            let signatureFinalState = "interim"
+            let signatureSpeechState: String
+            if segment.speechFinal {
+                signatureSpeechState = "speechFinal"
+            } else {
+                signatureSpeechState = "open"
+            }
+            let signature = [
+                segment.text,
+                signatureFinalState,
+                signatureSpeechState,
+                signatureSpeakerID,
+                signatureSpeakerLabel
+            ].joined(separator: "\u{1F}")
+            guard processedLiveCaptionSegmentSignaturesByID[segment.id] != signature else { continue }
+            processedLiveCaptionSegmentSignaturesByID[segment.id] = signature
             currentPerformanceEventLogger()?.logSegment(
                 "caption_segment_ingested",
                 segment: segment,

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -936,6 +936,45 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, latestText)
     }
 
+    func testUnchangedInterimSegmentIsNotIngestedAgainOnRefresh() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let record = try store.createMeeting(name: "Meet", startedAt: Date()).record
+        let writer = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL), structuredURL: XCTUnwrap(record.transcriptJSONURL))
+        let provider = ViewModelFakeTextTranslationProvider(translations: ["dg-active": "临时翻译"])
+        let viewModel = MeetingAgentViewModel(
+            store: store,
+            captionTranslationProviderFactory: { _ in provider }
+        )
+        try viewModel.loadMeetings()
+        viewModel.selectMeeting(record.id)
+
+        try writer.replace(with: [
+            TranscriptSegment(
+                id: "dg-active",
+                text: "hello interim",
+                language: "en-US",
+                sourceProvider: "deepgram-transcribe",
+                isFinal: false
+            )
+        ])
+        viewModel.drainRecordingFrames()
+        try await waitFor { viewModel.liveCaptionTurns.first?.translatedText == "临时翻译" }
+
+        viewModel.drainRecordingFrames()
+
+        let ingestedEvents = try readPerformanceEvents(from: XCTUnwrap(record.performanceEventsURL))
+            .filter {
+                $0.event == "caption_segment_ingested"
+                    && $0.segmentID == "dg-active"
+                    && $0.metadata["path"] == "interim"
+            }
+
+        XCTAssertEqual(ingestedEvents.count, 1)
+        XCTAssertEqual(provider.requests.count, 1)
+    }
+
     func testInterimDeepgramSegmentDisplaysWithDraftTranslationBeforeFinalArrives() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary
- Dedupe unchanged interim caption segments during selected meeting refreshes
- Include final/interim state in caption segment signatures so interim-to-final transitions still process
- Add a regression test that repeated refreshes do not re-ingest or re-translate the same interim segment

## Verification
- make test