### PR TITLE
feat: persist caption translations

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -445,3 +445,19 @@ Transcript latency can compare event wall time against meeting start plus audio 
 Before summarizing performance events, inspect each event family for its actual timestamp fields and correlation keys instead of applying one latency formula globally.
 
 ---
+
+## [81] Do not let draft caches satisfy final translation state
+
+**Date**: 2026-04-29
+**Category**: logic-error
+
+### What went wrong
+The first persisted caption translation hydration treated any cached translation as complete for a reopened hard-final caption, so a draft cache could have blocked the required final translation request.
+
+### Correct approach
+Hydrate draft cached translations only for draft or soft-boundary caption state. Hard-final caption turns require a cache explicitly marked as final; otherwise they must remain eligible for final translation.
+
+### How to avoid
+When caching derived pipeline output, persist and check the lifecycle state that determines whether downstream work is truly complete.
+
+---

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -957,6 +957,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             )
             for update in liveCaptionChunker.append(segment) {
                 liveCaptionStore.upsert(update.turn)
+                hydrateCachedTranslation(from: segment, toTurnID: update.turn.id)
                 logCaptionTurnUpdate(update.turn)
             }
         }
@@ -995,6 +996,7 @@ public final class MeetingAgentViewModel: ObservableObject {
                 metadata: ["path": "interim"]
             )
             _ = liveCaptionStore.append(segment)
+            hydrateCachedTranslation(from: segment, toTurnID: segment.id)
         }
         liveCaptionTurns = liveCaptionStore.turns
         meetingProgressHealth.caption = liveCaptionTurns.isEmpty ? .idle : .live
@@ -1448,6 +1450,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             return
         }
         liveCaptionStore.attachTranslation(translatedText, toTurnID: request.turn.id)
