### PR TITLE
fix: sync agenda title after summary generation

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -461,3 +461,19 @@ Hydrate draft cached translations only for draft or soft-boundary caption state.
 When caching derived pipeline output, persist and check the lifecycle state that determines whether downstream work is truly complete.
 
 ---
+
+## [77] Update clean-state baselines after saving UI drafts
+
+**Date**: 2026-04-29
+**Category**: logic-error
+
+### What went wrong
+The first agenda title sync fix added a record-backed draft baseline for background refreshes, but did not update that baseline after a successful agenda save. That could leave a saved draft looking dirty and block later automatic title refreshes.
+
+### Correct approach
+When UI refresh logic compares a visible draft against a clean baseline, update the baseline both when loading from persisted state and after successful saves.
+
+### How to avoid
+For dirty-state guards, audit every path that transitions a draft from dirty back to clean, not only the initial load/reset path.
+
+---

--- a/Sources/MeetingAgentApp/TodayAgendaView.swift
+++ b/Sources/MeetingAgentApp/TodayAgendaView.swift
@@ -14,6 +14,7 @@ struct TodayAgendaView: View {
     let createMeeting: () throws -> Void
 
     @State private var draft = AgendaDraft()
+    @State private var recordBackedDraft = AgendaDraft()
     @State private var draftMeetingID: UUID?
     @State private var saveError: String?
     @State private var createError: String?
@@ -47,6 +48,9 @@ struct TodayAgendaView: View {
             guard draftMeetingID == selectedMeetingID else {
                 resetDraftFromSelection()
                 return
+            }
+            if draft == recordBackedDraft {
+                resetDraftFromSelection()
             }
         }
     }
@@ -172,11 +176,13 @@ struct TodayAgendaView: View {
     private func resetDraftFromSelection() {
         guard let selectedMeeting else {
             draft = AgendaDraft()
+            recordBackedDraft = draft
             draftMeetingID = nil
             saveError = nil
             return
         }
         draft = AgendaDraft(meeting: selectedMeeting)
+        recordBackedDraft = draft
         draftMeetingID = selectedMeeting.id
         saveError = nil
     }

--- a/Sources/MeetingAgentApp/TodayAgendaView.swift
+++ b/Sources/MeetingAgentApp/TodayAgendaView.swift
@@ -192,6 +192,7 @@ struct TodayAgendaView: View {
         do {
             try saveAgenda(meetingID, draft.update())
             saveError = nil
+            recordBackedDraft = draft
             draftMeetingID = meetingID
         } catch {
             saveError = "Could not save agenda: \(error)"

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -53,6 +53,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
 
         XCTAssertTrue(source.contains("@State private var recordBackedDraft = AgendaDraft()"))
         XCTAssertTrue(source.contains("draft == recordBackedDraft"))
+        XCTAssertTrue(source.contains("recordBackedDraft = draft"))
         XCTAssertTrue(source.contains("resetDraftFromSelection()"))
     }
 

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -48,6 +48,14 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("Save / Discard / Cancel"))
     }
 
