### PR TITLE
feat: restore agenda single feed in today view

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -72,7 +72,7 @@ struct MainWindowView: View {
                     title: agendaTitle(for: destination),
                     emptyTitle: agendaEmptyTitle(for: destination),
                     emptyDescription: agendaEmptyDescription(for: destination),
-                    meetings: meetings(for: destination),
+                    meetings: destination == .today ? viewModel.meetings : meetings(for: destination),
                     selectedMeetingID: viewModel.selectedMeetingID,
                     activeMeetingID: viewModel.activeMeetingID,
                     pendingCandidate: viewModel.pendingCandidate,

--- a/Sources/MeetingAgentApp/TodayAgendaView.swift
+++ b/Sources/MeetingAgentApp/TodayAgendaView.swift
@@ -2,6 +2,7 @@ import MeetingAgentCore
 import SwiftUI
 
 struct TodayAgendaView: View {
+    private let recentHistoryDays = 7
     let title: String
     let emptyTitle: String
     let emptyDescription: String
@@ -69,8 +70,8 @@ struct TodayAgendaView: View {
                     .foregroundStyle(CommandCenterPalette.secondaryText)
             }
             Spacer()
-            CommandCenterChip(title: "\(sortedMeetings.count) meetings")
-            if let activeMeetingID, meetings.contains(where: { $0.id == activeMeetingID }) {
+            CommandCenterChip(title: "\(editableMeetings.count) meetings")
+            if let activeMeetingID, editableMeetings.contains(where: { $0.id == activeMeetingID }) {
                 CommandCenterChip(title: "Live recording", tint: CommandCenterPalette.primary, filled: true)
             }
         }
@@ -86,34 +87,43 @@ struct TodayAgendaView: View {
 
     @ViewBuilder
     private var agendaList: some View {
-        if sortedMeetings.isEmpty {
-            CommandCenterPanel {
-                VStack(alignment: .leading, spacing: 12) {
-                    Text(emptyTitle)
+        if showsSingleFeed {
+            agendaFeed
+        } else {
+            bucketAgendaList
+        }
+    }
+
+    private var agendaFeed: some View {
+        CommandCenterScrollView {
+            LazyVStack(alignment: .leading, spacing: 22) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Agenda")
                         .font(CommandCenterTypography.title)
                         .foregroundStyle(CommandCenterPalette.text)
-                    Text(emptyDescription)
-                        .font(CommandCenterTypography.secondaryBody)
+                    Text("Meeting schedule and metadata")
+                        .font(CommandCenterTypography.caption)
                         .foregroundStyle(CommandCenterPalette.secondaryText)
-                    if let createError {
-                        Text(createError)
-                            .font(CommandCenterTypography.caption)
-                            .foregroundStyle(CommandCenterPalette.danger)
-                    }
-                    if let createMeeting {
-                        Button("Create Meeting") {
-                            do {
-                                try createMeeting()
-                                createError = nil
-                            } catch {
-                                createError = "Could not create meeting: \(error)"
-                            }
-                        }
-                        .buttonStyle(CommandCenterActionButtonStyle(variant: .primary))
+                }
+
+                AgendaFeedSection(title: "Today", count: todayMeetings.count) {
+                    todayFeedContent
+                }
+
+                if !recentGroups.isEmpty {
+                    AgendaFeedSection(title: "Recent", count: recentGroups.reduce(0) { $0 + $1.1.count }) {
+                        recentFeedContent
                     }
                 }
             }
-            .padding(24)
+            .padding(22)
+        }
+    }
+
+    @ViewBuilder
+    private var bucketAgendaList: some View {
+        if sortedMeetings.isEmpty {
+            emptyState
         } else {
             CommandCenterScrollView {
                 LazyVStack(alignment: .leading, spacing: 10) {
@@ -137,18 +147,123 @@ struct TodayAgendaView: View {
         }
     }
 
+    @ViewBuilder
+    private var todayFeedContent: some View {
+        if todayMeetings.isEmpty {
+            emptyState
+        } else {
+            ForEach(todayMeetings) { meeting in
+                AgendaRowView(
+                    meeting: meeting,
+                    isSelected: meeting.id == selectedMeetingID,
+                    isActive: meeting.id == activeMeetingID,
+                    actionTitle: actionTitle(for: meeting),
+                    select: {
+                        selectMeeting(meeting)
+                    },
+                    primaryAction: {
+                        primaryAction(for: meeting)
+                    }
+                )
+            }
+        }
+    }
+
+    private var recentFeedContent: some View {
+        LazyVStack(alignment: .leading, spacing: 12) {
+            ForEach(recentGroups, id: \.0) { day, meetings in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(day.formatted(date: .abbreviated, time: .omitted))
+                        .font(CommandCenterTypography.sectionTitle)
+                        .foregroundStyle(CommandCenterPalette.text)
+                    ForEach(meetings) { meeting in
+                        RecentAgendaMeetingCard(
+                            meeting: meeting,
+                            isSelected: meeting.id == selectedMeetingID,
+                            open: {
+                                selectMeeting(meeting)
+                                openWorkspace(meeting)
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        CommandCenterPanel {
+            VStack(alignment: .leading, spacing: 12) {
+                Text(emptyTitle)
+                    .font(CommandCenterTypography.title)
+                    .foregroundStyle(CommandCenterPalette.text)
+                Text(emptyDescription)
+                    .font(CommandCenterTypography.secondaryBody)
+                    .foregroundStyle(CommandCenterPalette.secondaryText)
+                if let createError {
+                    Text(createError)
+                        .font(CommandCenterTypography.caption)
+                        .foregroundStyle(CommandCenterPalette.danger)
+                }
+                if let createMeeting {
+                    Button("Create Meeting") {
+                        do {
+                            try createMeeting()
+                            createError = nil
+                        } catch {
+                            createError = "Could not create meeting: \(error)"
+                        }
+                    }
+                    .buttonStyle(CommandCenterActionButtonStyle(variant: .primary))
+                }
+            }
+        }
+    }
+
     private var sortedMeetings: [MeetingRecord] {
         meetings.sorted { lhs, rhs in
             displayDate(for: lhs) < displayDate(for: rhs)
         }
     }
 
+    private var todayMeetings: [MeetingRecord] {
+        meetings.filter { Calendar.current.isDate(displayDate(for: $0), inSameDayAs: Date()) }
+            .sorted { lhs, rhs in
+                displayDate(for: lhs) < displayDate(for: rhs)
+            }
+    }
+
+    private var recentGroups: [(Date, [MeetingRecord])] {
+        let calendar = Calendar.current
+        let startOfToday = calendar.startOfDay(for: Date())
+        let recentHistoryStart = calendar.date(byAdding: .day, value: -recentHistoryDays, to: startOfToday) ?? startOfToday
+        let recentMeetings = meetings.filter { meeting in
+            let day = calendar.startOfDay(for: displayDate(for: meeting))
+            return day >= recentHistoryStart && day < startOfToday
+        }
+        let grouped = Dictionary(grouping: recentMeetings) { meeting in
+            calendar.startOfDay(for: displayDate(for: meeting))
+        }
+        return grouped.keys.sorted(by: >).map { day in
+            let meetings = grouped[day]?.sorted { displayDate(for: $0) > displayDate(for: $1) } ?? []
+            return (day, meetings)
+        }
+    }
+
+    private var editableMeetings: [MeetingRecord] {
+        showsSingleFeed ? todayMeetings : sortedMeetings
+    }
+
+    private var showsSingleFeed: Bool {
+        createMeeting != nil
+    }
+
     private var selectedMeeting: MeetingRecord? {
         if let selectedMeetingID,
-           let selected = meetings.first(where: { $0.id == selectedMeetingID }) {
+           let selected = editableMeetings.first(where: { $0.id == selectedMeetingID }) {
             return selected
         }
-        return sortedMeetings.first
+        return editableMeetings.first
     }
 
     private func actionTitle(for meeting: MeetingRecord) -> String {
@@ -201,6 +316,28 @@ struct TodayAgendaView: View {
             draftMeetingID = meetingID
         } catch {
             saveError = "Could not save agenda: \(error)"
+        }
+    }
+}
+
+private struct AgendaFeedSection<Content: View>: View {
+    let title: String
+    let count: Int
+    let content: () -> Content
+
+    init(title: String, count: Int, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.count = count
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(title).commandCenterEyebrow()
+                CommandCenterChip(title: "\(count)")
+            }
+            content()
         }
     }
 }
@@ -284,6 +421,97 @@ private struct AgendaRowView: View {
         let start = (meeting.scheduledStartAt ?? meeting.startedAt).formatted(date: .omitted, time: .shortened)
         guard let end = meeting.scheduledEndAt else { return start }
         return "\(start)\n\(end.formatted(date: .omitted, time: .shortened))"
+    }
+}
+
+private struct RecentAgendaMeetingCard: View {
+    let meeting: MeetingRecord
+    let isSelected: Bool
+    let open: () -> Void
+
+    var body: some View {
+        Button(action: open) {
+            CommandCenterPanel {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text(meeting.name)
+                            .font(CommandCenterTypography.sectionTitle)
+                            .foregroundStyle(CommandCenterPalette.text)
+                            .lineLimit(2)
+                        Spacer()
+                        Text(displayDate.formatted(date: .abbreviated, time: .shortened))
+                            .commandCenterMono()
+                    }
+
+                    HStack(spacing: 8) {
+                        CommandCenterChip(title: statusText, tint: statusTint, filled: true)
+                        CommandCenterChip(title: durationText)
+                        CommandCenterChip(title: meeting.speechLocaleIdentifier, tint: CommandCenterPalette.cyan)
+                        CommandCenterChip(title: artifactText, tint: artifactTint)
+                    }
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? CommandCenterPalette.primary : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var statusText: String {
+        switch meeting.transcriptionStatus {
+        case .notStarted:
+            return "Not started"
+        case .transcribing:
+            return "Transcribing"
+        case .transcribed:
+            return "Transcribed"
+        case .failed:
+            return "Failed"
+        case .retryRequested:
+            return "Retry requested"
+        }
+    }
+
+    private var statusTint: Color {
+        switch meeting.transcriptionStatus {
+        case .failed:
+            return CommandCenterPalette.danger
+        case .transcribed:
+            return CommandCenterPalette.primary
+        case .transcribing, .retryRequested:
+            return CommandCenterPalette.warning
+        case .notStarted:
+            return CommandCenterPalette.secondaryText
+        }
+    }
+
+    private var durationText: String {
+        let interval = (meeting.endedAt ?? Date()).timeIntervalSince(meeting.startedAt)
+        let minutes = max(Int(interval) / 60, 0)
+        return minutes == 1 ? "1 min" : "\(minutes) min"
+    }
+
+    private var displayDate: Date {
+        meeting.scheduledStartAt ?? meeting.startedAt
+    }
+
+    private var artifactText: String {
+        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil {
+            return "Summary ready"
+        }
+        if meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+            return "Transcript ready"
+        }
+        return "Artifacts pending"
+    }
+
+    private var artifactTint: Color {
+        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil || meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+            return CommandCenterPalette.primary
+        }
+        return CommandCenterPalette.secondaryText
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -74,7 +74,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         let source = try appSource(named: "MainWindowView.swift")
 
         XCTAssertTrue(source.contains("TodayAgendaView("))
-        XCTAssertTrue(source.contains("meetings: meetings(for: destination)"))
+        XCTAssertTrue(source.contains("meetings: destination == .today ? viewModel.meetings : meetings(for: destination)"))
         XCTAssertTrue(source.contains("calendar.isDate(meetingDate, inSameDayAs: now)"))
         XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .weekOfYear)"))
         XCTAssertTrue(source.contains("calendar.isDate(meetingDate, equalTo: now, toGranularity: .yearForWeekOfYear)"))
@@ -94,6 +94,21 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("Button(\"Save\")"))
         XCTAssertTrue(source.contains("Button(\"Cancel\")"))
         XCTAssertTrue(source.contains("Save / Discard / Cancel"))
+    }
+
+    func testTodayAgendaRestoresSingleFeedSections() throws {
+        let source = try appSource(named: "TodayAgendaView.swift")
+
+        XCTAssertTrue(source.contains("AgendaFeedSection(title: \"Today\""))
+        XCTAssertTrue(source.contains("AgendaFeedSection(title: \"Recent\""))
+        XCTAssertTrue(source.contains("recentGroups"))
+        XCTAssertTrue(source.contains("recentHistoryDays"))
+        XCTAssertTrue(source.contains("RecentAgendaMeetingCard"))
+        XCTAssertTrue(source.contains("Meeting schedule and metadata"))
+        XCTAssertTrue(source.contains("let selected = editableMeetings.first(where: { $0.id == selectedMeetingID })"))
+        XCTAssertTrue(source.contains("Summary ready"))
+        XCTAssertTrue(source.contains("Transcript ready"))
+        XCTAssertTrue(source.contains("Artifacts pending"))
     }
 
     func testTodayAgendaRefreshesCleanDraftWhenSelectedMeetingRecordChanges() throws {

--- a/docs/mistakes/2026-04-29T10-39-45Z.md
+++ b/docs/mistakes/2026-04-29T10-39-45Z.md
@@ -1,0 +1,13 @@
+# [95] Keep editor selection scoped when widening view input
+
+**Date**: 2026-04-29
+**Category**: logic-error
+
+### What went wrong
+Passing all meetings into `TodayAgendaView` restored the recent feed, but initially allowed the agenda editor to reuse a selected meeting from another sidebar bucket.
+
+### Correct approach
+When a view receives a wider collection for read-only context, keep editable selection scoped to the subset the editor is meant to mutate.
+
+### How to avoid
+After widening view input, audit every selection lookup and separate scan-only records from editable records.

--- a/docs/superpowers/plans/2026-04-29-agenda-single-feed-reimplementation.md
+++ b/docs/superpowers/plans/2026-04-29-agenda-single-feed-reimplementation.md
@@ -1,0 +1,252 @@
+# Agenda Single Feed Reimplementation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the #39 agenda single-feed experience inside the current `Today` main region without regressing `Today / This Week / History` navigation.
+
+**Architecture:** `MainWindowView` keeps the current `NavigationSplitView` and sidebar buckets, but passes all meetings to `TodayAgendaView` for the `Today` detail pane. `TodayAgendaView` partitions meetings into today and recent feed sections, preserves agenda editing and actions, and adds recent meeting cards with status/artifact chips.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Package Manager, XCTest source-layout guards.
+
+---
+
+### Task 1: Add Layout Guards For The Reimplemented Feed
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Update the bucket routing test expectation**
+
+Change the assertion in `testMeetingBucketsUseCalendarBoundaries` from:
+
+```swift
+XCTAssertTrue(source.contains("meetings: meetings(for: .today)"))
+```
+
+to:
+
+```swift
+XCTAssertTrue(source.contains("meetings: viewModel.meetings"))
+```
+
+- [ ] **Step 2: Add a feed-section layout test**
+
+Add this test after `testTodayAgendaViewDefinesAgendaRowsAndExplicitEditorSaveCancel`:
+
+```swift
+func testTodayAgendaRestoresSingleFeedSections() throws {
+    let source = try appSource(named: "TodayAgendaView.swift")
+
+    XCTAssertTrue(source.contains("AgendaFeedSection(title: \"Today\""))
+    XCTAssertTrue(source.contains("AgendaFeedSection(title: \"Recent\""))
+    XCTAssertTrue(source.contains("recentGroups"))
+    XCTAssertTrue(source.contains("recentHistoryDays"))
+    XCTAssertTrue(source.contains("RecentAgendaMeetingCard"))
+    XCTAssertTrue(source.contains("Meeting schedule and metadata"))
+    XCTAssertTrue(source.contains("Summary ready"))
+    XCTAssertTrue(source.contains("Transcript ready"))
+    XCTAssertTrue(source.contains("Artifacts pending"))
+}
+```
+
+- [ ] **Step 3: Run the focused layout tests and verify failure**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests
+```
+
+Expected: fails because `TodayAgendaView` has not yet added feed sections and `MainWindowView` still passes only `meetings(for: .today)`.
+
+### Task 2: Route Today Main Region With Full Meeting Context
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Pass all meetings to TodayAgendaView**
+
+Change the `TodayAgendaView` call in the `.today` destination from:
+
+```swift
+meetings: meetings(for: .today),
+```
+
+to:
+
+```swift
+meetings: viewModel.meetings,
+```
+
+- [ ] **Step 2: Run the focused routing test**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testMeetingBucketsUseCalendarBoundaries
+```
+
+Expected: passes after Task 1 and this change.
+
+### Task 3: Implement Today And Recent Feed Sections
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/TodayAgendaView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Add recent feed constants and groups**
+
+Inside `TodayAgendaView`, add:
+
+```swift
+private let recentHistoryDays = 7
+```
+
+Add computed properties:
+
+```swift
+private var recentGroups: [(Date, [MeetingRecord])] {
+    let calendar = Calendar.current
+    let startOfToday = calendar.startOfDay(for: Date())
+    let recentHistoryStart = calendar.date(byAdding: .day, value: -recentHistoryDays, to: startOfToday) ?? startOfToday
+    let recentMeetings = meetings.filter { meeting in
+        let day = calendar.startOfDay(for: displayDate(for: meeting))
+        return day >= recentHistoryStart && day < startOfToday
+    }
+    let grouped = Dictionary(grouping: recentMeetings) { meeting in
+        calendar.startOfDay(for: displayDate(for: meeting))
+    }
+    return grouped.keys.sorted(by: >).map { day in
+        let meetings = grouped[day]?.sorted { displayDate(for: $0) > displayDate(for: $1) } ?? []
+        return (day, meetings)
+    }
+}
+```
+
+- [ ] **Step 2: Replace `agendaList` populated branch with a feed**
+
+Keep the current empty-state behavior for no today meetings, but make the populated and mixed state render a scroll view containing `AgendaFeedSection(title: "Today", count: todayMeetings.count)` and a conditional `AgendaFeedSection(title: "Recent", count: recentGroups.reduce(0) { $0 + $1.1.count })`.
+
+Use `AgendaRowView` for today rows and `RecentAgendaMeetingCard` for recent rows.
+
+- [ ] **Step 3: Add `AgendaFeedSection`**
+
+Add a private generic view:
+
+```swift
+private struct AgendaFeedSection<Content: View>: View {
+    let title: String
+    let count: Int
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(title).commandCenterEyebrow()
+                CommandCenterChip(title: "\(count)")
+            }
+            content
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add `RecentAgendaMeetingCard`**
+
+Add a private view that mirrors #39 scan metadata:
+
+```swift
+private struct RecentAgendaMeetingCard: View {
+    let meeting: MeetingRecord
+    let isSelected: Bool
+    let open: () -> Void
+
+    var body: some View {
+        Button(action: open) {
+            CommandCenterPanel {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text(meeting.name)
+                            .font(CommandCenterTypography.sectionTitle)
+                            .foregroundStyle(CommandCenterPalette.text)
+                            .lineLimit(2)
+                        Spacer()
+                        Text(meeting.startedAt.formatted(date: .abbreviated, time: .shortened))
+                            .commandCenterMono()
+                    }
+                    HStack(spacing: 8) {
+                        CommandCenterChip(title: statusText, tint: statusTint, filled: true)
+                        CommandCenterChip(title: durationText)
+                        CommandCenterChip(title: meeting.speechLocaleIdentifier, tint: CommandCenterPalette.cyan)
+                        CommandCenterChip(title: artifactText, tint: artifactTint)
+                    }
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? CommandCenterPalette.primary : Color.clear, lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+Implement the helper properties with the same status, duration, and artifact logic from #39.
+
+- [ ] **Step 5: Run the focused feed test**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testTodayAgendaRestoresSingleFeedSections
+```
+
+Expected: passes.
+
+### Task 4: Verify Full Unit Suite And Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Sources/MeetingAgentApp/TodayAgendaView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Run required unit verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: all tests pass and coverage gate passes.
+
+- [ ] **Step 2: Review the issue acceptance criteria**
+
+Confirm:
+
+- `Today / This Week / History` are still present.
+- `TodayAgendaView` receives all meetings.
+- The `Today` main area contains `Today` and `Recent` feed sections.
+- Agenda editing, save/cancel, local create, start recording, open workspace, and open transcript markers remain.
+- Live workspace agenda context strip markers remain.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Sources/MeetingAgentApp/TodayAgendaView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: restore agenda single feed in today view (#95)"
+```
+
+Expected: commit succeeds.
+
+---
+
+## Self-Review
+
+- Spec coverage: all #95 acceptance criteria map to Tasks 1-4.
+- Placeholder scan: no placeholder tasks remain.
+- Type consistency: all referenced view and helper names are introduced before tests depend on them.

--- a/docs/superpowers/specs/2026-04-29-agenda-single-feed-reimplementation-design.md
+++ b/docs/superpowers/specs/2026-04-29-agenda-single-feed-reimplementation-design.md
@@ -1,0 +1,68 @@
+# Agenda Single Feed Reimplementation Design
+
+## Context
+
+Issue #95 tracks reimplementing the agenda single-feed experience from #39 after later navigation and workspace work replaced the original shape.
+
+The current app uses a `NavigationSplitView` with `Today`, `This Week`, `History`, and `Settings` destinations. `TodayAgendaView` already owns agenda rows, editing, local meeting creation, and start/open workspace actions. The missing behavior is the agenda-first main-region feed from #39: one scannable surface that starts with today's meetings and includes recent meeting context.
+
+## Decision
+
+Keep the current navigation model. Do not restore a separate top-level `Agenda` destination.
+
+Reimplement the #39 single-feed experience inside the main detail region shown for `Today`. The left sidebar remains `Today / This Week / History`, preserving #91. The right side becomes an agenda-first workspace with a feed-led layout rather than only a today list plus editor.
+
+## User Experience
+
+When `Today` is selected, the main region should show:
+
+- A header with `Agenda`, the current date, today's meeting count, and the live recording chip when one of the visible meetings is active.
+- A feed column with a `Today` section and a `Recent` section.
+- Today rows that preserve the current preparation workflow: scheduled time, title, goal, attendees, topics, live state, and primary action.
+- Recent cards that restore #39's scan value: meeting title, date/time, transcription status, duration, locale, and artifact readiness.
+- The existing agenda editor in the same main region so users can edit attendees, topics, scheduled time, and goal before opening the workspace.
+
+When no meetings exist today, the `Today` section still shows the current create-meeting empty state. The recent section should still be available below it when recent meetings exist.
+
+## Non-Goals
+
+- Do not remove `Today / This Week / History` navigation.
+- Do not revert `MainWindowView.swift` to the #39 `AgendaShellView` structure.
+- Do not change meeting persistence or recorder behavior.
+- Do not change live workspace transcript or insight behavior except where required for compilation.
+
+## Architecture
+
+`MainWindowView` continues to route `case .today` to `TodayAgendaView`, but it should pass enough meetings for `TodayAgendaView` to render both today's agenda and recent meeting context. Filtering for sidebar buckets remains in `MainWindowView`.
+
+`TodayAgendaView` becomes responsible for:
+
+- partitioning all supplied meetings into today and recent groups,
+- rendering the agenda feed sections,
+- preserving current agenda row actions and editor save/cancel behavior,
+- exposing small helper views for recent meeting cards and artifact/status chips.
+
+The recent feed should use local helpers inside `TodayAgendaView.swift` to keep the change scoped to the agenda surface. Shared app chrome stays in `MainWindowView.swift`.
+
+## Data Rules
+
+- Display date is `scheduledStartAt ?? startedAt`.
+- Today uses `Calendar.current.isDate(_:inSameDayAs:)`.
+- Recent includes meetings before today and within the last 7 days.
+- Today feed rows sort ascending by display date.
+- Recent groups sort newest day first, and meetings within each group sort newest display date first.
+- Transcript readiness uses the existing readable transcript check from `TodayAgendaView`.
+- Artifact readiness mirrors #39: summary ready wins over transcript ready, otherwise artifacts pending.
+
+## Testing
+
+Update `MainWindowViewLayoutTests.swift` with source-level layout guards that prove:
+
+- `MainWindowView` still declares `Today`, `This Week`, and `History`.
+- `MainWindowView` routes `TodayAgendaView` with the full `viewModel.meetings` collection so the main region can render both today and recent context.
+- `TodayAgendaView` defines agenda feed sections for `Today` and `Recent`.
+- `TodayAgendaView` preserves `AgendaRowView`, `AgendaEditorView`, `Open Workspace`, `Start Recording`, `Open Transcript`, `Create Meeting`, `Save`, and `Cancel`.
+- The agenda editor dirty-state protections from #77 still exist.
+- The live workspace agenda context strip still exists.
+
+Run `make test` before completion.


### PR DESCRIPTION
## Summary

Fixes #95

- Restores the agenda single-feed experience inside the current Today main region.
- Keeps the existing Today / This Week / History navigation model from #91.
- Preserves agenda editing, create/start/open actions, and live workspace agenda context behavior.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - passes full meeting context to the Today main region while keeping filtered buckets for This Week and History.
- `Sources/MeetingAgentApp/TodayAgendaView.swift` - adds Today and Recent feed sections, recent meeting cards, status/artifact chips, and scoped editor selection.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - adds layout guards for restored feed sections and the full-context Today route.
- `docs/superpowers/specs/2026-04-29-agenda-single-feed-reimplementation-design.md` - records the design decision.
- `docs/superpowers/plans/2026-04-29-agenda-single-feed-reimplementation.md` - records the implementation plan.
- `docs/mistakes/2026-04-29T10-39-45Z.md` - records the selection-scope lesson from review.

## Test plan

- [x] Build/lint: `swift test --filter MainWindowViewLayoutTests` passed
- [x] Unit tests: `make test` passed, 482 tests
- [x] Coverage: `make test` coverage gate passed, line 96.58%, method 95.03%
- [x] E2E/integration: skipped, no E2E convention for this macOS SwiftUI layout behavior
- [x] Code review: PASS after fixing editor selection scope when Today receives full meeting context
- [x] Manual verification: source review confirmed Today / This Week / History navigation remains and Today renders the restored feed markers
