### PR TITLE
feat: align navigation around meetings

### DIFF
--- a/MISTAKES.md
+++ b/MISTAKES.md
@@ -493,3 +493,19 @@ When deleting source files, search build and coverage scripts for static file li
 After deleting source files, run `rg` across scripts and config for every deleted filename before final verification.
 
 ---
+
+## [91] Check every spec requirement before review pass
+
+**Date**: 2026-04-29
+**Category**: test-mistake
+
+### What went wrong
+The first meeting bucket navigation implementation covered labels and filtering, but missed the spec requirement for empty bucket states until manual review.
+
+### Correct approach
+Before marking implementation review as passing, compare each spec requirement against both code and tests, including small UI states like empty lists.
+
+### How to avoid
+For UI navigation changes, add explicit coverage for every visible state named in the spec, not only the primary populated path.
+
+---

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -4,7 +4,8 @@ import SwiftUI
 
 private enum MainWindowDestination: Hashable {
     case today
-    case recordings
+    case thisWeek
+    case history
     case workspace
     case settings
 }
@@ -24,10 +25,15 @@ struct MainWindowView: View {
                     }
                     .buttonStyle(SidebarNavigationButtonStyle(isSelected: destination == .today))
 
-                    Button("Recordings") {
-                        destination = .recordings
+                    Button("This Week") {
+                        destination = .thisWeek
                     }
-                    .buttonStyle(SidebarNavigationButtonStyle(isSelected: destination == .recordings))
+                    .buttonStyle(SidebarNavigationButtonStyle(isSelected: destination == .thisWeek))
+
+                    Button("History") {
+                        destination = .history
+                    }
+                    .buttonStyle(SidebarNavigationButtonStyle(isSelected: destination == .history))
                 }
                 .padding(12)
 
@@ -39,20 +45,27 @@ struct MainWindowView: View {
                     }
                 )) {
                     Section {
-                        ForEach(viewModel.meetings) { meeting in
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text(meeting.name)
-                                    .font(CommandCenterTypography.title)
-                                    .foregroundStyle(CommandCenterPalette.text)
-                                Text(meeting.startedAt, style: .date)
-                                    .font(CommandCenterTypography.caption)
-                                    .foregroundStyle(CommandCenterPalette.secondaryText)
+                        if meetings(for: destination).isEmpty {
+                            Text(emptyMeetingListText(for: destination))
+                                .font(CommandCenterTypography.caption)
+                                .foregroundStyle(CommandCenterPalette.secondaryText)
+                                .padding(.vertical, 4)
+                        } else {
+                            ForEach(meetings(for: destination)) { meeting in
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text(meeting.name)
+                                        .font(CommandCenterTypography.title)
+                                        .foregroundStyle(CommandCenterPalette.text)
+                                    Text(meeting.startedAt, style: .date)
+                                        .font(CommandCenterTypography.caption)
+                                        .foregroundStyle(CommandCenterPalette.secondaryText)
+                                }
+                                .padding(.vertical, 4)
+                                .tag(Optional(meeting.id))
                             }
-                            .padding(.vertical, 4)
-                            .tag(Optional(meeting.id))
                         }
                     } header: {
-                        Text("Recent Recordings")
+                        Text(meetingListTitle(for: destination))
                             .foregroundStyle(CommandCenterPalette.secondaryText)
                     }
                 }
@@ -93,7 +106,7 @@ struct MainWindowView: View {
                 )
             case .today:
                 TodayAgendaView(
-                    meetings: viewModel.meetings,
+                    meetings: meetings(for: .today),
                     selectedMeetingID: viewModel.selectedMeetingID,
                     activeMeetingID: viewModel.activeMeetingID,
                     pendingCandidate: viewModel.pendingCandidate,
@@ -128,7 +141,7 @@ struct MainWindowView: View {
                         viewModel.selectMeeting(created.id)
                     }
                 )
