### PR TITLE
fix: show agenda buckets from nav

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -37,43 +37,6 @@ struct MainWindowView: View {
                 }
                 .padding(12)
 
-                List(selection: Binding(
-                    get: { destination == .settings ? nil : viewModel.selectedMeetingID },
-                    set: { id in
-                        destination = .workspace
-                        viewModel.selectMeeting(id)
-                    }
-                )) {
-                    Section {
-                        if meetings(for: destination).isEmpty {
-                            Text(emptyMeetingListText(for: destination))
-                                .font(CommandCenterTypography.caption)
-                                .foregroundStyle(CommandCenterPalette.secondaryText)
-                                .padding(.vertical, 4)
-                        } else {
-                            ForEach(meetings(for: destination)) { meeting in
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(meeting.name)
-                                        .font(CommandCenterTypography.title)
-                                        .foregroundStyle(CommandCenterPalette.text)
-                                    Text(meeting.startedAt, style: .date)
-                                        .font(CommandCenterTypography.caption)
-                                        .foregroundStyle(CommandCenterPalette.secondaryText)
-                                }
-                                .padding(.vertical, 4)
-                                .tag(Optional(meeting.id))
-                            }
-                        }
-                    } header: {
-                        Text(meetingListTitle(for: destination))
-                            .foregroundStyle(CommandCenterPalette.secondaryText)
-                    }
-                }
-                .scrollContentBackground(.hidden)
-                .background(CommandCenterPalette.surface)
-                .environment(\.colorScheme, .dark)
-                .foregroundStyle(CommandCenterPalette.text)
-
                 Spacer()
 
                 Divider()
@@ -104,9 +67,12 @@ struct MainWindowView: View {
                     primaryChainPreflightResult: viewModel.primaryChainPreflightResult,
                     save: { viewModel.saveSpeechConfiguration($0) }
                 )
