### PR TITLE
feat: hide caption edit control

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -182,15 +182,6 @@ struct MainWindowView: View {
                                 NSSound.beep()
                             }
                         }
-                    },
-                    updateTranscriptSegmentText: { meeting, segmentID, text in
-                        Task {
-                            do {
-                                try await viewModel.updateTranscriptSegmentText(for: meeting.id, segmentID: segmentID, text: text)
-                            } catch {
-                                NSSound.beep()
-                            }
-                        }
                     }
                 )
             }
@@ -310,7 +301,6 @@ private struct MeetingDetailView: View {
     let exportVTT: (MeetingRecord) -> Void
     let retryTranscription: (MeetingRecord) -> Void
     let updateSpeakerLabel: (MeetingRecord, String, String) -> Void
-    let updateTranscriptSegmentText: (MeetingRecord, String, String) -> Void
 
     var body: some View {
         ZStack {
@@ -341,9 +331,6 @@ private struct MeetingDetailView: View {
                     retryTranscription: { retryTranscription(meeting) },
                     updateSpeakerLabel: { speakerID, label in
                         updateSpeakerLabel(meeting, speakerID, label)
-                    },
-                    updateTranscriptSegmentText: { segmentID, text in
-                        updateTranscriptSegmentText(meeting, segmentID, text)
                     }
                 )
             } else {
@@ -494,7 +481,6 @@ private struct MeetingCommandCenterView: View {
     let exportVTT: () -> Void
     let retryTranscription: () -> Void
     let updateSpeakerLabel: (String, String) -> Void
-    let updateTranscriptSegmentText: (String, String) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -522,8 +508,7 @@ private struct MeetingCommandCenterView: View {
                     transcriptionStatusText: transcriptionStatusText,
                     stopRecording: stopRecording,
                     retryTranscription: retryTranscription,
-                    updateSpeakerLabel: updateSpeakerLabel,
-                    updateTranscriptSegmentText: updateTranscriptSegmentText
+                    updateSpeakerLabel: updateSpeakerLabel
                 )
                 .frame(minWidth: 520)
 
@@ -602,11 +587,8 @@ private struct TranscriptPaneView: View {
     let stopRecording: () -> Void
     let retryTranscription: () -> Void
     let updateSpeakerLabel: (String, String) -> Void
-    let updateTranscriptSegmentText: (String, String) -> Void
     @State private var speakerEditTarget: LiveCaptionTurn?
     @State private var speakerLabelDraft = ""
-    @State private var transcriptEditTarget: LiveCaptionTurn?
-    @State private var transcriptTextDraft = ""
     @State private var autoFollowsLatest = true
 
     var body: some View {
@@ -634,10 +616,6 @@ private struct TranscriptPaneView: View {
                             editSpeaker: { turn in
                                 speakerLabelDraft = turn.speaker.label ?? turn.speaker.identifier ?? ""
                                 speakerEditTarget = turn
-                            },
-                            editText: { turn in
-                                transcriptTextDraft = turn.originalText
-                                transcriptEditTarget = turn
                             }
                         )
                     }
@@ -665,18 +643,6 @@ private struct TranscriptPaneView: View {
                     speakerEditTarget = nil
                 },
                 cancel: { speakerEditTarget = nil }
-            )
-        }
-        .sheet(item: $transcriptEditTarget) { turn in
-            CaptionEditSheet(
-                title: "Correct Caption",
-                text: $transcriptTextDraft,
-                saveTitle: "Save Caption",
-                save: {
-                    updateTranscriptSegmentText(turn.id, transcriptTextDraft)
-                    transcriptEditTarget = nil
-                },
-                cancel: { transcriptEditTarget = nil }
             )
         }
     }
@@ -1034,7 +1000,6 @@ private struct UnifiedTranscriptView: View {
     let returnToLatest: () -> Void
     let pauseFollowing: () -> Void
     let editSpeaker: (LiveCaptionTurn) -> Void
-    let editText: (LiveCaptionTurn) -> Void
 
     var body: some View {
         CommandCenterPanel {
@@ -1064,8 +1029,7 @@ private struct UnifiedTranscriptView: View {
                                     if let firstTurn = group.turns.first {
                                         editSpeaker(firstTurn)
                                     }
-                                },
-                                editText: editText
+                                }
                             )
                             .id(group.id)
                         }
@@ -1105,7 +1069,6 @@ private struct BilingualTranscriptGroup: View {
     let sourceLocale: String
     let targetLocale: String
     var editSpeaker: (() -> Void)? = nil
-    var editText: (LiveCaptionTurn) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -1113,10 +1076,7 @@ private struct BilingualTranscriptGroup: View {
             ForEach(group.turns) { turn in
                 BilingualTranscriptBlock(
                     turn: turn,
-                    secondLanguageEnabled: secondLanguageEnabled(for: turn),
-                    editText: {
-                        editText(turn)
-                    }
+                    secondLanguageEnabled: secondLanguageEnabled(for: turn)
                 )
                 .id(turn.id)
             }
@@ -1179,22 +1139,10 @@ private struct BilingualTranscriptGroup: View {
 private struct BilingualTranscriptBlock: View {
     let turn: LiveCaptionTurn
     let secondLanguageEnabled: Bool
-    var editText: (() -> Void)? = nil
 
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
-            transcriptText
-                .frame(maxWidth: .infinity, alignment: .leading)
-            if let editText {
-                Button {
-                    editText()
-                } label: {
-                    Image(systemName: "pencil")
-                }
-                .buttonStyle(CommandCenterIconButtonStyle())
-                .help("Correct caption")
-            }
-        }
+        transcriptText
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -269,7 +269,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("translation unavailable"))
         XCTAssertTrue(source.contains("Translating"))
         XCTAssertTrue(source.contains("Button(\"Edit name\")"))
-        XCTAssertTrue(source.contains("Image(systemName: \"pencil\")"))
+        XCTAssertFalse(source.contains("Image(systemName: \"pencil\")"))
     }
 
     func testUnifiedTranscriptRendersSpeakerGroupsInsteadOfOneLabelPerBlock() throws {
@@ -324,10 +324,10 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains(".id(group.turns.last?.id ?? group.id)"))
     }
 
-    func testBilingualTranscriptBlockDoesNotReserveBlankHeaderRowForCorrectionButton() throws {
+    func testBilingualTranscriptBlockDoesNotReserveBlankEditControlSpace() throws {
         let source = try String(contentsOfFile: "Sources/MeetingAgentApp/MainWindowView.swift")
 
-        XCTAssertTrue(source.contains("HStack(alignment: .top, spacing: 8)"))
+        XCTAssertTrue(source.contains("transcriptText\n            .frame(maxWidth: .infinity, alignment: .leading)"))
         XCTAssertFalse(source.contains("""
             HStack(spacing: 8) {
                 Spacer()
@@ -349,22 +349,23 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("Readiness Report"))
     }
 
-    func testLiveCaptionsExposeCorrectionControls() throws {
+    func testLiveCaptionsHideCaptionCorrectionWhileKeepingSpeakerEdit() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
         XCTAssertTrue(source.contains("updateSpeakerLabel"))
-        XCTAssertTrue(source.contains("updateTranscriptSegmentText"))
         XCTAssertTrue(source.contains("CaptionEditSheet"))
         XCTAssertTrue(source.contains("Menu {"))
         XCTAssertTrue(source.contains("Button(\"Edit name\")"))
         XCTAssertTrue(source.contains("Image(systemName: \"chevron.down\")"))
-        XCTAssertFalse(source.contains("person.crop.circle.badge.pencil"))
-        XCTAssertTrue(source.contains("Image(systemName: \"pencil\")"))
-        XCTAssertTrue(source.contains("Correct Caption"))
         XCTAssertTrue(source.contains("Save Speaker"))
-        XCTAssertTrue(source.contains("Save Caption"))
+
+        XCTAssertFalse(source.contains("updateTranscriptSegmentText"))
+        XCTAssertFalse(source.contains("Correct Caption"))
+        XCTAssertFalse(source.contains("Save Caption"))
+        XCTAssertFalse(source.contains("Image(systemName: \"pencil\")"))
+        XCTAssertFalse(source.contains("person.crop.circle.badge.pencil"))
     }
 
     func testUnifiedTranscriptRendersSpeakerGroupStartTimeBesideSpeakerName() throws {

--- a/docs/superpowers/plans/2026-04-29-hide-caption-edit.md
+++ b/docs/superpowers/plans/2026-04-29-hide-caption-edit.md
@@ -1,0 +1,149 @@
+# Hide Caption Edit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hide the per-caption pencil correction UI while preserving speaker-name editing.
+
+**Architecture:** This is a view-layer change in `MainWindowView.swift`. Remove the caption edit closure path from the transcript view hierarchy and update source-layout tests to guard against reintroducing the caption correction UI.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout tests, Swift Package Manager.
+
+---
+
+### Task 1: Update Layout Regression Tests
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Replace the correction-control test with a hidden-caption-edit regression**
+
+Change `testLiveCaptionsExposeCorrectionControls` to assert speaker editing remains and caption correction UI is absent:
+
+```swift
+func testLiveCaptionsHideCaptionCorrectionWhileKeepingSpeakerEdit() throws {
+    let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+    let source = try String(contentsOf: sourceURL)
+
+    XCTAssertTrue(source.contains("updateSpeakerLabel"))
+    XCTAssertTrue(source.contains("CaptionEditSheet"))
+    XCTAssertTrue(source.contains("Menu {"))
+    XCTAssertTrue(source.contains("Button(\"Edit name\")"))
+    XCTAssertTrue(source.contains("Image(systemName: \"chevron.down\")"))
+    XCTAssertTrue(source.contains("Save Speaker"))
+
+    XCTAssertFalse(source.contains("updateTranscriptSegmentText"))
+    XCTAssertFalse(source.contains("Correct Caption"))
+    XCTAssertFalse(source.contains("Save Caption"))
+    XCTAssertFalse(source.contains("Image(systemName: \"pencil\")"))
+    XCTAssertFalse(source.contains("person.crop.circle.badge.pencil"))
+}
+```
+
+- [ ] **Step 2: Tighten the quiet-control test**
+
+In `testUnifiedTranscriptPreservesFallbackAndQuietCorrectionControls`, remove the assertion that expects `Image(systemName: "pencil")` and replace it with an assertion that it is absent:
+
+```swift
+XCTAssertFalse(source.contains("Image(systemName: \"pencil\")"))
+```
+
+- [ ] **Step 3: Run the focused test and confirm it fails before implementation**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testLiveCaptionsHideCaptionCorrectionWhileKeepingSpeakerEdit`
+
+Expected: FAIL because `MainWindowView.swift` still contains caption correction wiring and the pencil image.
+
+### Task 2: Remove Caption Correction UI Wiring
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Remove transcript edit state and sheet wiring**
+
+In `TranscriptPaneView`, remove:
+
+```swift
+@State private var transcriptEditTarget: LiveCaptionTurn?
+@State private var transcriptTextDraft = ""
+```
+
+Remove the `editText` argument passed to `UnifiedTranscriptView`:
+
+```swift
+editText: { turn in
+    transcriptTextDraft = turn.originalText
+    transcriptEditTarget = turn
+}
+```
+
+Remove the `transcriptEditTarget` sheet:
+
+```swift
+.sheet(item: $transcriptEditTarget) { turn in
+    CaptionEditSheet(
+        title: "Correct Caption",
+        text: $transcriptTextDraft,
+        saveTitle: "Save Caption",
+        save: {
+            updateTranscriptSegmentText(turn.id, transcriptTextDraft)
+            transcriptEditTarget = nil
+        },
+        cancel: { transcriptEditTarget = nil }
+    )
+}
+```
+
+- [ ] **Step 2: Remove the edit closure from transcript views**
+
+Remove `editText` from `UnifiedTranscriptView`, `BilingualTranscriptGroup`, and `BilingualTranscriptBlock`. `BilingualTranscriptBlock` should render only `transcriptText`:
+
+```swift
+var body: some View {
+    transcriptText
+        .frame(maxWidth: .infinity, alignment: .leading)
+}
+```
+
+Keep `editSpeaker` and the `Button("Edit name")` menu unchanged.
+
+- [ ] **Step 3: Run focused layout tests**
+
+Run: `swift test --filter MainWindowViewLayoutTests`
+
+Expected: PASS.
+
+### Task 3: Full Verification and Commit
+
+**Files:**
+- Verify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Verify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Run build and tests**
+
+Run:
+
+```bash
+swift build --product MeetingAgentApp
+make test
+```
+
+Expected: both PASS.
+
+- [ ] **Step 2: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/specs/2026-04-29-hide-caption-edit-design.md docs/superpowers/plans/2026-04-29-hide-caption-edit.md
+git commit -m "feat: hide caption edit control (#80)"
+```
+
+Expected: one commit containing the UI change, regression tests, spec, and plan.
+
+## Plan Self-Review
+
+- Spec coverage: the plan removes only per-caption editing and preserves speaker editing.
+- Placeholder scan: no TBD, TODO, or deferred steps remain.
+- Type consistency: all named views and tests match the current source layout.
+

--- a/docs/superpowers/specs/2026-04-29-hide-caption-edit-design.md
+++ b/docs/superpowers/specs/2026-04-29-hide-caption-edit-design.md
@@ -1,0 +1,41 @@
+# Hide Caption Edit Design
+
+Issue #80 asks to hide the subtitle edit feature in the UI. The clarified scope is narrow: remove only the per-caption pencil edit affordance for correcting caption text, while preserving speaker-name editing.
+
+## Goal
+
+Managers should no longer see a caption-level pencil button or caption correction sheet from the live transcript. Speaker-name editing remains available through the existing speaker label menu.
+
+## Non-Goals
+
+- Do not remove speaker-name editing.
+- Do not remove transcript text selection, translation display, fallback transcript rendering, or export behavior.
+- Do not change lower-level transcript correction APIs unless they are no longer referenced by the UI change.
+- Do not add a setting or feature flag for caption editing.
+
+## Selected Approach
+
+Remove the caption edit closure from the unified transcript view hierarchy and stop rendering the pencil button in `BilingualTranscriptBlock`. This hides the feature at the UI surface and avoids dead sheet state in `TranscriptPaneView`.
+
+Alternatives considered:
+
+- Hide the pencil with styling or conditional visibility. This leaves correction wiring in place and is easier to regress accidentally.
+- Add a user setting for edit visibility. This is unnecessary for the issue and expands product surface area.
+
+## Affected Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+  - Remove caption edit state and sheet wiring from the transcript pane.
+  - Remove the optional `editText` path from `UnifiedTranscriptView`, `BilingualTranscriptGroup`, and `BilingualTranscriptBlock`.
+  - Keep speaker edit menu and `CaptionEditSheet` for speaker labels.
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+  - Update layout assertions so caption correction UI is absent.
+  - Keep assertions that speaker editing remains available.
+
+## Test Plan
+
+- Add or update a layout regression test that asserts `Correct Caption`, `Save Caption`, and the caption pencil button are absent.
+- Preserve assertions for `Button("Edit name")`, `Image(systemName: "chevron.down")`, `Save Speaker`, and `updateSpeakerLabel`.
+- Run `swift test --filter MainWindowViewLayoutTests`.
+- Run `make test` before final handoff.
+


### PR DESCRIPTION
## Summary

Fixes #80

- Hide the per-caption pencil correction UI from the transcript surface.
- Preserve speaker-name editing through the existing speaker label menu.
- Add regression coverage that caption correction controls are absent while speaker editing remains.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - removes caption edit closure wiring, transcript edit state, and the pencil button from transcript blocks.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - updates layout guards for hidden caption editing and preserved speaker editing.
- `docs/superpowers/specs/2026-04-29-hide-caption-edit-design.md` - records the scoped design.
- `docs/superpowers/plans/2026-04-29-hide-caption-edit.md` - records the implementation plan.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests` passed; `make test` passed with coverage gate
- [x] E2E/integration: skipped, source-layout UI affordance change with no E2E convention required
- [x] Code review: PASS manual Swift review
- [x] Manual verification: source search confirms caption correction strings are absent from app source and speaker edit remains