+        persistCaptionTranslation(request, translatedText: translatedText, isFinal: false)
         request.performanceEventLogger?.log(
             "caption_translation_attached",
             segmentID: request.turn.id,
@@ -1478,6 +1481,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
         liveCaptionStore.attachTranslation(translatedText, toTurnID: request.turn.id)
         liveCaptionStore.markTranslationFinal(forTurnID: request.turn.id)
+        persistCaptionTranslation(request, translatedText: translatedText, isFinal: true)
         request.performanceEventLogger?.log(
             "caption_translation_attached",
             segmentID: request.turn.id,
@@ -1519,6 +1523,46 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     private func captionTranslationKey(for turn: LiveCaptionTurn) -> String {
         "\(turn.sourceSegmentIDs.joined(separator: ","))|\(turn.sourceLocale)|\(turn.targetLocale)|\(turn.originalText)"
+    }
+
+    private func hydrateCachedTranslation(from segment: TranscriptSegment, toTurnID turnID: String) {
+        guard let translatedText = segment.translatedText?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !translatedText.isEmpty,
+              let targetLocale = segment.translationTargetLocale?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let current = liveCaptionStore.turns.first(where: { $0.id == turnID }),
+              targetLocale == current.targetLocale
+        else {
+            return
+        }
+        if current.displayState == .sealed,
+           current.boundaryStrength == .hard,
+           segment.translationIsFinal != true {
+            return
+        }
+        liveCaptionStore.attachTranslation(translatedText, toTurnID: turnID)
+        guard let hydrated = liveCaptionStore.turns.first(where: { $0.id == turnID }) else { return }
+        draftTranslationKeysByTurnID[turnID] = draftCaptionTranslationKey(for: hydrated)
+        draftTranslationCharacterCountsByTurnID[turnID] = hydrated.originalText.count
+        if segment.translationIsFinal == true {
+            liveCaptionStore.markTranslationFinal(forTurnID: turnID)
+            finalTranslationKeysByTurnID[turnID] = finalCaptionTranslationKey(for: hydrated)
+        }
+    }
+
+    private func persistCaptionTranslation(
+        _ request: CaptionTranslationRequest,
+        translatedText: String,
+        isFinal: Bool
+    ) {
+        guard let meeting = selectedMeeting else { return }
+        try? TranscriptFileWriter.updateSegmentTranslation(
+            segmentID: request.turn.sourceSegmentID,
+            text: translatedText,
+            targetLocale: request.turn.targetLocale,
+            isFinal: isFinal,
+            textURL: meeting.transcriptURL,
+            structuredURL: meeting.transcriptJSONURL
+        )
     }
 
     private func attachRealtimeTranslationsToLiveCaptions() {

--- a/Sources/MeetingAgentCore/TranscriptFileWriter.swift
+++ b/Sources/MeetingAgentCore/TranscriptFileWriter.swift
@@ -38,7 +38,7 @@ public final class TranscriptFileWriter {
         guard !isClosed else { return }
         var document = try Self.readDocument(from: structuredURL)
         if let index = document.segments.firstIndex(where: { $0.id == segment.id }) {
-            document.segments[index] = segment
+            document.segments[index] = Self.segment(segment, preservingTranslationFrom: document.segments[index])
             document.segments.removeAll {
                 $0.id != segment.id && Self.shouldReplaceExistingSegment($0, with: segment)
             }
@@ -121,7 +121,10 @@ public final class TranscriptFileWriter {
                 speechFinal: segment.speechFinal,
                 confidence: segment.confidence,
                 createdAt: segment.createdAt,
-                timingSource: segment.timingSource
+                timingSource: segment.timingSource,
+                translatedText: segment.translatedText,
+                translationTargetLocale: segment.translationTargetLocale,
+                translationIsFinal: segment.translationIsFinal
             )
         }
         let updatedDocument = TranscriptDocument(version: document.version, segments: updatedSegments)
@@ -163,7 +166,61 @@ public final class TranscriptFileWriter {
                 speechFinal: segment.speechFinal,
                 confidence: segment.confidence,
                 createdAt: segment.createdAt,
-                timingSource: segment.timingSource
+                timingSource: segment.timingSource,
+                translatedText: nil,
+                translationTargetLocale: nil,
+                translationIsFinal: nil
+            )
+        }
+        guard didUpdateSegment else {
+            throw ProbeError.invalidArguments("Transcript segment not found")
+        }
+        let updatedDocument = TranscriptDocument(version: document.version, segments: updatedSegments)
+        let data = try JSONEncoder.meetingAgent.encode(updatedDocument)
+        try data.write(to: structuredURL, options: .atomic)
+        if let textURL {
+            try (TranscriptFormatter.render(updatedSegments) + "\n").write(to: textURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    public static func updateSegmentTranslation(
+        segmentID: String,
+        text: String,
+        targetLocale: String,
+        isFinal: Bool,
+        textURL: URL?,
+        structuredURL: URL?
+    ) throws {
+        guard let structuredURL else {
+            throw MeetingExportError.missingArtifact("structured transcript")
+        }
+        let normalizedSegmentID = segmentID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedTargetLocale = targetLocale.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedSegmentID.isEmpty, !normalizedText.isEmpty, !normalizedTargetLocale.isEmpty else {
+            throw ProbeError.invalidArguments("Segment ID, translated text, and target locale are required")
+        }
+        let document = try readDocument(from: structuredURL)
+        var didUpdateSegment = false
+        let updatedSegments = document.segments.map { segment in
+            guard segment.id == normalizedSegmentID else { return segment }
+            didUpdateSegment = true
+            return TranscriptSegment(
+                id: segment.id,
+                speaker: segment.speaker,
+                startTimeSeconds: segment.startTimeSeconds,
+                endTimeSeconds: segment.endTimeSeconds,
+                text: segment.text,
+                language: segment.language,
+                sourceProvider: segment.sourceProvider,
+                isFinal: segment.isFinal,
+                speechFinal: segment.speechFinal,
+                confidence: segment.confidence,
+                createdAt: segment.createdAt,
+                timingSource: segment.timingSource,
+                translatedText: normalizedText,
+                translationTargetLocale: normalizedTargetLocale,
+                translationIsFinal: isFinal
             )
         }
         guard didUpdateSegment else {
@@ -346,7 +403,10 @@ public final class TranscriptFileWriter {
                     speechFinal: current.speechFinal,
                     confidence: current.confidence,
                     createdAt: current.createdAt,
-                    timingSource: current.timingSource
+                    timingSource: current.timingSource,
+                    translatedText: current.translatedText,
+                    translationTargetLocale: current.translationTargetLocale,
+                    translationIsFinal: current.translationIsFinal
                 )
             }
             output.append(current)
@@ -469,8 +529,41 @@ public final class TranscriptFileWriter {
                 speechFinal: segment.speechFinal,
                 confidence: segment.confidence,
                 createdAt: segment.createdAt,
-                timingSource: segment.timingSource
+                timingSource: segment.timingSource,
+                translatedText: segment.translatedText,
+                translationTargetLocale: segment.translationTargetLocale,
+                translationIsFinal: segment.translationIsFinal
             )
         }
+    }
+
+    private static func segment(
+        _ incoming: TranscriptSegment,
+        preservingTranslationFrom existing: TranscriptSegment
+    ) -> TranscriptSegment {
+        guard incoming.text == existing.text,
+              incoming.translatedText == nil,
+              incoming.translationTargetLocale == nil,
+              incoming.translationIsFinal == nil
+        else {
+            return incoming
+        }
+        return TranscriptSegment(
+            id: incoming.id,
+            speaker: incoming.speaker,
+            startTimeSeconds: incoming.startTimeSeconds,
+            endTimeSeconds: incoming.endTimeSeconds,
+            text: incoming.text,
+            language: incoming.language,
+            sourceProvider: incoming.sourceProvider,
+            isFinal: incoming.isFinal,
+            speechFinal: incoming.speechFinal,
+            confidence: incoming.confidence,
+            createdAt: incoming.createdAt,
+            timingSource: incoming.timingSource,
+            translatedText: existing.translatedText,
+            translationTargetLocale: existing.translationTargetLocale,
+            translationIsFinal: existing.translationIsFinal
+        )
     }
 }

--- a/Sources/MeetingAgentCore/TranscriptSegment.swift
+++ b/Sources/MeetingAgentCore/TranscriptSegment.swift
@@ -34,6 +34,9 @@ public struct TranscriptSegment: Codable, Equatable, Identifiable {
     public let confidence: Double?
     public let createdAt: Date
     public let timingSource: TranscriptTimingSource
+    public let translatedText: String?
+    public let translationTargetLocale: String?
+    public let translationIsFinal: Bool?
 
     public var speaker: TranscriptSpeaker {
         TranscriptSpeaker(identifier: speakerID, label: speakerLabel)
@@ -51,7 +54,10 @@ public struct TranscriptSegment: Codable, Equatable, Identifiable {
         speechFinal: Bool = false,
         confidence: Double? = nil,
         createdAt: Date = Date(),
-        timingSource: TranscriptTimingSource = .unavailable
+        timingSource: TranscriptTimingSource = .unavailable,
+        translatedText: String? = nil,
+        translationTargetLocale: String? = nil,
+        translationIsFinal: Bool? = nil
     ) {
         self.id = id
         self.speakerID = speaker.identifier
@@ -66,6 +72,9 @@ public struct TranscriptSegment: Codable, Equatable, Identifiable {
         self.confidence = confidence
         self.createdAt = createdAt
         self.timingSource = timingSource
+        self.translatedText = translatedText
+        self.translationTargetLocale = translationTargetLocale
+        self.translationIsFinal = translationIsFinal
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -82,6 +91,9 @@ public struct TranscriptSegment: Codable, Equatable, Identifiable {
         case confidence
         case createdAt
         case timingSource
+        case translatedText
+        case translationTargetLocale
+        case translationIsFinal
     }
 
     public init(from decoder: Decoder) throws {
@@ -99,6 +111,9 @@ public struct TranscriptSegment: Codable, Equatable, Identifiable {
         confidence = try container.decodeIfPresent(Double.self, forKey: .confidence)
         createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
         timingSource = try container.decodeIfPresent(TranscriptTimingSource.self, forKey: .timingSource) ?? .unavailable
+        translatedText = try container.decodeIfPresent(String.self, forKey: .translatedText)
+        translationTargetLocale = try container.decodeIfPresent(String.self, forKey: .translationTargetLocale)
+        translationIsFinal = try container.decodeIfPresent(Bool.self, forKey: .translationIsFinal)
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -459,6 +459,94 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(provider.requests.count, 1)
     }
 
+    func testReopenedMeetingHydratesPersistedCaptionTranslationWithoutProviderRequest() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let record = try store.createMeeting(name: "Meet", startedAt: Date()).record
+        let writer = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL), structuredURL: XCTUnwrap(record.transcriptJSONURL))
+        try writer.replace(with: [
+            TranscriptSegment(
+                id: "segment-1",
+                speaker: TranscriptSpeaker(identifier: "speaker-1", label: "Alex"),
+                text: "Alex is the launch owner.",
+                language: "en-US",
+                isFinal: true,
+                speechFinal: true
+            )
+        ])
+        let firstProvider = ViewModelFakeTextTranslationProvider(translations: ["segment-1": "Alex 是上线负责人。"])
+        let firstViewModel = MeetingAgentViewModel(
+            store: store,
+            captionTranslationProviderFactory: { _ in firstProvider },
+            processTargetsProvider: { [] }
+        )
+        try firstViewModel.loadMeetings()
+        firstViewModel.selectMeeting(record.id)
+
+        firstViewModel.drainRecordingFrames()
+        try await waitFor { firstViewModel.liveCaptionTurns.first?.translatedText == "Alex 是上线负责人。" }
+
+        var document = try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL))
+        XCTAssertEqual(document.segments.first?.translatedText, "Alex 是上线负责人。")
+        XCTAssertEqual(document.segments.first?.translationTargetLocale, "zh-CN")
+        XCTAssertEqual(document.segments.first?.translationIsFinal, true)
+
+        let reopenProvider = ViewModelFakeTextTranslationProvider(translations: ["segment-1": "should not be requested"])
+        let reopenedViewModel = MeetingAgentViewModel(
+            store: store,
+            captionTranslationProviderFactory: { _ in reopenProvider },
+            processTargetsProvider: { [] }
+        )
+        try reopenedViewModel.loadMeetings()
+        reopenedViewModel.selectMeeting(record.id)
+        reopenedViewModel.drainRecordingFrames()
+        try await Task.sleep(nanoseconds: 20_000_000)
+
+        XCTAssertEqual(reopenedViewModel.liveCaptionTurns.first?.translatedText, "Alex 是上线负责人。")
+        XCTAssertEqual(reopenedViewModel.liveCaptionTurns.first?.translationHealth, .live)
+        XCTAssertEqual(reopenedViewModel.liveCaptionTurns.first?.translationState, .final)
+        XCTAssertTrue(reopenProvider.requests.isEmpty)
+
+        document = try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL))
+        XCTAssertEqual(document.segments.first?.translatedText, "Alex 是上线负责人。")
+    }
+
+    func testReopenedHardFinalCaptionDoesNotTreatDraftCacheAsComplete() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let record = try store.createMeeting(name: "Meet", startedAt: Date()).record
+        let writer = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL), structuredURL: XCTUnwrap(record.transcriptJSONURL))
+        try writer.replace(with: [
+            TranscriptSegment(
+                id: "segment-1",
+                speaker: TranscriptSpeaker(identifier: "speaker-1", label: "Alex"),
+                text: "Alex is the launch owner.",
+                language: "en-US",
+                isFinal: true,
+                speechFinal: true,
+                translatedText: "draft translation",
+                translationTargetLocale: "zh-CN",
+                translationIsFinal: false
+            )
+        ])
+        let provider = ViewModelFakeTextTranslationProvider(translations: ["segment-1": "最终翻译"])
+        let viewModel = MeetingAgentViewModel(
+            store: store,
+            captionTranslationProviderFactory: { _ in provider },
+            processTargetsProvider: { [] }
+        )
+        try viewModel.loadMeetings()
+        viewModel.selectMeeting(record.id)
+
+        viewModel.drainRecordingFrames()
+
+        try await waitFor { viewModel.liveCaptionTurns.first?.translatedText == "最终翻译" }
+        XCTAssertEqual(provider.requests.count, 1)
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationState, .final)
+    }
+
     func testCaptionTranslationPerformanceEventsShareRequestID() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift
