### PR TITLE
feat: add recommended questions module

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -414,6 +414,22 @@ When a lower-level service mutates persisted model state during an async operati
 
 ---
 
+## [76] Preserve public protocol compatibility when adding optional context
+
+**Date**: 2026-04-29
+**Category**: api-misuse
+
+### What went wrong
+The first recommended-questions implementation added agenda topics directly to the public `MeetingProgressAnalyzing` protocol requirement, which would force every existing conformer to change even when it did not need agenda context.
+
+### Correct approach
+Keep the existing public protocol requirement intact and add a narrower agenda-aware protocol for analyzers that can use the extra context.
+
+### How to avoid
+When adding optional context to a public protocol, prefer a new refined protocol or adapter path over changing the base requirement.
+
+---
+
 ## [73] Match latency calculations to event time bases
 
 **Date**: 2026-04-29

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -136,6 +136,7 @@ struct MainWindowView: View {
                     statusText: viewModel.statusText,
                     isRecording: viewModel.isRecording,
                     liveCaptionTurns: viewModel.liveCaptionTurns,
+                    recommendedQuestions: viewModel.recommendedQuestions,
                     stopRecording: {
                         Task {
                             do {
@@ -300,6 +301,7 @@ private struct MeetingDetailView: View {
     let statusText: String
     let isRecording: Bool
     let liveCaptionTurns: [LiveCaptionTurn]
+    let recommendedQuestions: [FollowUpQuestionSuggestion]
     let stopRecording: () -> Void
     let copySummary: (MeetingRecord) -> Void
     let exportTranscript: (MeetingRecord) -> Void
@@ -329,6 +331,7 @@ private struct MeetingDetailView: View {
                     transcriptText: transcriptText(for: meeting),
                     transcriptionStatusText: transcriptionStatusText(for: meeting),
                     summary: summary(for: meeting),
+                    recommendedQuestions: recommendedQuestions,
                     stopRecording: stopRecording,
                     copySummary: { copySummary(meeting) },
                     exportTranscript: { exportTranscript(meeting) },
@@ -482,6 +485,7 @@ private struct MeetingCommandCenterView: View {
     let transcriptText: String
     let transcriptionStatusText: String
     let summary: MeetingSummary?
+    let recommendedQuestions: [FollowUpQuestionSuggestion]
     let stopRecording: () -> Void
     let copySummary: () -> Void
     let exportTranscript: () -> Void
@@ -530,6 +534,7 @@ private struct MeetingCommandCenterView: View {
                     meeting: meeting,
                     isRecording: isRecording,
                     summary: summary,
+                    recommendedQuestions: recommendedQuestions,
                     copySummary: copySummary,
                     exportTranscript: exportTranscript,
                     exportMeetingData: exportMeetingData,
@@ -884,6 +889,7 @@ private struct InsightPaneView: View {
     let meeting: MeetingRecord
     let isRecording: Bool
     let summary: MeetingSummary?
+    let recommendedQuestions: [FollowUpQuestionSuggestion]
     let copySummary: () -> Void
     let exportTranscript: () -> Void
     let exportMeetingData: () -> Void
@@ -894,6 +900,9 @@ private struct InsightPaneView: View {
         VStack(spacing: 0) {
             CommandCenterScrollView(background: CommandCenterPalette.surface, content: {
                 VStack(alignment: .leading, spacing: 16) {
+                    if !recommendedQuestions.isEmpty {
+                        RecommendedQuestionsPanel(questions: recommendedQuestions)
+                    }
                     phaseSummary
                     exports
                     summaryPanel
@@ -986,6 +995,29 @@ private struct InsightPaneView: View {
                 } else {
                     Text("No summary generated yet.")
                         .foregroundStyle(CommandCenterPalette.secondaryText)
+                }
+            }
+        }
+    }
+}
+
+private struct RecommendedQuestionsPanel: View {
+    let questions: [FollowUpQuestionSuggestion]
+
+    var body: some View {
+        CommandCenterPanel {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Recommended Questions").commandCenterEyebrow()
+                ForEach(Array(questions.prefix(2))) { question in
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(question.chinese)
+                            .font(CommandCenterTypography.sectionTitle)
+                            .foregroundStyle(CommandCenterPalette.text)
+                            .textSelection(.enabled)
+                        Text(question.english)
+                            .commandCenterCaption(CommandCenterPalette.secondaryText)
+                            .textSelection(.enabled)
+                    }
                 }
             }
         }

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -763,13 +763,21 @@ public struct MeetingProgressState: Codable, Equatable {
 public protocol MeetingProgressAnalyzing {
     func analyze(
         goal: MeetingGoal,
+        recentCaptions: [LiveCaptionTurn],
+        previousState: MeetingProgressState?
+    ) async throws -> MeetingProgressState
+}
+
+public protocol AgendaAwareMeetingProgressAnalyzing: MeetingProgressAnalyzing {
+    func analyze(
+        goal: MeetingGoal,
         agendaTopics: [MeetingAgendaTopic],
         recentCaptions: [LiveCaptionTurn],
         previousState: MeetingProgressState?
     ) async throws -> MeetingProgressState
 }
 
-public final class DeterministicMeetingProgressAnalyzer: MeetingProgressAnalyzing {
+public final class DeterministicMeetingProgressAnalyzer: AgendaAwareMeetingProgressAnalyzing {
     private let meetingID: UUID
     private let now: () -> Date
 
@@ -780,7 +788,20 @@ public final class DeterministicMeetingProgressAnalyzer: MeetingProgressAnalyzin
 
     public func analyze(
         goal: MeetingGoal,
-        agendaTopics: [MeetingAgendaTopic] = [],
+        recentCaptions: [LiveCaptionTurn],
+        previousState: MeetingProgressState?
+    ) async throws -> MeetingProgressState {
+        try await analyze(
+            goal: goal,
+            agendaTopics: [],
+            recentCaptions: recentCaptions,
+            previousState: previousState
+        )
+    }
+
+    public func analyze(
+        goal: MeetingGoal,
+        agendaTopics: [MeetingAgendaTopic],
         recentCaptions: [LiveCaptionTurn],
         previousState: MeetingProgressState?
     ) async throws -> MeetingProgressState {
@@ -927,12 +948,21 @@ public final class MeetingProgressCoordinator {
         }
         analysisHealth = .pending
         do {
-            let nextState = try await analyzer.analyze(
-                goal: goal,
-                agendaTopics: agendaTopics,
-                recentCaptions: newTurns,
-                previousState: state
-            )
+            let nextState: MeetingProgressState
+            if let agendaAwareAnalyzer = analyzer as? AgendaAwareMeetingProgressAnalyzing {
+                nextState = try await agendaAwareAnalyzer.analyze(
+                    goal: goal,
+                    agendaTopics: agendaTopics,
+                    recentCaptions: newTurns,
+                    previousState: state
+                )
+            } else {
+                nextState = try await analyzer.analyze(
+                    goal: goal,
+                    recentCaptions: newTurns,
+                    previousState: state
+                )
+            }
             state = nextState
             lastAnalyzedAt = currentTime
             analysisHealth = .live

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -763,6 +763,7 @@ public struct MeetingProgressState: Codable, Equatable {
 public protocol MeetingProgressAnalyzing {
     func analyze(
         goal: MeetingGoal,
+        agendaTopics: [MeetingAgendaTopic],
         recentCaptions: [LiveCaptionTurn],
         previousState: MeetingProgressState?
     ) async throws -> MeetingProgressState
@@ -779,6 +780,7 @@ public final class DeterministicMeetingProgressAnalyzer: MeetingProgressAnalyzin
 
     public func analyze(
         goal: MeetingGoal,
+        agendaTopics: [MeetingAgendaTopic] = [],
         recentCaptions: [LiveCaptionTurn],
         previousState: MeetingProgressState?
     ) async throws -> MeetingProgressState {
@@ -805,18 +807,11 @@ public final class DeterministicMeetingProgressAnalyzer: MeetingProgressAnalyzin
         } else {
             status = .partiallyCovered
         }
-        let questions = goal.requiredQuestions
-            .filter { question in
-                !text.contains(question.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "?？")))
-            }
-            .prefix(3)
-            .map {
-                FollowUpQuestionSuggestion(
-                    chinese: Self.simpleChinesePrompt(for: $0),
-                    english: $0,
-                    sourceObjectiveID: nil
-                )
-            }
+        let questions = Self.recommendedQuestions(
+            from: objectiveProgress,
+            agendaTopics: agendaTopics,
+            transcriptText: text
+        )
         return MeetingProgressState(
             meetingID: previousState?.meetingID ?? meetingID,
             goal: goal,
@@ -831,13 +826,72 @@ public final class DeterministicMeetingProgressAnalyzer: MeetingProgressAnalyzin
         )
     }
 
-    private static func simpleChinesePrompt(for english: String) -> String {
-        "请确认：\(english)"
+    private static func recommendedQuestions(
+        from objectiveProgress: [MeetingObjectiveProgress],
+        agendaTopics: [MeetingAgendaTopic],
+        transcriptText: String
+    ) -> [FollowUpQuestionSuggestion] {
+        let unresolvedObjectiveQuestions = objectiveProgress
+            .filter { $0.status != .confirmed }
+            .compactMap { progress -> FollowUpQuestionSuggestion? in
+                let title = normalized(progress.title)
+                guard !title.isEmpty else { return nil }
+                return FollowUpQuestionSuggestion(
+                    chinese: chinesePrompt(for: title),
+                    english: englishPrompt(for: title),
+                    sourceObjectiveID: progress.objectiveID
+                )
+            }
+        if !unresolvedObjectiveQuestions.isEmpty {
+            return Array(unresolvedObjectiveQuestions.prefix(2))
+        }
+
+        let topicQuestions = agendaTopics.compactMap { topic -> FollowUpQuestionSuggestion? in
+            let title = normalized(topic.title)
+            guard !title.isEmpty,
+                  !transcriptText.contains(title.lowercased())
+            else {
+                return nil
+            }
+            return FollowUpQuestionSuggestion(
+                chinese: chinesePrompt(for: title),
+                english: englishPrompt(for: title),
+                sourceObjectiveID: nil
+            )
+        }
+        return Array(topicQuestions.prefix(2))
+    }
+
+    private static func normalized(_ value: String) -> String {
+        value
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    private static func englishPrompt(for topic: String) -> String {
+        "Could we clarify \(questionSubject(for: topic))?"
+    }
+
+    private static func chinesePrompt(for topic: String) -> String {
+        "可以进一步确认\(questionSubject(for: topic))吗？"
+    }
+
+    private static func questionSubject(for topic: String) -> String {
+        let prefixes = ["Confirm ", "Decide ", "Review ", "Align on ", "Clarify "]
+        for prefix in prefixes where topic.range(
+            of: prefix,
+            options: [.caseInsensitive, .anchored]
+        ) != nil {
+            return String(topic.dropFirst(prefix.count))
+        }
+        return topic
     }
 }
 
 public final class MeetingProgressCoordinator {
     private let goal: MeetingGoal
+    private let agendaTopics: [MeetingAgendaTopic]
     private let analyzer: MeetingProgressAnalyzing
     private let progressURL: URL
     private let minimumAnalysisInterval: TimeInterval
@@ -849,12 +903,14 @@ public final class MeetingProgressCoordinator {
 
     public init(
         goal: MeetingGoal,
+        agendaTopics: [MeetingAgendaTopic] = [],
         analyzer: MeetingProgressAnalyzing,
         progressURL: URL,
         minimumAnalysisInterval: TimeInterval = 30,
         now: @escaping () -> Date = Date.init
     ) {
         self.goal = goal
+        self.agendaTopics = agendaTopics
         self.analyzer = analyzer
         self.progressURL = progressURL
         self.minimumAnalysisInterval = minimumAnalysisInterval
@@ -873,6 +929,7 @@ public final class MeetingProgressCoordinator {
         do {
             let nextState = try await analyzer.analyze(
                 goal: goal,
+                agendaTopics: agendaTopics,
                 recentCaptions: newTurns,
                 previousState: state
             )

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -52,6 +52,9 @@ public final class MeetingAgentViewModel: ObservableObject {
     private var liveCaptionChunker = LiveCaptionChunker(sourceLocale: "en-US", targetLocale: "zh-CN")
     private var processedLiveCaptionSegmentSignaturesByID: [String: String] = [:]
     @Published public private(set) var meetingGoal: MeetingGoal?
+    public var recommendedQuestions: [FollowUpQuestionSuggestion] {
+        Array((meetingProgressState?.suggestedQuestions ?? []).prefix(2))
+    }
     private var meetingProgressCoordinator: MeetingProgressCoordinator?
     private var attachedRealtimeTranslationTurnIDs = Set<String>()
     private var realtimeTranslationAttachmentCountsByCaptionID: [String: Int] = [:]
@@ -1585,6 +1588,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
         meetingProgressCoordinator = MeetingProgressCoordinator(
             goal: goal,
+            agendaTopics: selectedMeeting?.agendaTopics ?? [],
             analyzer: DeterministicMeetingProgressAnalyzer(meetingID: selectedMeeting?.id ?? UUID()),
             progressURL: progressURL
         )

--- a/Tests/MeetingAgentCoreTests/DeterministicMeetingProgressAnalyzerTests.swift
+++ b/Tests/MeetingAgentCoreTests/DeterministicMeetingProgressAnalyzerTests.swift
@@ -29,16 +29,21 @@ final class DeterministicMeetingProgressAnalyzerTests: XCTestCase {
         XCTAssertEqual(state.status, .partiallyCovered)
         XCTAssertEqual(state.unresolvedItems, ["Confirm launch deadline"])
         XCTAssertEqual(state.suggestedQuestions.count, 1)
-        XCTAssertEqual(state.suggestedQuestions.first?.english, "Have we confirmed the deadline?")
+        XCTAssertEqual(state.suggestedQuestions.first?.english, "Could we clarify launch deadline?")
+        XCTAssertEqual(state.suggestedQuestions.first?.sourceObjectiveID, "deadline")
         XCTAssertFalse(state.suggestedQuestions.first?.chinese.isEmpty ?? true)
     }
 
-    func testBoundsSuggestedQuestionsToThree() async throws {
+    func testRecommendedQuestionsAreDecoupledFromRequiredQuestionsAndBoundedToTwo() async throws {
         let analyzer = DeterministicMeetingProgressAnalyzer()
         let goal = MeetingGoal(
             title: "Confirm launch plan",
-            objectives: [],
-            requiredQuestions: ["Q1?", "Q2?", "Q3?", "Q4?"],
+            objectives: [
+                MeetingObjective(id: "owner", title: "Confirm launch owner"),
+                MeetingObjective(id: "deadline", title: "Confirm launch deadline"),
+                MeetingObjective(id: "budget", title: "Confirm launch budget")
+            ],
+            requiredQuestions: ["This configured question should not be used"],
             expectedDecisions: [],
             keyTerms: []
         )
@@ -49,6 +54,55 @@ final class DeterministicMeetingProgressAnalyzerTests: XCTestCase {
             previousState: nil
         )
 
-        XCTAssertEqual(state.suggestedQuestions.count, 3)
+        XCTAssertEqual(state.suggestedQuestions.map(\.english), [
+            "Could we clarify launch owner?",
+            "Could we clarify launch deadline?"
+        ])
+    }
+
+    func testFallsBackToUncoveredAgendaTopicsWhenNoObjectivesExist() async throws {
+        let analyzer = DeterministicMeetingProgressAnalyzer()
+        let goal = MeetingGoal(
+            title: "Weekly operating review",
+            objectives: [],
+            requiredQuestions: [],
+            expectedDecisions: [],
+            keyTerms: []
+        )
+
+        let state = try await analyzer.analyze(
+            goal: goal,
+            agendaTopics: [
+                MeetingAgendaTopic(title: "Hiring plan"),
+                MeetingAgendaTopic(title: "Budget risk"),
+                MeetingAgendaTopic(title: "Launch readiness")
+            ],
+            recentCaptions: [LiveCaptionTurn(sourceSegmentID: "segment-1", originalText: "We already covered hiring plan.", isFinal: true)],
+            previousState: nil
+        )
+
+        XCTAssertEqual(state.suggestedQuestions.map(\.english), [
+            "Could we clarify Budget risk?",
+            "Could we clarify Launch readiness?"
+        ])
+    }
+
+    func testOmitsRecommendedQuestionsWithoutObjectiveOrTopicContext() async throws {
+        let analyzer = DeterministicMeetingProgressAnalyzer()
+        let goal = MeetingGoal(
+            title: "Weekly sync",
+            objectives: [],
+            requiredQuestions: ["Should not be shown"],
+            expectedDecisions: [],
+            keyTerms: []
+        )
+
+        let state = try await analyzer.analyze(
+            goal: goal,
+            recentCaptions: [LiveCaptionTurn(sourceSegmentID: "segment-1", originalText: "hello", isFinal: true)],
+            previousState: nil
+        )
+
+        XCTAssertEqual(state.suggestedQuestions, [])
     }
 }

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -118,6 +118,18 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("Button(\"Regenerate Summary\")"))
     }
 
+    func testInsightsPaneShowsRecommendedQuestionsOnlyWhenAvailable() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("recommendedQuestions: viewModel.recommendedQuestions"))
+        XCTAssertTrue(source.contains("let recommendedQuestions: [FollowUpQuestionSuggestion]"))
+        XCTAssertTrue(source.contains("if !recommendedQuestions.isEmpty"))
+        XCTAssertTrue(source.contains("RecommendedQuestionsPanel(questions: recommendedQuestions)"))
+        XCTAssertTrue(source.contains("Text(\"Recommended Questions\").commandCenterEyebrow()"))
+        XCTAssertTrue(source.contains("ForEach(Array(questions.prefix(2)))"))
+        XCTAssertFalse(source.contains("No recommended questions"))
+    }
+
     func testMainWindowHasSettingsDestinationAndNoInlineConfigurationFields() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -1336,10 +1336,61 @@ final class MeetingAgentViewModelTests: XCTestCase {
         await viewModel.refreshMeetingProgress()
 
         XCTAssertEqual(viewModel.meetingProgressState?.status, .onTrack)
-        XCTAssertEqual(viewModel.meetingProgressState?.suggestedQuestions.first?.english, "Have we confirmed the deadline?")
+        XCTAssertEqual(viewModel.meetingProgressState?.suggestedQuestions, [])
         let progressURL = try XCTUnwrap(record.meetingProgressJSONURL)
         let saved = try JSONDecoder.meetingAgent.decode(MeetingProgressState.self, from: Data(contentsOf: progressURL))
         XCTAssertEqual(saved.lastAnalyzedSegmentID, "segment-1")
+    }
+
+    func testRefreshMeetingProgressPublishesRecommendedQuestions() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .local,
+                localeIdentifier: "en-US",
+                targetLocaleIdentifier: "zh-CN",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil
+            ),
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        let record = try XCTUnwrap(viewModel.meetings.first)
+        try viewModel.saveAgenda(
+            for: record.id,
+            update: MeetingAgendaUpdate(
+                name: record.name,
+                attendees: [],
+                agendaTopics: [
+                    MeetingAgendaTopic(title: "Budget risk"),
+                    MeetingAgendaTopic(title: "Launch readiness")
+                ],
+                scheduledStartAt: record.scheduledStartAt,
+                scheduledEndAt: record.scheduledEndAt,
+                meetingGoal: MeetingGoal(
+                    title: "Confirm launch plan",
+                    objectives: [],
+                    requiredQuestions: [],
+                    expectedDecisions: [],
+                    keyTerms: []
+                )
+            )
+        )
+        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
+        try transcriptWriter.replace(with: [
+            TranscriptSegment(id: "segment-1", text: "We discussed hiring.", language: "en-US", isFinal: true)
+        ])
+        viewModel.drainRecordingFrames()
+
+        await viewModel.refreshMeetingProgress()
+
+        XCTAssertEqual(viewModel.recommendedQuestions.map(\.english), [
+            "Could we clarify Budget risk?",
+            "Could we clarify Launch readiness?"
+        ])
     }
 
     func testPreMeetingGoalAnalyzesAfterRecordingStarts() async throws {

--- a/Tests/MeetingAgentCoreTests/MeetingProgressCoordinatorTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingProgressCoordinatorTests.swift
@@ -73,6 +73,7 @@ final class MeetingProgressCoordinatorTests: XCTestCase {
 
 private final class SpyProgressAnalyzer: MeetingProgressAnalyzing {
     struct Call {
+        let agendaTopics: [MeetingAgendaTopic]
         let recentCaptions: [LiveCaptionTurn]
     }
 
@@ -81,10 +82,11 @@ private final class SpyProgressAnalyzer: MeetingProgressAnalyzing {
 
     func analyze(
         goal: MeetingGoal,
+        agendaTopics: [MeetingAgendaTopic],
         recentCaptions: [LiveCaptionTurn],
         previousState: MeetingProgressState?
     ) async throws -> MeetingProgressState {
-        calls.append(Call(recentCaptions: recentCaptions))
+        calls.append(Call(agendaTopics: agendaTopics, recentCaptions: recentCaptions))
         if let error {
             throw error
         }

--- a/Tests/MeetingAgentCoreTests/MeetingProgressCoordinatorTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingProgressCoordinatorTests.swift
@@ -56,6 +56,26 @@ final class MeetingProgressCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.analysisHealth, .failed("test error 1"))
     }
 
+    func testPassesAgendaTopicsToAgendaAwareAnalyzer() async {
+        let progressURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-progress-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: progressURL) }
+        let analyzer = AgendaAwareSpyProgressAnalyzer()
+        let topics = [MeetingAgendaTopic(title: "Budget risk")]
+        let coordinator = MeetingProgressCoordinator(
+            goal: sampleGoal(),
+            agendaTopics: topics,
+            analyzer: analyzer,
+            progressURL: progressURL,
+            minimumAnalysisInterval: 0,
+            now: { Date(timeIntervalSince1970: 100) }
+        )
+
+        await coordinator.process(turns: [LiveCaptionTurn(sourceSegmentID: "final", originalText: "launch owner confirmed", isFinal: true)])
+
+        XCTAssertEqual(analyzer.agendaTopics, topics)
+    }
+
     private func sampleGoal() -> MeetingGoal {
         MeetingGoal(
             id: UUID(uuidString: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")!,
@@ -73,7 +93,6 @@ final class MeetingProgressCoordinatorTests: XCTestCase {
 
 private final class SpyProgressAnalyzer: MeetingProgressAnalyzing {
     struct Call {
-        let agendaTopics: [MeetingAgendaTopic]
         let recentCaptions: [LiveCaptionTurn]
     }
 
@@ -82,11 +101,10 @@ private final class SpyProgressAnalyzer: MeetingProgressAnalyzing {
 
     func analyze(
         goal: MeetingGoal,
-        agendaTopics: [MeetingAgendaTopic],
         recentCaptions: [LiveCaptionTurn],
         previousState: MeetingProgressState?
     ) async throws -> MeetingProgressState {
-        calls.append(Call(agendaTopics: agendaTopics, recentCaptions: recentCaptions))
+        calls.append(Call(recentCaptions: recentCaptions))
         if let error {
             throw error
         }
@@ -98,6 +116,39 @@ private final class SpyProgressAnalyzer: MeetingProgressAnalyzing {
                 MeetingObjectiveProgress(objectiveID: $0.id, title: $0.title, status: .confirmed, evidenceSegmentIDs: recentCaptions.map(\.sourceSegmentID))
             },
             confirmedItems: ["launch owner confirmed"],
+            unresolvedItems: [],
+            suggestedQuestions: [],
+            health: MeetingProgressHealth(caption: .live, translation: .pending, analysis: .live),
+            lastAnalyzedSegmentID: recentCaptions.last?.sourceSegmentID,
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+    }
+}
+
+private final class AgendaAwareSpyProgressAnalyzer: AgendaAwareMeetingProgressAnalyzing {
+    var agendaTopics: [MeetingAgendaTopic] = []
+
+    func analyze(
+        goal: MeetingGoal,
+        recentCaptions: [LiveCaptionTurn],
+        previousState: MeetingProgressState?
+    ) async throws -> MeetingProgressState {
+        try await analyze(goal: goal, agendaTopics: [], recentCaptions: recentCaptions, previousState: previousState)
+    }
+
+    func analyze(
+        goal: MeetingGoal,
+        agendaTopics: [MeetingAgendaTopic],
+        recentCaptions: [LiveCaptionTurn],
+        previousState: MeetingProgressState?
+    ) async throws -> MeetingProgressState {
+        self.agendaTopics = agendaTopics
+        return MeetingProgressState(
+            meetingID: UUID(uuidString: "cccccccc-cccc-cccc-cccc-cccccccccccc")!,
+            goal: goal,
+            status: .onTrack,
+            objectives: [],
+            confirmedItems: [],
             unresolvedItems: [],
             suggestedQuestions: [],
             health: MeetingProgressHealth(caption: .live, translation: .pending, analysis: .live),

--- a/docs/superpowers/plans/2026-04-29-recommended-questions.md
+++ b/docs/superpowers/plans/2026-04-29-recommended-questions.md
@@ -1,0 +1,109 @@
+# Recommended Questions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a context-driven recommended questions module that shows at most two accurate manager questions during a meeting.
+
+**Architecture:** Reuse `MeetingProgressState.suggestedQuestions` as the data path. Generate suggestions deterministically in `DeterministicMeetingProgressAnalyzer`, expose them through `MeetingAgentViewModel`, and conditionally render them in `MainWindowView`.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest, Swift Package Manager.
+
+---
+
+### Task 1: Analyzer Recommendations
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Test: `Tests/MeetingAgentCoreTests/DeterministicMeetingProgressAnalyzerTests.swift`
+
+- [ ] **Step 1: Write failing analyzer tests**
+
+Add tests that prove recommendations are generated from unresolved objectives without `requiredQuestions`, capped at two, and empty when no objective/topic context exists.
+
+- [ ] **Step 2: Run focused analyzer tests**
+
+Run: `swift test --filter DeterministicMeetingProgressAnalyzerTests`
+
+Expected: new tests fail before implementation.
+
+- [ ] **Step 3: Implement deterministic question generation**
+
+Replace the current `requiredQuestions.prefix(3)` logic with a helper that chooses unresolved objectives, then uncovered agenda topics, and emits at most two `FollowUpQuestionSuggestion` values.
+
+- [ ] **Step 4: Re-run analyzer tests**
+
+Run: `swift test --filter DeterministicMeetingProgressAnalyzerTests`
+
+Expected: PASS.
+
+### Task 2: View Model Surface
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Write failing view-model test**
+
+Add a test that refreshes meeting progress and asserts `viewModel.recommendedQuestions` contains the generated recommendation.
+
+- [ ] **Step 2: Add published derived property**
+
+Expose `recommendedQuestions` as a public computed property returning `meetingProgressState?.suggestedQuestions.prefix(2)` or `[]`.
+
+- [ ] **Step 3: Run focused view-model test**
+
+Run: `swift test --filter MeetingAgentViewModelTests/testRefreshMeetingProgressPublishesRecommendedQuestions`
+
+Expected: PASS.
+
+### Task 3: Insights UI
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Add layout guard**
+
+Assert that `MainWindowView.swift` wires `recommendedQuestions`, defines `RecommendedQuestionsPanel`, includes the `Recommended Questions` heading, and does not include a placeholder empty-state for that panel.
+
+- [ ] **Step 2: Render panel only when non-empty**
+
+Pass `viewModel.recommendedQuestions` into `MeetingDetailView`, `MeetingCommandCenterView`, and `InsightPaneView`. Render `RecommendedQuestionsPanel` before summary/export panels only when the array is non-empty.
+
+- [ ] **Step 3: Run layout test**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testInsightsPaneShowsRecommendedQuestionsOnlyWhenAvailable`
+
+Expected: PASS.
+
+### Task 4: Full Verification and Commit
+
+**Files:**
+- All changed implementation, tests, spec, and plan files.
+
+- [ ] **Step 1: Build**
+
+Run: `swift build --product MeetingAgentApp`
+
+Expected: PASS.
+
+- [ ] **Step 2: Unit coverage entrypoint**
+
+Run: `make test`
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit implementation**
+
+Commit all issue-related files with:
+
+```bash
+git add Sources/MeetingAgentCore/LiveMeetingCockpit.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/DeterministicMeetingProgressAnalyzerTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/plans/2026-04-29-recommended-questions.md
+git commit -m "feat: add recommended questions module (#76)"
+```
+
+## Self-Review
+
+- Spec coverage: the plan covers deterministic generation, at-most-two behavior, hidden empty UI, and tests.
+- Placeholder scan: no TBD/TODO placeholders remain.
+- Type consistency: all steps use existing `FollowUpQuestionSuggestion`, `MeetingProgressState`, and `MeetingAgentViewModel` names.

--- a/docs/superpowers/specs/2026-04-29-recommended-questions-design.md
+++ b/docs/superpowers/specs/2026-04-29-recommended-questions-design.md
@@ -1,0 +1,57 @@
+# Recommended Questions Design
+
+## Context
+
+Issue #76 asks for a recommended questions module based on the meeting topic and goal progress. The module should show at most two questions, and should not appear when the app cannot produce accurate recommendations.
+
+The existing `MeetingGoal.requiredQuestions` field is not exposed in the agenda UI, so this feature must not depend on preconfigured required questions.
+
+## Goals
+
+- Generate recommended manager questions from the meeting goal, agenda topics, unresolved objective progress, and current transcript context.
+- Show at most two recommended questions.
+- Hide the module when there is not enough meeting context for accurate recommendations.
+- Keep the implementation deterministic for this iteration; do not add an extra LLM call.
+
+## Non-Goals
+
+- Add UI for editing `requiredQuestions`.
+- Add a new hosted recommendation provider.
+- Persist a separate recommendation artifact beyond the existing meeting progress JSON.
+
+## Approach
+
+`DeterministicMeetingProgressAnalyzer` will continue writing `MeetingProgressState.suggestedQuestions`, but the source of those suggestions will change from `requiredQuestions` to context-driven recommendations.
+
+The analyzer will:
+
+- Prefer unresolved meeting objectives when objectives exist.
+- Fall back to agenda topics when objectives are unavailable.
+- Avoid recommending a question when the objective or topic already appears covered by the transcript text.
+- Return at most two recommendations.
+- Return no recommendations when there is no useful goal/objective/topic context.
+
+`MeetingAgentViewModel` will expose a derived `recommendedQuestions` array from the current `meetingProgressState`.
+
+`MainWindowView` will pass those questions into the right-side insights pane and render a `Recommended Questions` panel only when the array is non-empty.
+
+## UI Behavior
+
+The insights pane will show `Recommended Questions` above the summary/export controls. Each item shows the localized Chinese prompt when available and the English/source prompt as supporting text. If there are no suggested questions, the panel is not rendered.
+
+## Data Flow
+
+1. A meeting has a `MeetingGoal` and optional agenda topics.
+2. Live captions are drained into the view model.
+3. `refreshMeetingProgress()` runs the analyzer.
+4. The analyzer writes up to two context-driven `FollowUpQuestionSuggestion` values into `MeetingProgressState`.
+5. The view model publishes the current progress state.
+6. The insights pane conditionally renders the recommended questions panel.
+
+## Testing
+
+- Unit-test the analyzer returns at most two context-driven suggestions.
+- Unit-test suggestions do not require `requiredQuestions`.
+- Unit-test suggestions are hidden when there is no reliable objective/topic context.
+- Add a view-model test proving recommended questions publish from refreshed progress.
+- Add a layout guard proving the insights pane contains the recommended questions panel and does not render placeholder empty-state text.


### PR DESCRIPTION
## Summary

Fixes #76

- Adds context-driven recommended questions decoupled from hidden requiredQuestions configuration.
- Shows up to two recommended questions in the Insights pane only when suggestions exist.
- Keeps the existing progress analyzer protocol compatible while adding agenda-aware analysis support.

## Changes

- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift` - generates recommendations from unresolved objectives and agenda topics.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - exposes capped recommended questions to the app.
- `Sources/MeetingAgentApp/MainWindowView.swift` - renders the conditional Recommended Questions panel.
- `Tests/MeetingAgentCoreTests/*` - covers analyzer, coordinator, view-model, and layout behavior.
- `docs/superpowers/*` - records the design and implementation plan.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `make test` passed, 505 tests, coverage gate passed
- [x] E2E/integration: skipped; no E2E convention for this SwiftUI panel behavior
- [x] Code review: PASS_WITH_FIXES; public protocol compatibility fixed in `7827e46`
- [x] Manual verification: source/layout reviewed for conditional panel rendering
