### PR TITLE
fix: expand sidebar navigation hit area

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -278,6 +278,7 @@ private struct SidebarNavigationButtonStyle: ButtonStyle {
             .font(CommandCenterTypography.button)
             .foregroundStyle(isSelected ? CommandCenterPalette.primary : CommandCenterPalette.text)
             .frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)
+            .contentShape(Rectangle())
             .padding(.horizontal, 12)
             .background(isSelected ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -33,6 +33,21 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("Text(\"Meetings\")"))
     }
 
+    func testSidebarNavigationRowsDefineFullWidthHitArea() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        guard let styleRange = source.range(of: "private struct SidebarNavigationButtonStyle") else {
+            return XCTFail("Sidebar navigation button style is missing")
+        }
+        guard let nextViewRange = source.range(of: "private struct MeetingDetailView", range: styleRange.upperBound..<source.endIndex) else {
+            return XCTFail("Sidebar navigation button style boundary is missing")
+        }
+
+        let styleSource = source[styleRange.lowerBound..<nextViewRange.lowerBound]
+        XCTAssertTrue(styleSource.contains(".frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)"))
+        XCTAssertTrue(styleSource.contains(".contentShape(Rectangle())"))
+    }
+
     func testTodayAgendaViewDefinesAgendaRowsAndExplicitEditorSaveCancel() throws {
         let source = try appSource(named: "TodayAgendaView.swift")
 


### PR DESCRIPTION
## Summary

Fixes #90

- Make the Today and Recordings sidebar rows use a full-width hit-test shape.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - adds an explicit rectangular content shape to the sidebar navigation button style.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - adds a regression guard for full-width sidebar navigation hit areas.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed; no separate lint command is defined for this Swift package.
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testSidebarNavigationRowsDefineFullWidthHitArea` failed before the fix and passed after; `make test` passed with 468 XCTest tests and coverage gate.
- [x] E2E/integration: skipped; no E2E convention exists for this static SwiftUI hit-area change.
- [x] Code review: PASS
- [x] Manual verification: source-level review confirms the full-width visual row now has `.contentShape(Rectangle())`.