@@ -22,6 +22,50 @@ final class TranscriptFileWriterTests: XCTestCase {
         let document = try JSONDecoder.meetingAgent.decode(TranscriptDocument.self, from: data)
 
         XCTAssertEqual(document.segments.first?.speechFinal, false)
+        XCTAssertNil(document.segments.first?.translatedText)
+        XCTAssertNil(document.segments.first?.translationTargetLocale)
+        XCTAssertNil(document.segments.first?.translationIsFinal)
+    }
+
+    func testUpdateSegmentTranslationPersistsCacheAndTextEditClearsIt() throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("probe-transcript-\(UUID().uuidString).txt")
+        let jsonURL = url.deletingPathExtension().appendingPathExtension("json")
+        defer {
+            try? FileManager.default.removeItem(at: url)
+            try? FileManager.default.removeItem(at: jsonURL)
+        }
+
+        let writer = try TranscriptFileWriter(url: url)
+        try writer.replace(with: [
+            TranscriptSegment(id: "segment-1", text: "Confirm the owner.", language: "en-US")
+        ])
+
+        try TranscriptFileWriter.updateSegmentTranslation(
+            segmentID: "segment-1",
+            text: "确认负责人。",
+            targetLocale: "zh-CN",
+            isFinal: true,
+            textURL: url,
+            structuredURL: jsonURL
+        )
+
+        var document = try TranscriptFileWriter.readDocument(from: jsonURL)
+        XCTAssertEqual(document.segments.first?.translatedText, "确认负责人。")
+        XCTAssertEqual(document.segments.first?.translationTargetLocale, "zh-CN")
+        XCTAssertEqual(document.segments.first?.translationIsFinal, true)
+
+        try TranscriptFileWriter.updateSegmentText(
+            segmentID: "segment-1",
+            text: "Confirm the launch owner.",
+            textURL: url,
+            structuredURL: jsonURL
+        )
+
+        document = try TranscriptFileWriter.readDocument(from: jsonURL)
+        XCTAssertEqual(document.segments.first?.text, "Confirm the launch owner.")
+        XCTAssertNil(document.segments.first?.translatedText)
+        XCTAssertNil(document.segments.first?.translationTargetLocale)
+        XCTAssertNil(document.segments.first?.translationIsFinal)
     }
 
     func testTranscriptWriterReplacesPartialTextWithLatestText() throws {

--- a/docs/superpowers/plans/2026-04-29-persist-caption-translations.md
+++ b/docs/superpowers/plans/2026-04-29-persist-caption-translations.md
@@ -1,0 +1,55 @@
+# Persist Caption Translations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist translated caption text into meeting artifacts so reopening a meeting does not translate the same caption again.
+
+**Architecture:** Store caption translation cache metadata on `TranscriptSegment`, update it through `TranscriptFileWriter`, and hydrate `LiveCaptionStore` from cached segment translations during transcript replay. Keep cache invalidation tied to source text edits and changed segment content.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, existing `MeetingAgentCore` transcript and view-model types.
+
+---
+
+### Task 1: Add Translation Cache Fields To Transcript Segments
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/TranscriptSegment.swift`
+- Test: `Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift`
+
+- [ ] Add optional `translatedText`, `translationTargetLocale`, and `translationIsFinal` properties to `TranscriptSegment`.
+- [ ] Update the initializer and decoder with nil defaults so legacy transcript JSON decodes.
+- [ ] Add a writer test that saves a translated segment, reads it back, and verifies all cache fields.
+
+### Task 2: Add Writer APIs And Cache Invalidation
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/TranscriptFileWriter.swift`
+- Test: `Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift`
+
+- [ ] Add `TranscriptFileWriter.updateSegmentTranslation(segmentID:text:targetLocale:isFinal:textURL:structuredURL:)`.
+- [ ] Preserve existing cache fields when assigning speaker labels.
+- [ ] Clear cache fields when `updateSegmentText` changes source text.
+- [ ] Preserve cache fields during `upsert` only when the incoming segment has the same id and source text.
+- [ ] Run `swift test --filter TranscriptFileWriterTests`.
+
+### Task 3: Persist And Hydrate View-Model Caption Translations
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] Persist successful draft and final caption translations to the selected meeting's structured transcript.
+- [ ] During transcript replay, attach cached segment translations to generated live caption turns when target locale matches the current caption target.
+- [ ] Mark hydrated final translations final and set the scheduler's draft/final keys so cached turns are treated as already translated.
+- [ ] Add a regression that translates once, opens the same meeting in a new view model, and verifies the provider is not called again.
+- [ ] Run `swift test --filter MeetingAgentViewModelTests`.
+
+### Task 4: Verify And Commit
+
+**Files:**
+- All files changed above.
+
+- [ ] Run `swift build --product MeetingAgentApp`.
+- [ ] Run `make test`.
+- [ ] Stage only issue-related files.
+- [ ] Commit with `feat: persist caption translations (#81)`.