+    func testTodayAgendaRefreshesCleanDraftWhenSelectedMeetingRecordChanges() throws {
+        let source = try appSource(named: "TodayAgendaView.swift")
+
+        XCTAssertTrue(source.contains("@State private var recordBackedDraft = AgendaDraft()"))
+        XCTAssertTrue(source.contains("draft == recordBackedDraft"))
+        XCTAssertTrue(source.contains("resetDraftFromSelection()"))
+    }
+
     func testLiveWorkspaceShowsAgendaContextStrip() throws {
         let source = try appSource(named: "MainWindowView.swift")
 

--- a/docs/superpowers/plans/2026-04-29-agenda-generated-title-sync.md
+++ b/docs/superpowers/plans/2026-04-29-agenda-generated-title-sync.md
@@ -1,0 +1,123 @@
+# Agenda Generated Title Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the Agenda editor title synchronized with summary-generated meeting titles without overwriting unsaved agenda edits.
+
+**Architecture:** `TodayAgendaView` will store both the visible `AgendaDraft` and the last record-backed baseline draft. The `meetings` change handler will refresh from the selected meeting only when the visible draft is still clean.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout regression tests, Swift Package Manager.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentApp/TodayAgendaView.swift`: add record-backed draft baseline state and clean-draft refresh logic.
+- Modify `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`: add a focused source regression for the agenda draft refresh guard.
+
+## Task 1: Add Agenda Draft Sync Guard
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/TodayAgendaView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write the failing source regression**
+
+Add this test to `MainWindowViewLayoutTests`:
+
+```swift
+func testTodayAgendaRefreshesCleanDraftWhenSelectedMeetingRecordChanges() throws {
+    let source = try appSource(named: "TodayAgendaView.swift")
+
+    XCTAssertTrue(source.contains("@State private var recordBackedDraft = AgendaDraft()"))
+    XCTAssertTrue(source.contains("draft == recordBackedDraft"))
+    XCTAssertTrue(source.contains("resetDraftFromSelection()"))
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testTodayAgendaRefreshesCleanDraftWhenSelectedMeetingRecordChanges
+```
+
+Expected: FAIL because `recordBackedDraft` does not exist yet.
+
+- [ ] **Step 3: Implement baseline draft tracking**
+
+In `TodayAgendaView`, add a baseline state next to the existing draft state:
+
+```swift
+@State private var draft = AgendaDraft()
+@State private var recordBackedDraft = AgendaDraft()
+@State private var draftMeetingID: UUID?
+```
+
+Update the `meetings` change handler:
+
+```swift
+.onChange(of: meetings) { _, _ in
+    guard draftMeetingID == selectedMeetingID else {
+        resetDraftFromSelection()
+        return
+    }
+    if draft == recordBackedDraft {
+        resetDraftFromSelection()
+    }
+}
+```
+
+Update `resetDraftFromSelection()` so empty and selected states maintain the baseline:
+
+```swift
+private func resetDraftFromSelection() {
+    guard let selectedMeeting else {
+        draft = AgendaDraft()
+        recordBackedDraft = draft
+        draftMeetingID = nil
+        saveError = nil
+        return
+    }
+    draft = AgendaDraft(meeting: selectedMeeting)
+    recordBackedDraft = draft
+    draftMeetingID = selectedMeeting.id
+    saveError = nil
+}
+```
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testTodayAgendaRefreshesCleanDraftWhenSelectedMeetingRecordChanges
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/TodayAgendaView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/specs/2026-04-29-agenda-generated-title-sync-design.md docs/superpowers/plans/2026-04-29-agenda-generated-title-sync.md
+git commit -m "fix: sync agenda title after summary generation (#77)"
+```
+
+## Self-Review
+
+- The plan covers the approved clean-draft refresh design.
+- There are no placeholders.
+- The test checks for the baseline state and clean-draft guard needed to prevent overwriting unsaved edits.

--- a/docs/superpowers/specs/2026-04-29-agenda-generated-title-sync-design.md
+++ b/docs/superpowers/specs/2026-04-29-agenda-generated-title-sync-design.md
@@ -1,0 +1,65 @@
+# Agenda Generated Title Sync Design
+
+## Context
+
+GitHub issue #77 reports that recent meetings now use the summary-generated title, while the agenda can still show a generic process title such as "Google Chrome". Issue #61 already persists successful generated titles to `MeetingRecord.name`; this issue is about keeping the agenda UI's local editor state in sync with that persisted title.
+
+## User Intent And Success Criteria
+
+Managers should see the same useful meeting title in both Recent meetings and the Agenda after summary generation. The agenda editor should refresh from the updated meeting record when the user is not actively editing, and it should not discard unsaved agenda edits.
+
+## Requirements
+
+- Refresh the agenda editor draft title when the selected meeting record changes from a generic name to the generated summary title.
+- Preserve unsaved user edits in the agenda editor when background meeting updates arrive.
+- Keep the existing summary title persistence behavior unchanged.
+- Keep the change local to agenda UI state unless verification shows a deeper model issue.
+
+## Non-Requirements
+
+- No new title-generation provider.
+- No new UI control for accepting or rejecting generated titles.
+- No overwrite of user-authored agenda titles.
+- No changes to summary JSON or markdown artifact formats.
+
+## Approaches Considered
+
+### Selected: Clean Draft Refresh
+
+Track the last record-backed agenda draft. When `TodayAgendaView` receives a `meetings` update for the same selected meeting, refresh the draft only if the current draft still equals the last record-backed draft. This updates stale generated titles while preserving in-progress edits.
+
+### Alternative: Always Refresh On Meeting Updates
+
+Always rebuilding the draft from the selected meeting is simple, but it can discard unsaved attendee, topic, date, or goal edits when transcription or summary metadata changes.
+
+### Alternative: Display-Only Title Helper
+
+The agenda row could display a derived title while the editor keeps its draft untouched. That would make part of the agenda look correct, but the editable title field could still show "Google Chrome".
+
+## Architecture
+
+`TodayAgendaView` already owns `AgendaDraft` and resets it when the selection changes. Add a second state value that stores the latest record-backed draft. `resetDraftFromSelection()` updates both the visible draft and this baseline.
+
+On `meetings` changes:
+
+- If the selected meeting changed, reset from selection as before.
+- If the selected meeting is unchanged and the visible draft equals the baseline, reset from the updated selected record.
+- If the visible draft differs from the baseline, keep the user's unsaved edits.
+
+## Data Flow
+
+1. Summary generation persists a generated title to `MeetingRecord.name`.
+2. The view model publishes the updated `meetings` array.
+3. `TodayAgendaView` observes the `meetings` change.
+4. If the selected agenda draft is clean, it rebuilds from the updated selected meeting and shows the generated title.
+5. If the draft is dirty, it keeps the user's in-progress edit.
+
+## Error Handling
+
+No new fallible operation is introduced. If no selected meeting exists, the agenda draft resets to an empty state. If a dirty draft exists, the background update is intentionally deferred until the user saves, cancels, or changes selection.
+
+## Testing
+
+- Add a focused layout/source regression test that verifies `TodayAgendaView` tracks a record-backed draft baseline and only refreshes clean drafts on `meetings` changes.
+- Run the focused test.
+- Run `make test` for full project verification.


### PR DESCRIPTION
## Summary

Fixes #77

- Refresh the selected agenda draft when the underlying meeting record receives a generated summary title.
- Preserve unsaved agenda edits by only auto-refreshing clean drafts.
- Record the design, implementation plan, and review lesson for this issue.

## Changes

- `Sources/MeetingAgentApp/TodayAgendaView.swift` - track the record-backed agenda draft baseline and refresh clean drafts on meeting updates.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - add a regression guard for clean-draft refresh behavior.
- `docs/superpowers/specs/2026-04-29-agenda-generated-title-sync-design.md` - document the approved design.
- `docs/superpowers/plans/2026-04-29-agenda-generated-title-sync.md` - document the implementation plan.
- `MISTAKES.md` - record the saved-draft baseline lesson from review.

## Test plan

- [x] Build/lint: `make test` passed; SwiftPM build completed as part of test run.
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testTodayAgendaRefreshesCleanDraftWhenSelectedMeetingRecordChanges` failed before implementation and passed after implementation.
- [x] Unit tests: `make test` passed with 511 tests and coverage gate passed.
- [x] E2E/integration: skipped; no E2E convention for this SwiftUI state-sync fix.
- [x] Code review: PASS after one manual review fix.
- [x] Manual verification: not applicable; covered by source-layout regression and unit suite.