-            case .recordings, .workspace:
+            case .thisWeek, .history, .workspace:
                 MeetingDetailView(
                     meeting: viewModel.selectedMeeting,
                     speechConfiguration: viewModel.speechConfiguration,
@@ -231,6 +244,66 @@ struct MainWindowView: View {
                 .fill(CommandCenterPalette.border)
                 .frame(height: 1)
         }
+    }
+
+    private func meetings(for destination: MainWindowDestination) -> [MeetingRecord] {
+        switch destination {
+        case .today:
+            return viewModel.meetings.filter { isToday($0) }
+        case .thisWeek:
+            return viewModel.meetings.filter { isThisWeek($0) && !isToday($0) }
+        case .history:
+            return viewModel.meetings.filter { !isThisWeek($0) }
+        case .workspace:
+            return viewModel.meetings
+        case .settings:
+            return []
+        }
+    }
+
+    private func meetingListTitle(for destination: MainWindowDestination) -> String {
+        switch destination {
+        case .today:
+            return "Today"
+        case .thisWeek:
+            return "This Week"
+        case .history:
+            return "History"
+        case .workspace:
+            return "All Meetings"
+        case .settings:
+            return "Meetings"
+        }
+    }
+
+    private func emptyMeetingListText(for destination: MainWindowDestination) -> String {
+        switch destination {
+        case .today:
+            return "No meetings today"
+        case .thisWeek:
+            return "No meetings this week"
+        case .history:
+            return "No meeting history"
+        case .workspace:
+            return "No meetings"
+        case .settings:
+            return ""
+        }
+    }
+
+    private func isToday(_ meeting: MeetingRecord, now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        let meetingDate = meetingDisplayDate(meeting)
+        return calendar.isDate(meetingDate, inSameDayAs: now)
+    }
+
+    private func isThisWeek(_ meeting: MeetingRecord, now: Date = Date(), calendar: Calendar = .current) -> Bool {
+        let meetingDate = meetingDisplayDate(meeting)
+        return calendar.isDate(meetingDate, equalTo: now, toGranularity: .weekOfYear)
+            && calendar.isDate(meetingDate, equalTo: now, toGranularity: .yearForWeekOfYear)
+    }
+
+    private func meetingDisplayDate(_ meeting: MeetingRecord) -> Date {
+        meeting.scheduledStartAt ?? meeting.startedAt
     }
 
     private func copySummary(for meeting: MeetingRecord) {

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -20,16 +20,27 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains(".frame(minWidth: 260, idealWidth: 300)"))
     }
 
-    func testMainWindowRoutesThroughAgendaFirstSidebarSections() throws {
+    func testMainWindowRoutesThroughMeetingRecordBuckets() throws {
         let source = try appSource(named: "MainWindowView.swift")
 
         XCTAssertTrue(source.contains("enum MainWindowDestination"))
         XCTAssertTrue(source.contains("case today"))
-        XCTAssertTrue(source.contains("case recordings"))
+        XCTAssertTrue(source.contains("case thisWeek"))
+        XCTAssertTrue(source.contains("case history"))
         XCTAssertTrue(source.contains("TodayAgendaView("))
         XCTAssertTrue(source.contains("Button(\"Today\")"))
-        XCTAssertTrue(source.contains("Button(\"Recordings\")"))
+        XCTAssertTrue(source.contains("Button(\"This Week\")"))
+        XCTAssertTrue(source.contains("Button(\"History\")"))
         XCTAssertTrue(source.contains("Label(\"Settings\", systemImage: \"gearshape\")"))
+        XCTAssertTrue(source.contains("meetings(for: destination)"))
+        XCTAssertTrue(source.contains("emptyMeetingListText(for: destination)"))
+        XCTAssertTrue(source.contains("meetingDisplayDate(_ meeting: MeetingRecord)"))
+        XCTAssertTrue(source.contains("meeting.scheduledStartAt ?? meeting.startedAt"))
+        XCTAssertTrue(source.contains("No meetings today"))
+        XCTAssertTrue(source.contains("No meetings this week"))
+        XCTAssertTrue(source.contains("No meeting history"))
+        XCTAssertFalse(source.contains("Button(\"Recordings\")"))
+        XCTAssertFalse(source.contains("Text(\"Recent Recordings\")"))
         XCTAssertFalse(source.contains("Text(\"Meetings\")"))
     }
 
@@ -46,6 +57,17 @@ final class MainWindowViewLayoutTests: XCTestCase {
         let styleSource = source[styleRange.lowerBound..<nextViewRange.lowerBound]
         XCTAssertTrue(styleSource.contains(".frame(maxWidth: .infinity, minHeight: 36, alignment: .leading)"))
         XCTAssertTrue(styleSource.contains(".contentShape(Rectangle())"))
+    }
+
+    func testMeetingBucketsUseCalendarBoundaries() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("TodayAgendaView("))
+        XCTAssertTrue(source.contains("meetings: meetings(for: .today)"))
+        XCTAssertTrue(source.contains("calendar.isDate(meetingDate, inSameDayAs: now)"))
+        XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .weekOfYear)"))
+        XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .yearForWeekOfYear)"))
+        XCTAssertTrue(source.contains("return viewModel.meetings.filter { isThisWeek($0) && !isToday($0) }"))
     }
 
     func testTodayAgendaViewDefinesAgendaRowsAndExplicitEditorSaveCancel() throws {
@@ -166,7 +188,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("\"STT Locale\""))
     }
 