-            case .today:
+            case .today, .thisWeek, .history:
                 TodayAgendaView(
-                    meetings: meetings(for: .today),
+                    title: agendaTitle(for: destination),
+                    emptyTitle: agendaEmptyTitle(for: destination),
+                    emptyDescription: agendaEmptyDescription(for: destination),
+                    meetings: meetings(for: destination),
                     selectedMeetingID: viewModel.selectedMeetingID,
                     activeMeetingID: viewModel.activeMeetingID,
                     pendingCandidate: viewModel.pendingCandidate,
@@ -136,12 +102,12 @@ struct MainWindowView: View {
                     saveAgenda: { meetingID, update in
                         try viewModel.saveAgenda(for: meetingID, update: update)
                     },
-                    createMeeting: {
+                    createMeeting: destination == .today ? {
                         let created = try viewModel.createAgendaMeeting()
                         viewModel.selectMeeting(created.id)
-                    }
+                    } : nil
                 )
-            case .thisWeek, .history, .workspace:
+            case .workspace:
                 MeetingDetailView(
                     meeting: viewModel.selectedMeeting,
                     speechConfiguration: viewModel.speechConfiguration,
@@ -261,7 +227,7 @@ struct MainWindowView: View {
         }
     }
 
-    private func meetingListTitle(for destination: MainWindowDestination) -> String {
+    private func agendaTitle(for destination: MainWindowDestination) -> String {
         switch destination {
         case .today:
             return "Today"
@@ -276,17 +242,30 @@ struct MainWindowView: View {
         }
     }
 
-    private func emptyMeetingListText(for destination: MainWindowDestination) -> String {
+    private func agendaEmptyTitle(for destination: MainWindowDestination) -> String {
         switch destination {
         case .today:
-            return "No meetings today"
+            return "No meetings scheduled today"
         case .thisWeek:
-            return "No meetings this week"
+            return "No meetings scheduled this week"
         case .history:
             return "No meeting history"
         case .workspace:
             return "No meetings"
         case .settings:
+            return ""
+        }
+    }
+
+    private func agendaEmptyDescription(for destination: MainWindowDestination) -> String {
+        switch destination {
+        case .today:
+            return "Create a local agenda item to prepare attendees, topics, and meeting goals before recording."
+        case .thisWeek:
+            return "Meetings scheduled later this week will appear here with their agenda details."
+        case .history:
+            return "Completed and past meetings will appear here with their saved agenda details."
+        case .workspace, .settings:
             return ""
         }
     }

--- a/Sources/MeetingAgentApp/TodayAgendaView.swift
+++ b/Sources/MeetingAgentApp/TodayAgendaView.swift
@@ -2,6 +2,9 @@ import MeetingAgentCore
 import SwiftUI
 
 struct TodayAgendaView: View {
+    let title: String
+    let emptyTitle: String
+    let emptyDescription: String
     let meetings: [MeetingRecord]
     let selectedMeetingID: UUID?
     let activeMeetingID: UUID?
@@ -11,7 +14,7 @@ struct TodayAgendaView: View {
     let openWorkspace: (MeetingRecord) -> Void
     let startRecording: (MeetingRecord) -> Void
     let saveAgenda: (UUID, MeetingAgendaUpdate) throws -> Void
-    let createMeeting: () throws -> Void
+    let createMeeting: (() throws -> Void)?
 
     @State private var draft = AgendaDraft()
     @State private var recordBackedDraft = AgendaDraft()
@@ -58,7 +61,7 @@ struct TodayAgendaView: View {
     private var header: some View {
         HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 5) {
-                Text("Today")
+                Text(title)
                     .font(CommandCenterTypography.title)
                     .foregroundStyle(CommandCenterPalette.text)
                 Text(Date().formatted(date: .complete, time: .omitted))
@@ -66,7 +69,7 @@ struct TodayAgendaView: View {
                     .foregroundStyle(CommandCenterPalette.secondaryText)
             }
             Spacer()
-            CommandCenterChip(title: "\(todayMeetings.count) meetings")
+            CommandCenterChip(title: "\(sortedMeetings.count) meetings")
             if let activeMeetingID, meetings.contains(where: { $0.id == activeMeetingID }) {
                 CommandCenterChip(title: "Live recording", tint: CommandCenterPalette.primary, filled: true)
             }
@@ -83,13 +86,13 @@ struct TodayAgendaView: View {
 
     @ViewBuilder
     private var agendaList: some View {
-        if todayMeetings.isEmpty {
+        if sortedMeetings.isEmpty {
             CommandCenterPanel {
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("No meetings scheduled today")
+                    Text(emptyTitle)
                         .font(CommandCenterTypography.title)
                         .foregroundStyle(CommandCenterPalette.text)
-                    Text("Create a local agenda item to prepare attendees, topics, and meeting goals before recording.")
+                    Text(emptyDescription)
                         .font(CommandCenterTypography.secondaryBody)
                         .foregroundStyle(CommandCenterPalette.secondaryText)
                     if let createError {
@@ -97,22 +100,24 @@ struct TodayAgendaView: View {
                             .font(CommandCenterTypography.caption)
                             .foregroundStyle(CommandCenterPalette.danger)
                     }
-                    Button("Create Meeting") {
-                        do {
-                            try createMeeting()
-                            createError = nil
-                        } catch {
-                            createError = "Could not create meeting: \(error)"
+                    if let createMeeting {
+                        Button("Create Meeting") {
+                            do {
+                                try createMeeting()
+                                createError = nil
+                            } catch {
+                                createError = "Could not create meeting: \(error)"
+                            }
                         }
+                        .buttonStyle(CommandCenterActionButtonStyle(variant: .primary))
                     }
-                    .buttonStyle(CommandCenterActionButtonStyle(variant: .primary))
                 }
             }
             .padding(24)
         } else {
             CommandCenterScrollView {
                 LazyVStack(alignment: .leading, spacing: 10) {
-                    ForEach(todayMeetings) { meeting in
+                    ForEach(sortedMeetings) { meeting in
                         AgendaRowView(
                             meeting: meeting,
                             isSelected: meeting.id == selectedMeetingID,
@@ -132,7 +137,7 @@ struct TodayAgendaView: View {
         }
     }
 
-    private var todayMeetings: [MeetingRecord] {
+    private var sortedMeetings: [MeetingRecord] {
         meetings.sorted { lhs, rhs in
             displayDate(for: lhs) < displayDate(for: rhs)
         }
@@ -143,7 +148,7 @@ struct TodayAgendaView: View {
            let selected = meetings.first(where: { $0.id == selectedMeetingID }) {
             return selected
         }
-        return todayMeetings.first
+        return sortedMeetings.first
     }
 
     private func actionTitle(for meeting: MeetingRecord) -> String {

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -33,15 +33,26 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("Button(\"History\")"))
         XCTAssertTrue(source.contains("Label(\"Settings\", systemImage: \"gearshape\")"))
         XCTAssertTrue(source.contains("meetings(for: destination)"))
-        XCTAssertTrue(source.contains("emptyMeetingListText(for: destination)"))
+        XCTAssertTrue(source.contains("TodayAgendaView("))
+        XCTAssertTrue(source.contains("case .today, .thisWeek, .history:"))
+        XCTAssertTrue(source.contains("agendaEmptyTitle(for: destination)"))
+        XCTAssertTrue(source.contains("agendaEmptyDescription(for: destination)"))
         XCTAssertTrue(source.contains("meetingDisplayDate(_ meeting: MeetingRecord)"))
         XCTAssertTrue(source.contains("meeting.scheduledStartAt ?? meeting.startedAt"))
-        XCTAssertTrue(source.contains("No meetings today"))
-        XCTAssertTrue(source.contains("No meetings this week"))
+        XCTAssertTrue(source.contains("No meetings scheduled today"))
+        XCTAssertTrue(source.contains("No meetings scheduled this week"))
         XCTAssertTrue(source.contains("No meeting history"))
         XCTAssertFalse(source.contains("Button(\"Recordings\")"))
         XCTAssertFalse(source.contains("Text(\"Recent Recordings\")"))
         XCTAssertFalse(source.contains("Text(\"Meetings\")"))
+    }
+
+    func testSidebarBucketNavigationDoesNotRenderMeetingSelectionList() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertFalse(source.contains("List(selection: Binding("))
+        XCTAssertFalse(source.contains(".tag(Optional(meeting.id))"))
+        XCTAssertFalse(source.contains("meetingListTitle(for: destination)"))
     }
 
     func testSidebarNavigationRowsDefineFullWidthHitArea() throws {
@@ -63,7 +74,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         let source = try appSource(named: "MainWindowView.swift")
 
         XCTAssertTrue(source.contains("TodayAgendaView("))
-        XCTAssertTrue(source.contains("meetings: meetings(for: .today)"))
+        XCTAssertTrue(source.contains("meetings: meetings(for: destination)"))
         XCTAssertTrue(source.contains("calendar.isDate(meetingDate, inSameDayAs: now)"))
         XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .weekOfYear)"))
         XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .yearForWeekOfYear)"))
@@ -188,13 +199,13 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("\"STT Locale\""))
     }
 
-    func testMeetingRowsUseListSelectionTags() throws {
+    func testMeetingRowsDoNotUseSidebarListSelectionTags() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        XCTAssertTrue(source.contains("List(selection: Binding("))
-        XCTAssertTrue(source.contains(".tag(Optional(meeting.id))"))
+        XCTAssertFalse(source.contains("List(selection: Binding("))
+        XCTAssertFalse(source.contains(".tag(Optional(meeting.id))"))
         XCTAssertFalse(source.contains(".onTapGesture {\n                            viewModel.selectMeeting(meeting.id)"))
     }
 


### PR DESCRIPTION
## Summary

Fixes #94

- Remove the meeting selection list from the sidebar bucket navigation
- Route Today, This Week, and History to the agenda view in the main content area
- Add bucket-specific agenda titles and empty states

## Changes

- Sources/MeetingAgentApp/MainWindowView.swift - removes sidebar meeting list and routes bucket destinations to agenda content
- Sources/MeetingAgentApp/TodayAgendaView.swift - parameterizes agenda title, empty copy, and create action
- Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift - covers absence of sidebar list and bucket agenda routing

## Test plan

- [x] Build/lint: swift build --product MeetingAgentApp passed
- [x] Unit tests: focused sidebar regression failed before fix and passed after fix; swift test --filter MainWindowViewLayoutTests passed
- [x] Full verification: make test passed, 470 tests, coverage gate passed
- [x] E2E/integration: skipped; no E2E convention for this SwiftUI layout behavior
- [x] Code review: PASS via manual Swift/project-convention review
- [x] Manual verification: static layout checks confirm sidebar list selectors are gone