### PR TITLE
fix: bundle local whisper runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 .record/
 .superpowers
 Resources/WhisperModels/
+Resources/WhisperBin/
+Resources/WhisperLib/
+Resources/WhisperLibexec/

--- a/Sources/MeetingAgentApp/SettingsView.swift
+++ b/Sources/MeetingAgentApp/SettingsView.swift
@@ -57,12 +57,6 @@ struct SettingsView: View {
                         }
 
                         if draft.localTranscriptionProviderID == "whisper-local" {
-                            Picker("Whisper Binary Path", selection: whisperBinaryPathBinding) {
-                                ForEach(whisperBinaryPathOptions, id: \.self) { path in
-                                    Text(path).tag(path)
-                                }
-                            }
-
                             Picker("Whisper Model Path", selection: whisperModelPathBinding) {
                                 ForEach(whisperModelPathOptions, id: \.self) { path in
                                     Text(path).tag(path)
@@ -165,13 +159,6 @@ struct SettingsView: View {
         }
     }
 
-    private var whisperBinaryPathBinding: Binding<String> {
-        Binding(
-            get: { draft.whisperBinaryPath ?? "" },
-            set: { draft.whisperBinaryPath = SpeechTranscriptionConfiguration.normalized($0) }
-        )
-    }
-
     private var whisperModelPathBinding: Binding<String> {
         Binding(
             get: { draft.whisperModelPath ?? "" },
@@ -199,16 +186,6 @@ struct SettingsView: View {
 
     private var usesDeepgram: Bool {
         draft.usesDeepgram
-    }
-
-    private var whisperBinaryPathOptions: [String] {
-        uniqueNonBlank([
-            draft.whisperBinaryPath,
-            configuration.whisperBinaryPath,
-            ProcessInfo.processInfo.environment["MEETING_AGENT_WHISPER_BIN"],
-            "/opt/homebrew/bin/whisper-cli",
-            "/usr/local/bin/whisper-cli"
-        ])
     }
 
     private var whisperModelPathOptions: [String] {

--- a/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
@@ -216,7 +216,9 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
         guard let whisperBinaryPath = WhisperConfigurationResolver.binaryPath(
             explicitPath: whisperBinaryPath,
             environment: environment,
-            fileManager: fileManager
+            fileManager: fileManager,
+            bundledResourceURL: bundledResourceURL,
+            developmentResourceSearchRoots: developmentResourceSearchRoots
         ) else {
             return .unavailable("Whisper binary path is not configured")
         }

--- a/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift
@@ -14,7 +14,9 @@ struct WhisperConfiguration: Equatable {
         guard let binaryPath = WhisperConfigurationResolver.binaryPath(
             explicitPath: configuration.whisperBinaryPath,
             environment: environment,
-            fileManager: fileManager
+            fileManager: fileManager,
+            bundledResourceURL: bundledResourceURL,
+            developmentResourceSearchRoots: developmentResourceSearchRoots
         ) else {
             throw unavailable("Whisper binary path is not configured")
         }
@@ -37,7 +39,9 @@ struct WhisperConfiguration: Equatable {
         guard let binaryPath = WhisperConfigurationResolver.binaryPath(
             explicitPath: nil,
             environment: environment,
-            fileManager: fileManager
+            fileManager: fileManager,
+            bundledResourceURL: nil,
+            developmentResourceSearchRoots: []
         ) else {
             throw unavailable("MEETING_AGENT_WHISPER_BIN is not set")
         }
@@ -91,6 +95,7 @@ struct WhisperConfiguration: Equatable {
 }
 
 public enum WhisperConfigurationResolver {
+    public static let binDirectoryName = "WhisperBin"
     public static let modelsDirectoryName = "WhisperModels"
     private static let preferredModelFileNames = [
         "ggml-small.bin",
@@ -101,15 +106,52 @@ public enum WhisperConfigurationResolver {
     static func binaryPath(
         explicitPath: String?,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        bundledResourceURL: URL? = Bundle.main.resourceURL,
+        developmentResourceSearchRoots: [URL] = [URL(fileURLWithPath: FileManager.default.currentDirectoryPath)]
     ) -> String? {
         if let explicitPath = nonBlank(explicitPath) {
             return explicitPath
+        }
+        if let bundledPath = binaryPathOptions(
+            environment: environment,
+            fileManager: fileManager,
+            bundledResourceURL: bundledResourceURL,
+            developmentResourceSearchRoots: developmentResourceSearchRoots
+        ).first {
+            return bundledPath
         }
         if let environmentPath = nonBlank(environment["MEETING_AGENT_WHISPER_BIN"]) {
             return environmentPath
         }
         return executablePath(named: "whisper-cli", pathValue: environment["PATH"], fileManager: fileManager)
+    }
+
+    static func binaryPathOptions(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default,
+        bundledResourceURL: URL? = Bundle.main.resourceURL,
+        developmentResourceSearchRoots: [URL] = [URL(fileURLWithPath: FileManager.default.currentDirectoryPath)]
+    ) -> [String] {
+        var paths = [String?]()
+        if let bundledResourceURL {
+            paths.append(
+                bundledResourceURL
+                    .appendingPathComponent(binDirectoryName, isDirectory: true)
+                    .appendingPathComponent("whisper-cli")
+                    .path
+            )
+        }
+        for rootURL in developmentResourceSearchRoots {
+            paths.append(
+                rootURL.appendingPathComponent("Resources", isDirectory: true)
+                    .appendingPathComponent(binDirectoryName, isDirectory: true)
+                    .appendingPathComponent("whisper-cli")
+                    .path
+            )
+        }
+        paths.append(nonBlank(environment["MEETING_AGENT_WHISPER_BIN"]))
+        return uniqueExistingExecutablePaths(paths, fileManager: fileManager)
     }
 
     static func modelPath(
@@ -202,6 +244,20 @@ public enum WhisperConfigurationResolver {
         }
     }
 
+    private static func uniqueExistingExecutablePaths(_ paths: [String?], fileManager: FileManager) -> [String] {
+        var seen = Set<String>()
+        return paths.compactMap { path in
+            guard let path = nonBlank(path),
+                  !seen.contains(path),
+                  fileManager.isExecutableFile(atPath: URL(fileURLWithPath: path).path)
+            else {
+                return nil
+            }
+            seen.insert(path)
+            return path
+        }
+    }
+
     private static func nonBlank(_ value: String?) -> String? {
         guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
             return nil
@@ -271,6 +327,7 @@ struct WhisperProcessRunner: WhisperProcessRunning {
             outputBaseURL: outputBaseURL,
             languageCode: languageCode
         )
+        process.environment = Self.environment(for: binaryURL)
 
         let stderrPipe = Pipe()
         process.standardError = stderrPipe
@@ -309,6 +366,38 @@ struct WhisperProcessRunner: WhisperProcessRunning {
             "-of", outputBaseURL.path
         ]
         return arguments
+    }
+
+    static func environment(
+        for binaryURL: URL,
+        base: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> [String: String] {
+        var environment = base
+        let resourcesURL = binaryURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let backendURLs = [
+            resourcesURL.appendingPathComponent("libexec", isDirectory: true),
+            resourcesURL.appendingPathComponent("WhisperLibexec", isDirectory: true)
+        ]
+        let backendFileNames = [
+            "libggml-cpu-apple_m1.so",
+            "libggml-cpu-apple_m2_m3.so",
+            "libggml-cpu-apple_m4.so",
+            "libggml-metal.so",
+            "libggml-blas.so"
+        ]
+        for backendURL in backendURLs {
+            for fileName in backendFileNames {
+                let fileURL = backendURL.appendingPathComponent(fileName)
+                if fileManager.fileExists(atPath: fileURL.path) {
+                    environment["GGML_BACKEND_PATH"] = fileURL.path
+                    return environment
+                }
+            }
+        }
+        return environment
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/SettingsViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/SettingsViewLayoutTests.swift
@@ -29,7 +29,8 @@ final class SettingsViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("Picker(\"Hosted Translation Provider\""))
         XCTAssertFalse(source.contains("Picker(\"Bilingual Pipeline Profile\""))
         XCTAssertFalse(source.contains("Section(\"Bilingual Pipeline\")"))
-        XCTAssertTrue(source.contains("Picker(\"Whisper Binary Path\""))
+        XCTAssertFalse(source.contains("Picker(\"Whisper Binary Path\""))
+        XCTAssertFalse(source.contains("whisperBinaryPathOptions"))
         XCTAssertTrue(source.contains("Picker(\"Whisper Model Path\""))
         XCTAssertFalse(source.contains("TextField("))
     }

--- a/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
+++ b/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
@@ -40,7 +40,12 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         )
 
         XCTAssertEqual(
-            configuration.validationStatus(environment: ["MEETING_AGENT_OPENROUTER_API_KEY": "test-key"], fileManager: .default),
+            configuration.validationStatus(
+                environment: ["MEETING_AGENT_OPENROUTER_API_KEY": "test-key"],
+                fileManager: .default,
+                bundledResourceURL: nil,
+                developmentResourceSearchRoots: []
+            ),
             .unavailable("Whisper binary path is not configured")
         )
     }
@@ -96,16 +101,69 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         ]
 
         XCTAssertEqual(
-            configuration.validationStatus(environment: environment, fileManager: .default),
+            configuration.validationStatus(
+                environment: environment,
+                fileManager: .default,
+                bundledResourceURL: nil,
+                developmentResourceSearchRoots: []
+            ),
             .available
         )
         XCTAssertEqual(
             try WhisperConfiguration.fromAppConfiguration(
                 configuration,
                 environment: environment,
-                fileManager: .default
+                fileManager: .default,
+                bundledResourceURL: nil,
+                developmentResourceSearchRoots: []
             ).binaryURL,
             binaryURL
+        )
+    }
+
+    func testWhisperValidationFindsPackagedBinaryWhenNotExplicitlyConfigured() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("speech-config-packaged-bin-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let resourcesURL = directory.appendingPathComponent("Resources", isDirectory: true)
+        let binURL = resourcesURL
+            .appendingPathComponent("WhisperBin", isDirectory: true)
+            .appendingPathComponent("whisper-cli")
+        let modelsURL = resourcesURL.appendingPathComponent("WhisperModels", isDirectory: true)
+        try FileManager.default.createDirectory(at: binURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: modelsURL, withIntermediateDirectories: true)
+        let modelURL = modelsURL.appendingPathComponent("ggml-small.en.bin")
+        FileManager.default.createFile(atPath: binURL.path, contents: Data())
+        FileManager.default.createFile(atPath: modelURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binURL.path)
+
+        let configuration = SpeechTranscriptionConfiguration(
+            provider: .whisper,
+            localeIdentifier: "en-US",
+            whisperBinaryPath: nil,
+            whisperModelPath: nil,
+            translationExecutionMode: .local
+        )
+
+        XCTAssertEqual(
+            configuration.validationStatus(
+                environment: [:],
+                fileManager: .default,
+                bundledResourceURL: resourcesURL,
+                developmentResourceSearchRoots: []
+            ),
+            .available
+        )
+        XCTAssertEqual(
+            try WhisperConfiguration.fromAppConfiguration(
+                configuration,
+                environment: [:],
+                fileManager: .default,
+                bundledResourceURL: resourcesURL,
+                developmentResourceSearchRoots: []
+            ).binaryURL,
+            binURL
         )
     }
 

--- a/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift
@@ -138,6 +138,42 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         XCTAssertEqual(configuration.modelURL, modelURL)
     }
 
+    func testAppConfigurationFindsPackagedBinaryBeforePath() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-config-packaged-bin-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let resourcesURL = directory.appendingPathComponent("Resources", isDirectory: true)
+        let packagedBinURL = resourcesURL
+            .appendingPathComponent("WhisperBin", isDirectory: true)
+            .appendingPathComponent("whisper-cli")
+        let pathBinURL = directory.appendingPathComponent("whisper-cli")
+        let modelURL = directory.appendingPathComponent("ggml-small.en.bin")
+        try FileManager.default.createDirectory(at: packagedBinURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: packagedBinURL.path, contents: Data())
+        FileManager.default.createFile(atPath: pathBinURL.path, contents: Data())
+        FileManager.default.createFile(atPath: modelURL.path, contents: Data())
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: packagedBinURL.path)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: pathBinURL.path)
+
+        let appConfiguration = SpeechTranscriptionConfiguration(
+            provider: .whisper,
+            localeIdentifier: "en-US",
+            whisperBinaryPath: nil,
+            whisperModelPath: modelURL.path
+        )
+
+        let configuration = try WhisperConfiguration.fromAppConfiguration(
+            appConfiguration,
+            environment: ["PATH": directory.path],
+            fileManager: .default,
+            bundledResourceURL: resourcesURL,
+            developmentResourceSearchRoots: []
+        )
+
+        XCTAssertEqual(configuration.binaryURL, packagedBinURL)
+    }
+
     func testProcessRunnerBuildsExpectedArgumentsWithLanguage() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-runner-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -186,6 +222,53 @@ final class WhisperTranscriptionProviderTests: XCTestCase {
         )
 
         XCTAssertFalse(runner.recordedArguments.contains("-l"))
+    }
+
+    func testProcessRunnerUsesPackagedBackendDirectoryWhenAvailable() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-backend-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let binaryURL = directory
+            .appendingPathComponent("WhisperBin", isDirectory: true)
+            .appendingPathComponent("whisper-cli")
+        let backendURL = directory.appendingPathComponent("libexec", isDirectory: true)
+        let backendFileURL = backendURL.appendingPathComponent("libggml-cpu-apple_m1.so")
+        try FileManager.default.createDirectory(at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: backendURL, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: backendFileURL.path, contents: Data())
+
+        let environment = WhisperProcessRunner.environment(
+            for: binaryURL,
+            base: ["PATH": "/usr/bin"],
+            fileManager: .default
+        )
+
+        XCTAssertEqual(environment["PATH"], "/usr/bin")
+        XCTAssertEqual(environment["GGML_BACKEND_PATH"], backendFileURL.path)
+    }
+
+    func testProcessRunnerUsesDevelopmentBackendDirectoryWhenAvailable() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("whisper-backend-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let binaryURL = directory
+            .appendingPathComponent("WhisperBin", isDirectory: true)
+            .appendingPathComponent("whisper-cli")
+        let backendURL = directory.appendingPathComponent("WhisperLibexec", isDirectory: true)
+        let backendFileURL = backendURL.appendingPathComponent("libggml-cpu-apple_m2_m3.so")
+        try FileManager.default.createDirectory(at: binaryURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: backendURL, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: backendFileURL.path, contents: Data())
+
+        let environment = WhisperProcessRunner.environment(
+            for: binaryURL,
+            base: [:],
+            fileManager: .default
+        )
+
+        XCTAssertEqual(environment["GGML_BACKEND_PATH"], backendFileURL.path)
     }
 
     func testProcessRunnerThrowsWhenExitCodeIsNonZero() {

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -13,6 +13,12 @@ INFO_PLIST="$REPO_ROOT/Sources/MeetingAgentApp/Resources/Info.plist"
 RELEASE_EXECUTABLE="$REPO_ROOT/.build/release/$EXECUTABLE_NAME"
 ENV_FILE="$REPO_ROOT/.env"
 DEFAULT_CREDENTIALS="$RESOURCES_DIR/DefaultSpeechTranscriptionCredentials.json"
+WHISPER_BIN_SOURCE="$REPO_ROOT/Resources/WhisperBin/whisper-cli"
+WHISPER_BIN_DESTINATION="$RESOURCES_DIR/WhisperBin/whisper-cli"
+WHISPER_LIB_SOURCE="$REPO_ROOT/Resources/WhisperLib"
+WHISPER_LIB_DESTINATION="$RESOURCES_DIR/lib"
+WHISPER_BACKENDS_SOURCE="$REPO_ROOT/Resources/WhisperLibexec"
+WHISPER_BACKENDS_DESTINATION="$RESOURCES_DIR/libexec"
 WHISPER_MODELS_SOURCE="$REPO_ROOT/Resources/WhisperModels"
 WHISPER_MODELS_DESTINATION="$RESOURCES_DIR/WhisperModels"
 
@@ -31,6 +37,83 @@ mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 cp "$RELEASE_EXECUTABLE" "$MACOS_DIR/$EXECUTABLE_NAME"
 cp "$INFO_PLIST" "$CONTENTS_DIR/Info.plist"
 printf "APPL????" > "$CONTENTS_DIR/PkgInfo"
+
+if [ -f "$WHISPER_BIN_SOURCE" ]; then
+    mkdir -p "$(dirname "$WHISPER_BIN_DESTINATION")"
+    cp "$WHISPER_BIN_SOURCE" "$WHISPER_BIN_DESTINATION"
+    chmod 755 "$WHISPER_BIN_DESTINATION"
+    echo "Embedded Whisper CLI from $WHISPER_BIN_SOURCE"
+else
+    echo "No Whisper CLI embedded; missing $WHISPER_BIN_SOURCE"
+fi
+
+if [ -d "$WHISPER_LIB_SOURCE" ]; then
+    mkdir -p "$WHISPER_LIB_DESTINATION"
+    copied_libraries=0
+    for library_path in "$WHISPER_LIB_SOURCE"/*.dylib; do
+        if [ -f "$library_path" ]; then
+            cp "$library_path" "$WHISPER_LIB_DESTINATION"/
+            chmod 755 "$WHISPER_LIB_DESTINATION/$(basename "$library_path")"
+            copied_libraries=$((copied_libraries + 1))
+        fi
+    done
+    if [ "$copied_libraries" -gt 0 ]; then
+        echo "Embedded $copied_libraries Whisper libraries from $WHISPER_LIB_SOURCE"
+    else
+        echo "No Whisper libraries embedded; no dylibs found in $WHISPER_LIB_SOURCE"
+    fi
+else
+    echo "No Whisper libraries embedded; missing $WHISPER_LIB_SOURCE"
+fi
+
+if [ -d "$WHISPER_BACKENDS_SOURCE" ]; then
+    mkdir -p "$WHISPER_BACKENDS_DESTINATION"
+    copied_backends=0
+    for backend_path in "$WHISPER_BACKENDS_SOURCE"/*.so; do
+        if [ -f "$backend_path" ]; then
+            cp "$backend_path" "$WHISPER_BACKENDS_DESTINATION"/
+            chmod 755 "$WHISPER_BACKENDS_DESTINATION/$(basename "$backend_path")"
+            copied_backends=$((copied_backends + 1))
+        fi
+    done
+    if [ "$copied_backends" -gt 0 ]; then
+        echo "Embedded $copied_backends Whisper backend plugins from $WHISPER_BACKENDS_SOURCE"
+    else
+        echo "No Whisper backend plugins embedded; no shared objects found in $WHISPER_BACKENDS_SOURCE"
+    fi
+else
+    echo "No Whisper backend plugins embedded; missing $WHISPER_BACKENDS_SOURCE"
+fi
+
+if [ -f "$WHISPER_BIN_DESTINATION" ] && [ -d "$WHISPER_LIB_DESTINATION" ] && command -v install_name_tool >/dev/null 2>&1; then
+    install_name_tool \
+        -change /opt/homebrew/opt/ggml/lib/libggml.0.dylib @rpath/libggml.0.dylib \
+        -change /opt/homebrew/opt/ggml/lib/libggml-base.0.dylib @rpath/libggml-base.0.dylib \
+        "$WHISPER_BIN_DESTINATION" 2>/dev/null || true
+    for library_path in "$WHISPER_LIB_DESTINATION"/*.dylib; do
+        if [ -f "$library_path" ]; then
+            install_name_tool -id "@rpath/$(basename "$library_path")" "$library_path" 2>/dev/null || true
+            install_name_tool \
+                -change /opt/homebrew/opt/ggml/lib/libggml.0.dylib @rpath/libggml.0.dylib \
+                -change /opt/homebrew/opt/ggml/lib/libggml-base.0.dylib @rpath/libggml-base.0.dylib \
+            "$library_path" 2>/dev/null || true
+        fi
+    done
+    if [ -d "$WHISPER_BACKENDS_DESTINATION" ]; then
+        for backend_path in "$WHISPER_BACKENDS_DESTINATION"/*.so; do
+            if [ -f "$backend_path" ]; then
+                install_name_tool \
+                    -change /opt/homebrew/opt/ggml/lib/libggml-base.0.dylib @rpath/libggml-base.0.dylib \
+                    -change /opt/homebrew/opt/libomp/lib/libomp.dylib @rpath/libomp.dylib \
+                    "$backend_path" 2>/dev/null || true
+            fi
+        done
+    fi
+fi
+
+if [ -f "$WHISPER_LIB_DESTINATION/libggml.0.dylib" ] && command -v perl >/dev/null 2>&1; then
+    perl -0pi -e 's#/opt/homebrew/Cellar/ggml/0\.10\.0/libexec#"/tmp/meeting-agent-no-ggml-libexec" . ("\0" x 6)#e' "$WHISPER_LIB_DESTINATION/libggml.0.dylib"
+fi
 
 if [ -d "$WHISPER_MODELS_SOURCE" ]; then
     mkdir -p "$WHISPER_MODELS_DESTINATION"
@@ -124,12 +207,13 @@ else
     echo "No default credentials embedded; .env did not include supported API key names"
 fi
 
-if command -v codesign >/dev/null 2>&1; then
-    codesign --force --sign - "$APP_BUNDLE"
-fi
-
 if command -v xattr >/dev/null 2>&1; then
     xattr -cr "$APP_BUNDLE"
+fi
+
+if command -v codesign >/dev/null 2>&1; then
+    find "$RESOURCES_DIR" -type f \( -name "*.dylib" -o -name "*.so" -o -name "whisper-cli" \) -exec codesign --force --sign - {} \;
+    codesign --force --deep --sign - "$APP_BUNDLE"
 fi
 
 ditto -c -k --sequesterRsrc --keepParent "$APP_BUNDLE" "$ARCHIVE_PATH"


### PR DESCRIPTION
## Summary
- Resolve local Whisper model lookup from bundled app resources or project Resources/WhisperModels instead of hardcoded user paths.
- Package ignored Whisper runtime assets into MeetingAgent.app: whisper-cli, its required dylibs, and ggml-small.en.bin.
- Remove the Whisper CLI path picker from Settings; the app now defaults to the bundled/project CLI while retaining env/config fallback for developer flows.
- Force whisper.cpp language to English when the selected model is English-only (.en.bin/.en.gguf), while keeping transcript segment locale metadata unchanged.
- Update Settings and configuration tests for packaged binary/model discovery.

## Test plan
- [x] swift test --filter SettingsViewLayoutTests/testSettingsViewUsesPickersForAllEditableFields
- [x] swift test --filter SpeechTranscriptionConfigurationTests
- [x] swift test --filter WhisperTranscriptionProviderTests
- [x] MEETING_AGENT_COVERAGE_SCRATCH_PATH=/tmp/meeting-agent-coverage-current make test (501 tests, 0 failures; coverage gate passed)
- [x] make package-app (embedded Whisper CLI, 3 Whisper libraries, and 1 Whisper model)
- [x] dist/MeetingAgent.app/Contents/Resources/WhisperBin/whisper-cli --help exits successfully from the packaged app bundle

## Notes
- Whisper runtime files remain git-ignored under Resources/WhisperBin/, Resources/WhisperLib/, and Resources/WhisperModels/ and are packaged only into the local app bundle.
- Supersedes #72; GitHub kept #72's pull request head on the old SHA even after the branch ref moved.