--- a/docs/superpowers/specs/2026-04-29-persist-caption-translations-design.md
+++ b/docs/superpowers/specs/2026-04-29-persist-caption-translations-design.md
@@ -1,0 +1,40 @@
+# Persist Caption Translations Design
+
+## Context
+
+GitHub issue #81 reports that reopening a meeting triggers caption translation again. The app currently stores transcript source segments in `transcript.json`, but translated caption text lives only in `MeetingAgentViewModel`'s `LiveCaptionStore`. When a meeting is reopened, `refreshLiveCaptionTurnsFromSelectedMeeting()` rebuilds live captions from source segments and schedules translation for pending turns.
+
+## Success Criteria
+
+- A completed caption translation is written to the meeting's structured transcript artifact.
+- Reopening or reselecting a meeting hydrates live caption translated text from that artifact.
+- Cached translations prevent another provider request for the same source text and target locale.
+- Editing source transcript text clears stale cached translation for that segment.
+- Legacy transcript JSON without translation fields continues to decode.
+
+## Approach
+
+Add optional translation cache fields to `TranscriptSegment`: translated text, target locale, and translation finality. `TranscriptFileWriter` will expose a focused method for updating a segment's cached translation and will preserve cached translation only when a source segment is unchanged. Existing source text edits clear cached translation fields.
+
+`MeetingAgentViewModel` will persist successful draft and final caption translations back to the structured transcript segment represented by the translated live caption turn. During replay, caption updates built from cached translated segments will attach that text to the live turn, mark translation health live, and mark final translations final. Because hydrated turns are no longer pending, the scheduler will not call the provider again.
+
+## Alternatives Considered
+
+- A separate translation sidecar JSON file: rejected because it introduces another artifact to keep in sync with transcript edits and segment replacement.
+- Persisting only view-model `LiveCaptionTurn` snapshots: rejected because captions are derived display state and can change with chunking policy, while transcript segments are the stable source artifact.
+- Caching in process memory or settings: rejected because it does not survive app relaunch and is not scoped to a meeting.
+
+## Affected Files
+
+- `Sources/MeetingAgentCore/TranscriptSegment.swift`
+- `Sources/MeetingAgentCore/TranscriptFileWriter.swift`
+- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- `Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift`
+- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+## Test Plan
+
+- Add a transcript writer test proving translation cache fields persist and source text edits clear them.
+- Add a view-model regression proving a translation is written to `transcript.json`.
+- Add a reopen regression proving a new view model hydrates the cached translation and does not call the translation provider again.
+- Run focused Swift tests, then `make test`.


### PR DESCRIPTION
## Summary

Fixes #81

- Persists successful caption translations in the structured transcript artifact.
- Hydrates reopened meetings from cached translations so completed translations are not requested again.
- Clears stale translation cache when source transcript text changes and keeps draft caches from satisfying hard-final captions.

## Changes

- `Sources/MeetingAgentCore/TranscriptSegment.swift` - adds optional translation cache metadata to structured transcript segments.
- `Sources/MeetingAgentCore/TranscriptFileWriter.swift` - adds cache update/preservation/invalidation behavior.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - persists accepted caption translations and hydrates cached translations during replay.
- `Tests/MeetingAgentCoreTests/TranscriptFileWriterTests.swift` - covers persistence and source-edit invalidation.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - covers reopen hydration, no duplicate provider request, and draft-cache final-state handling.

## Test plan

- [x] Build: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter TranscriptFileWriterTests` passed
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests/testReopened` passed
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests` passed
- [x] Full verification: `make test` passed, 513 tests, coverage gate passed
- [x] Code review: PASS, manual Swift review because the available code-review skill is Java/TypeScript-specific
- [x] E2E/integration: skipped, no E2E convention for this artifact-level behavior