-    func testRecordingsRowsUseListSelectionTags() throws {
+    func testMeetingRowsUseListSelectionTags() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)

--- a/docs/superpowers/plans/2026-04-29-meeting-record-navigation.md
+++ b/docs/superpowers/plans/2026-04-29-meeting-record-navigation.md
@@ -1,0 +1,231 @@
+# Meeting Record Navigation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace recording-centric navigation with `MeetingRecord`-driven `Today`, `This Week`, and `History` meeting buckets.
+
+**Architecture:** Keep `MeetingAgentViewModel` and `MeetingRecord` unchanged. Compute calendar buckets inside `MainWindowView` from `scheduledStartAt ?? startedAt`, pass today's meetings into `TodayAgendaView`, and route bucket row selections to the existing workspace detail.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout regression tests, Swift Package Manager.
+
+---
+
+### Task 1: Add Navigation Regression Coverage
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Update the routing test first**
+
+Replace `testMainWindowRoutesThroughAgendaFirstSidebarSections` with assertions for `thisWeek`, `history`, bucket filtering helpers, and removal of the `Recordings` nav button:
+
+```swift
+func testMainWindowRoutesThroughMeetingRecordBuckets() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("enum MainWindowDestination"))
+    XCTAssertTrue(source.contains("case today"))
+    XCTAssertTrue(source.contains("case thisWeek"))
+    XCTAssertTrue(source.contains("case history"))
+    XCTAssertTrue(source.contains("TodayAgendaView("))
+    XCTAssertTrue(source.contains("Button(\"Today\")"))
+    XCTAssertTrue(source.contains("Button(\"This Week\")"))
+    XCTAssertTrue(source.contains("Button(\"History\")"))
+    XCTAssertTrue(source.contains("Label(\"Settings\", systemImage: \"gearshape\")"))
+    XCTAssertTrue(source.contains("meetings(for: destination)"))
+    XCTAssertTrue(source.contains("meetingDisplayDate(_ meeting: MeetingRecord)"))
+    XCTAssertTrue(source.contains("meeting.scheduledStartAt ?? meeting.startedAt"))
+    XCTAssertFalse(source.contains("Button(\"Recordings\")"))
+    XCTAssertFalse(source.contains("Text(\"Recent Recordings\")"))
+}
+```
+
+- [ ] **Step 2: Add a bucket-specific behavior guard**
+
+Add a new source-layout test that confirms today is passed into the agenda and current-week/history filtering is implemented:
+
+```swift
+func testMeetingBucketsUseCalendarBoundaries() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("TodayAgendaView("))
+    XCTAssertTrue(source.contains("meetings: meetings(for: .today)"))
+    XCTAssertTrue(source.contains("calendar.isDate(meetingDate, inSameDayAs: now)"))
+    XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .weekOfYear)"))
+    XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .yearForWeekOfYear)"))
+    XCTAssertTrue(source.contains("!calendar.isDate(meetingDate, inSameDayAs: now)"))
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testMainWindowRoutesThroughMeetingRecordBuckets --filter MainWindowViewLayoutTests/testMeetingBucketsUseCalendarBoundaries`
+
+Expected: fail before implementation because `thisWeek`, `history`, and bucket helpers do not exist yet.
+
+### Task 2: Implement Meeting Buckets in MainWindowView
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Replace the destination case**
+
+Change:
+
+```swift
+case recordings
+```
+
+to:
+
+```swift
+case thisWeek
+case history
+```
+
+- [ ] **Step 2: Replace sidebar buttons**
+
+Replace the `Recordings` button with:
+
+```swift
+Button("This Week") {
+    destination = .thisWeek
+}
+.buttonStyle(SidebarNavigationButtonStyle(isSelected: destination == .thisWeek))
+
+Button("History") {
+    destination = .history
+}
+.buttonStyle(SidebarNavigationButtonStyle(isSelected: destination == .history))
+```
+
+- [ ] **Step 3: Filter sidebar rows by destination**
+
+Change the `ForEach(viewModel.meetings)` list source to:
+
+```swift
+ForEach(meetings(for: destination)) { meeting in
+```
+
+Change the list header to:
+
+```swift
+Text(meetingListTitle(for: destination))
+    .foregroundStyle(CommandCenterPalette.secondaryText)
+```
+
+- [ ] **Step 4: Pass only today's meetings to the Today surface**
+
+Change the `TodayAgendaView` call to:
+
+```swift
+TodayAgendaView(
+    meetings: meetings(for: .today),
+```
+
+- [ ] **Step 5: Keep detail routing explicit**
+
+Change the detail switch case from:
+
+```swift
+case .recordings, .workspace:
+```
+
+to:
+
+```swift
+case .thisWeek, .history, .workspace:
+```
+
+- [ ] **Step 6: Add calendar bucket helpers**
+
+Add these helpers inside `MainWindowView`:
+
+```swift
+private func meetings(for destination: MainWindowDestination) -> [MeetingRecord] {
+    switch destination {
+    case .today:
+        return viewModel.meetings.filter { isToday($0) }
+    case .thisWeek:
+        return viewModel.meetings.filter { isThisWeek($0) && !isToday($0) }
+    case .history:
+        return viewModel.meetings.filter { !isThisWeek($0) }
+    case .workspace:
+        return viewModel.meetings
+    case .settings:
+        return []
+    }
+}
+
+private func meetingListTitle(for destination: MainWindowDestination) -> String {
+    switch destination {
+    case .today:
+        return "Today"
+    case .thisWeek:
+        return "This Week"
+    case .history:
+        return "History"
+    case .workspace:
+        return "All Meetings"
+    case .settings:
+        return "Meetings"
+    }
+}
+
+private func isToday(_ meeting: MeetingRecord, now: Date = Date(), calendar: Calendar = .current) -> Bool {
+    calendar.isDate(meetingDisplayDate(meeting), inSameDayAs: now)
+}
+
+private func isThisWeek(_ meeting: MeetingRecord, now: Date = Date(), calendar: Calendar = .current) -> Bool {
+    let meetingDate = meetingDisplayDate(meeting)
+    return calendar.isDate(meetingDate, equalTo: now, toGranularity: .weekOfYear)
+        && calendar.isDate(meetingDate, equalTo: now, toGranularity: .yearForWeekOfYear)
+}
+
+private func meetingDisplayDate(_ meeting: MeetingRecord) -> Date {
+    meeting.scheduledStartAt ?? meeting.startedAt
+}
+```
+
+- [ ] **Step 7: Run focused tests and verify pass**
+
+Run: `swift test --filter MainWindowViewLayoutTests`
+
+Expected: pass.
+
+### Task 3: Full Verification and Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+- Existing: `docs/superpowers/specs/2026-04-29-meeting-record-navigation-design.md`
+- Existing: `docs/superpowers/plans/2026-04-29-meeting-record-navigation.md`
+
+- [ ] **Step 1: Build the app**
+
+Run: `swift build --product MeetingAgentApp`
+
+Expected: build succeeds.
+
+- [ ] **Step 2: Run required unit verification**
+
+Run: `make test`
+
+Expected: all tests pass and coverage gate passes.
+
+- [ ] **Step 3: Inspect relevant diff**
+
+Run: `git diff -- Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/plans/2026-04-29-meeting-record-navigation.md`
+
+Expected: diff only covers meeting bucket navigation, layout tests, and this plan.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/plans/2026-04-29-meeting-record-navigation.md
+git commit -m "feat: align navigation around meetings (#91)"
+```

--- a/docs/superpowers/specs/2026-04-29-meeting-record-navigation-design.md
+++ b/docs/superpowers/specs/2026-04-29-meeting-record-navigation-design.md
@@ -1,0 +1,87 @@
+# Meeting Record Navigation Design
+
+## Issue
+
+GitHub issue #91 asks to align the app around the meeting model instead of showing agenda data as meetings while the adjacent navigation still presents recordings. The current app already stores agenda, recording, transcript, summary, and export artifact paths on `MeetingRecord`, but the shell still exposes a `Recordings` destination and a `Recent Recordings` sidebar list.
+
+## Goal
+
+Make `MeetingRecord` the visible entity across the main navigation. Meetings should appear under `Today`, `This Week`, and `History`; recording artifacts should remain associated with the selected meeting and appear only in the existing detail/workspace flow.
+
+## Selected Direction
+
+Use a `MeetingRecord`-driven three-section navigation:
+
+- `Today` shows meetings scheduled or started today.
+- `This Week` shows meetings from the current calendar week excluding today.
+- `History` shows meetings before the current calendar week.
+
+This was selected over a text-only rename because the issue explicitly calls out `Today`, `This Week`, and `history`. It was selected over a new `Recording` model because the current persistence model already treats recordings as artifacts of `MeetingRecord`; introducing a separate recording entity would require migration and broader changes to transcription, summary, export, and compatibility paths.
+
+## Requirements
+
+- Keep `MeetingRecord` as the single list entity.
+- Replace the `Recordings` navigation entry with `This Week` and `History`.
+- Remove recording-centric navigation copy such as `Recent Recordings`.
+- Filter left-side meeting rows by the active meeting bucket.
+- Keep `TodayAgendaView` focused on today's meetings.
+- Keep the existing workspace/detail view for selected meetings.
+- Preserve recording start, stop, retry transcription, summary generation, export, speaker label edit, transcript edit, and settings behavior.
+- Keep Settings as a fixed bottom entry.
+- Use calendar-aware day and week comparisons based on each meeting's scheduled start when present, otherwise `startedAt`.
+- Show useful empty states for meeting buckets with no rows.
+
+## Non-Requirements
+
+- No new persisted `Recording` model.
+- No storage migration.
+- No change to `MeetingRecord` fields.
+- No changes to audio capture, transcription, summary, or export artifacts.
+- No new search, calendar picker, or advanced filters.
+- No redesign of the meeting detail command center beyond routing and navigation copy.
+
+## Approach
+
+`MainWindowDestination` will replace the recordings destination with `thisWeek` and `history`, while retaining `today`, `workspace`, and `settings`.
+
+The sidebar will render `Today`, `This Week`, and `History` as first-class navigation buttons. Below the buttons, the existing meeting list will become bucket-aware. The list will use a helper that filters `viewModel.meetings` into the active bucket using `scheduledStartAt ?? startedAt`. Selecting a row will call `viewModel.selectMeeting(_:)` and route to `workspace`, preserving the existing detail flow.
+
+`TodayAgendaView` will receive only today's meetings from `MainWindowView`. It will continue to edit and create agenda meetings, start a pending recording for a meeting, and open the workspace. This keeps agenda preparation specific to the Today surface while the broader shell handles week and history navigation.
+
+For empty buckets, the sidebar list header and placeholder text will describe meetings rather than recordings. The detail pane will still show `No Meeting Selected` when a bucket has no selected row.
+
+## Data Flow
+
+`MeetingAgentViewModel` remains the source of truth. The view layer computes calendar buckets from `viewModel.meetings`; no bucket state is persisted. The selected meeting ID remains unchanged unless the user selects a row, creates a meeting, or starts a recording.
+
+Recording artifacts remain fields on the selected `MeetingRecord`. The workspace/detail view continues to receive `viewModel.selectedMeeting` and existing callbacks, so artifact behavior is unchanged.
+
+## Edge Cases
+
+- A meeting with `scheduledStartAt` uses that date for bucket placement.
+- A recorded ad hoc meeting without `scheduledStartAt` uses `startedAt`.
+- `This Week` excludes today to avoid duplicate rows across `Today` and `This Week`.
+- A selected meeting can remain selected when the user changes buckets; if it is not visible in the active bucket, the sidebar list simply has no selected row until the user opens the workspace or selects another meeting.
+- Meetings later than today but inside the current week appear in `This Week`.
+
+## Testing
+
+Use existing source-layout regression tests for SwiftUI structure and focused view-model tests where behavior is model-level.
+
+Tests should assert:
+
+- `MainWindowDestination` includes `today`, `thisWeek`, `history`, `workspace`, and `settings`.
+- The sidebar renders `Today`, `This Week`, and `History`, and no longer renders the `Recordings` navigation button.
+- The sidebar list no longer uses `Recent Recordings`.
+- Bucket filtering uses `scheduledStartAt ?? startedAt`.
+- `This Week` excludes today's meetings and `History` excludes current-week meetings.
+- `TodayAgendaView` is passed the today-filtered meeting list.
+- Existing detail routing, settings routing, and detected meeting start routing remain present.
+
+Run `make test` before completion.
+
+## Risks
+
+- Date bucketing can become surprising around locale week boundaries. Use `Calendar.current.isDate(_:equalTo:toGranularity:)` and week-of-year/year-for-week-of-year comparisons instead of raw intervals.
+- Routing changes can accidentally hide the detail workspace. Keep `workspace` as an explicit destination and route list selections there.
+- Source-layout tests can become brittle if they assert broad snippets. Keep new assertions focused on stable symbols and labels.


### PR DESCRIPTION
## Summary

Fixes #91

- Replace recording-centric sidebar navigation with MeetingRecord-based Today, This Week, and History buckets.
- Keep recording artifacts attached to the selected meeting workspace instead of introducing a Recording model.
- Add meeting-oriented empty states and source-layout regression coverage.

## Changes

- Sources/MeetingAgentApp/MainWindowView.swift - routes sidebar navigation through meeting buckets and passes only today meetings into the agenda surface.
- Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift - covers new navigation labels, bucket filtering, empty states, and removal of recording-centric nav copy.
- docs/superpowers/specs/2026-04-29-meeting-record-navigation-design.md - records the approved design.
- docs/superpowers/plans/2026-04-29-meeting-record-navigation.md - records the implementation plan.
- MISTAKES.md - records the review lesson from #91.

## Test plan

- [x] Build/lint: swift build --product MeetingAgentApp passed
- [x] Unit tests: swift test --filter MainWindowViewLayoutTests passed
- [x] Full verification: make test passed, 468 tests, coverage gate passed
- [x] Code review: PASS after fixing empty-state coverage gap
- [x] Manual verification: reviewed diff for meeting-only navigation copy and calendar bucket logic