### PR TITLE
feat: add meeting workspace back button

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -89,10 +89,11 @@ struct MainWindowView: View {
                             openWorkspace(from: destination, selecting: meeting)
                             return
                         }
+                        let returnDestination = destination.agendaReturnDestination
                         Task {
                             do {
                                 try await viewModel.startRecording(for: target, meetingID: meeting.id)
-                                workspaceReturnDestination = destination.agendaReturnDestination
+                                workspaceReturnDestination = returnDestination
                                 destination = .workspace
                             } catch {
                                 viewModel.setRecordingStartError(error)

--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -13,6 +13,7 @@ private enum MainWindowDestination: Hashable {
 struct MainWindowView: View {
     @ObservedObject var viewModel: MeetingAgentViewModel
     @State private var destination: MainWindowDestination = .today
+    @State private var workspaceReturnDestination: MainWindowDestination = .today
 
     var body: some View {
         NavigationSplitView {
@@ -81,18 +82,17 @@ struct MainWindowView: View {
                         viewModel.selectMeeting(meeting.id)
                     },
                     openWorkspace: { meeting in
-                        viewModel.selectMeeting(meeting.id)
-                        destination = .workspace
+                        openWorkspace(from: destination, selecting: meeting)
                     },
                     startRecording: { meeting in
                         guard let target = viewModel.pendingCandidate else {
-                            viewModel.selectMeeting(meeting.id)
-                            destination = .workspace
+                            openWorkspace(from: destination, selecting: meeting)
                             return
                         }
                         Task {
                             do {
                                 try await viewModel.startRecording(for: target, meetingID: meeting.id)
+                                workspaceReturnDestination = destination.agendaReturnDestination
                                 destination = .workspace
                             } catch {
                                 viewModel.setRecordingStartError(error)
@@ -116,6 +116,9 @@ struct MainWindowView: View {
                     isRecording: viewModel.isRecording,
                     liveCaptionTurns: viewModel.liveCaptionTurns,
                     recommendedQuestions: viewModel.recommendedQuestions,
+                    backToMeetings: {
+                        destination = workspaceReturnDestination
+                    },
                     stopRecording: {
                         Task {
                             do {
@@ -194,6 +197,12 @@ struct MainWindowView: View {
         } message: { target in
             Text("\(target.displayName) detected. Start recording?")
         }
+    }
+
+    private func openWorkspace(from destination: MainWindowDestination, selecting meeting: MeetingRecord) {
+        workspaceReturnDestination = destination.agendaReturnDestination
+        viewModel.selectMeeting(meeting.id)
+        self.destination = .workspace
     }
 
     private var sidebarHeader: some View {
@@ -322,6 +331,17 @@ struct MainWindowView: View {
 
 }
 
+private extension MainWindowDestination {
+    var agendaReturnDestination: MainWindowDestination {
+        switch self {
+        case .today, .thisWeek, .history:
+            return self
+        case .workspace, .settings:
+            return .today
+        }
+    }
+}
+
 private struct SidebarNavigationButtonStyle: ButtonStyle {
     let isSelected: Bool
 
@@ -346,6 +366,7 @@ private struct MeetingDetailView: View {
     let isRecording: Bool
     let liveCaptionTurns: [LiveCaptionTurn]
     let recommendedQuestions: [FollowUpQuestionSuggestion]
+    let backToMeetings: () -> Void
     let stopRecording: () -> Void
     let copySummary: (MeetingRecord) -> Void
     let exportTranscript: (MeetingRecord) -> Void
@@ -361,6 +382,7 @@ private struct MeetingDetailView: View {
             if let meeting {
                 MeetingCommandCenterView(
                     meeting: meeting,
+                    backToMeetings: backToMeetings,
                     pipelineDisplayName: pipelineDisplayName(for: speechConfiguration),
                     transcriptionLinkText: transcriptionLinkText(for: speechConfiguration),
                     transcriptionModelText: transcriptionModelText(for: speechConfiguration),
@@ -512,6 +534,7 @@ private struct MeetingDetailView: View {
 
 private struct MeetingCommandCenterView: View {
     let meeting: MeetingRecord
+    let backToMeetings: () -> Void
     let pipelineDisplayName: String
     let transcriptionLinkText: String
     let transcriptionModelText: String
@@ -537,6 +560,25 @@ private struct MeetingCommandCenterView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            HStack {
+                Button(action: backToMeetings) {
+                    Label("Back", systemImage: "chevron.left")
+                }
+                .buttonStyle(.plain)
+                .font(CommandCenterTypography.button)
+                .foregroundStyle(CommandCenterPalette.primary)
+
+                Spacer()
+            }
+            .padding(.horizontal, 22)
+            .padding(.vertical, 10)
+            .background(CommandCenterPalette.surface)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(CommandCenterPalette.border)
+                    .frame(height: 1)
+            }
+
             AgendaContextStrip(
                 meeting: meeting,
                 attendees: meeting.attendees,

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -135,6 +135,8 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("@State private var workspaceReturnDestination: MainWindowDestination = .today"))
         XCTAssertTrue(source.contains("private func openWorkspace(from destination: MainWindowDestination, selecting meeting: MeetingRecord)"))
         XCTAssertTrue(source.contains("workspaceReturnDestination = destination.agendaReturnDestination"))
+        XCTAssertTrue(source.contains("let returnDestination = destination.agendaReturnDestination"))
+        XCTAssertTrue(source.contains("workspaceReturnDestination = returnDestination"))
         XCTAssertTrue(source.contains("destination = .workspace"))
         XCTAssertTrue(source.contains("var agendaReturnDestination: MainWindowDestination"))
         XCTAssertTrue(source.contains("case .workspace, .settings:"))

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -129,6 +129,28 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("meeting.meetingGoal?.title"))
     }
 
+    func testMeetingWorkspaceBackButtonReturnsToSourceBucket() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("@State private var workspaceReturnDestination: MainWindowDestination = .today"))
+        XCTAssertTrue(source.contains("private func openWorkspace(from destination: MainWindowDestination, selecting meeting: MeetingRecord)"))
+        XCTAssertTrue(source.contains("workspaceReturnDestination = destination.agendaReturnDestination"))
+        XCTAssertTrue(source.contains("destination = .workspace"))
+        XCTAssertTrue(source.contains("var agendaReturnDestination: MainWindowDestination"))
+        XCTAssertTrue(source.contains("case .workspace, .settings:"))
+        XCTAssertTrue(source.contains("return .today"))
+    }
+
+    func testMeetingWorkspaceRendersBackButton() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("backToMeetings: {"))
+        XCTAssertTrue(source.contains("destination = workspaceReturnDestination"))
+        XCTAssertTrue(source.contains("let backToMeetings: () -> Void"))
+        XCTAssertTrue(source.contains("Button(action: backToMeetings)"))
+        XCTAssertTrue(source.contains("Label(\"Back\", systemImage: \"chevron.left\")"))
+    }
+
     func testCurrentPipelineMovesDebugDetailsBehindHoverIcon() throws {
         let source = try appSource(named: "MainWindowView.swift")
 

--- a/docs/mistakes/2026-04-29T11-42-31Z.md
+++ b/docs/mistakes/2026-04-29T11-42-31Z.md
@@ -1,0 +1,13 @@
+# [99] Capture navigation return state before async work
+
+**Date**: 2026-04-29
+**Category**: logic-error
+
+### What went wrong
+The first workspace back-button implementation read the current SwiftUI destination after awaiting recording startup, so a user navigation during startup could have changed the return target.
+
+### Correct approach
+Capture the intended return destination synchronously before starting async work, then apply the captured value after the awaited operation succeeds.
+
+### How to avoid
+When async UI actions depend on pre-action navigation state, store that state before the first await.

--- a/docs/superpowers/plans/2026-04-29-meeting-workspace-back-button.md
+++ b/docs/superpowers/plans/2026-04-29-meeting-workspace-back-button.md
@@ -1,0 +1,241 @@
+# Meeting Workspace Back Button Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Back button on the meeting workspace that returns users to the agenda bucket they came from, with Today as the fallback.
+
+**Architecture:** Keep navigation in `MainWindowView`'s existing explicit destination state. Store an optional agenda return destination before entering `.workspace`, pass a `backToMeetings` callback down to `MeetingDetailView`, and render the button in `MeetingCommandCenterView`.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout regression tests, macOS app target.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentApp/MainWindowView.swift`: add workspace return-state, route workspace entry through a helper, and render the Back button.
+- Modify `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`: add source-layout regression tests for the return state and Back button wiring.
+
+### Task 1: Add Failing Layout Coverage
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Add the regression tests**
+
+Append these tests near the other `MainWindowView.swift` layout tests:
+
+```swift
+func testMeetingWorkspaceBackButtonReturnsToSourceBucket() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("@State private var workspaceReturnDestination: MainWindowDestination = .today"))
+    XCTAssertTrue(source.contains("private func openWorkspace(from destination: MainWindowDestination, selecting meeting: MeetingRecord)"))
+    XCTAssertTrue(source.contains("workspaceReturnDestination = destination.agendaReturnDestination"))
+    XCTAssertTrue(source.contains("destination = .workspace"))
+    XCTAssertTrue(source.contains("private var agendaReturnDestination: MainWindowDestination"))
+    XCTAssertTrue(source.contains("case .workspace, .settings:"))
+    XCTAssertTrue(source.contains("return .today"))
+}
+
+func testMeetingWorkspaceRendersBackButton() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("backToMeetings: {"))
+    XCTAssertTrue(source.contains("destination = workspaceReturnDestination"))
+    XCTAssertTrue(source.contains("let backToMeetings: () -> Void"))
+    XCTAssertTrue(source.contains("Button(action: backToMeetings)"))
+    XCTAssertTrue(source.contains("Label(\"Back\", systemImage: \"chevron.left\")"))
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceBackButtonReturnsToSourceBucket`
+
+Expected: fails because `workspaceReturnDestination`, `openWorkspace(from:selecting:)`, and `agendaReturnDestination` do not exist yet.
+
+### Task 2: Implement Return Destination State And Routing
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Add return destination state**
+
+Change the `MainWindowView` state declarations to:
+
+```swift
+@State private var destination: MainWindowDestination = .today
+@State private var workspaceReturnDestination: MainWindowDestination = .today
+```
+
+- [ ] **Step 2: Route agenda workspace opens through a helper**
+
+Replace the `openWorkspace` closure inside `TodayAgendaView` with:
+
+```swift
+openWorkspace: { meeting in
+    openWorkspace(from: destination, selecting: meeting)
+},
+```
+
+Replace the no-pending-candidate branch of `startRecording` with:
+
+```swift
+guard let target = viewModel.pendingCandidate else {
+    openWorkspace(from: destination, selecting: meeting)
+    return
+}
+```
+
+Inside the successful async recording start path, set the return destination before entering the workspace:
+
+```swift
+try await viewModel.startRecording(for: target, meetingID: meeting.id)
+workspaceReturnDestination = destination.agendaReturnDestination
+destination = .workspace
+```
+
+- [ ] **Step 3: Pass Back callback into `MeetingDetailView`**
+
+Add this argument in the `.workspace` case:
+
+```swift
+backToMeetings: {
+    destination = workspaceReturnDestination
+},
+```
+
+- [ ] **Step 4: Add helper methods**
+
+Add these methods near the other `MainWindowView` private helpers:
+
+```swift
+private func openWorkspace(from destination: MainWindowDestination, selecting meeting: MeetingRecord) {
+    workspaceReturnDestination = destination.agendaReturnDestination
+    viewModel.selectMeeting(meeting.id)
+    self.destination = .workspace
+}
+```
+
+Add this extension after `MainWindowView`:
+
+```swift
+private extension MainWindowDestination {
+    var agendaReturnDestination: MainWindowDestination {
+        switch self {
+        case .today, .thisWeek, .history:
+            return self
+        case .workspace, .settings:
+            return .today
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the focused routing test**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceBackButtonReturnsToSourceBucket`
+
+Expected: passes.
+
+### Task 3: Render The Back Button
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Thread the callback through detail views**
+
+Add `let backToMeetings: () -> Void` to `MeetingDetailView` and pass it into `MeetingCommandCenterView`:
+
+```swift
+let backToMeetings: () -> Void
+```
+
+```swift
+MeetingCommandCenterView(
+    meeting: meeting,
+    backToMeetings: backToMeetings,
+    pipelineDisplayName: pipelineDisplayName(for: speechConfiguration),
+    ...
+)
+```
+
+Add the same stored property to `MeetingCommandCenterView`:
+
+```swift
+let backToMeetings: () -> Void
+```
+
+- [ ] **Step 2: Render the button above the agenda context strip**
+
+Change `MeetingCommandCenterView.body` to begin with this header before `AgendaContextStrip`:
+
+```swift
+VStack(spacing: 0) {
+    HStack {
+        Button(action: backToMeetings) {
+            Label("Back", systemImage: "chevron.left")
+        }
+        .buttonStyle(.plain)
+        .font(CommandCenterTypography.button)
+        .foregroundStyle(CommandCenterPalette.primary)
+
+        Spacer()
+    }
+    .padding(.horizontal, 22)
+    .padding(.vertical, 10)
+    .background(CommandCenterPalette.surface)
+    .overlay(alignment: .bottom) {
+        Rectangle()
+            .fill(CommandCenterPalette.border)
+            .frame(height: 1)
+    }
+
+    AgendaContextStrip(
+        meeting: meeting,
+        attendees: meeting.attendees,
+        topics: meeting.agendaTopics,
+        goalTitle: meeting.meetingGoal?.title
+    )
+```
+
+- [ ] **Step 3: Run the focused Back button test**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceRendersBackButton`
+
+Expected: passes.
+
+### Task 4: Full Verification And Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+
+Expected: all tests pass and coverage command completes.
+
+- [ ] **Step 2: Inspect diff**
+
+Run: `git diff -- Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+Expected: diff only contains the source-return state, Back button, and focused tests.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: add meeting workspace back button (#99)"
+```
+
+Expected: commit succeeds.
+
+## Self-Review
+
+- Spec coverage: return-to-source bucket, Today fallback, visible chevron Back button, unchanged persistence, and source-layout tests are all covered by Tasks 1-4.
+- Placeholder scan: no placeholder steps remain.
+- Type consistency: `workspaceReturnDestination`, `agendaReturnDestination`, `openWorkspace(from:selecting:)`, and `backToMeetings` are named consistently across tests and implementation.

--- a/docs/superpowers/specs/2026-04-29-meeting-workspace-back-button-design.md
+++ b/docs/superpowers/specs/2026-04-29-meeting-workspace-back-button-design.md
@@ -1,0 +1,60 @@
+# Meeting Workspace Back Button Design
+
+## Context
+
+GitHub issue #99 requests a back button on the meeting page. In the current macOS prototype, `MainWindowView` owns a hand-written `MainWindowDestination` state. Agenda buckets (`Today`, `This Week`, and `History`) render `TodayAgendaView`; opening a meeting switches the destination to `.workspace`, where `MeetingDetailView` renders the meeting workspace.
+
+## User Intent
+
+Managers should be able to return from a meeting workspace to the meeting list context they came from. If they opened a meeting from `History`, Back should return to `History`; if they opened one from `Today`, Back should return to `Today`. Entry paths without an obvious source, such as the meeting-detected alert, should return to `Today`.
+
+## Selected Approach
+
+Add source-page memory in `MainWindowView`.
+
+- Store the most recent agenda bucket used to enter `.workspace`.
+- Update that source before switching to `.workspace` from agenda cards and recording actions.
+- Add a `backToMeetings` callback to `MeetingDetailView`.
+- Render a compact `chevron.left` Back button at the top of the workspace.
+- Invoke the callback to switch back to the stored agenda bucket, falling back to `Today`.
+
+## Alternatives Considered
+
+### Always Return To Today
+
+This is the smallest implementation, but it creates a poor flow when users inspect a historical meeting and return to an unrelated list.
+
+### Navigation Stack
+
+A full navigation stack would model history more generally, but the app currently uses explicit destination state instead of nested `NavigationLink` paths. Adding stack machinery for one button would increase complexity without improving the current workflow.
+
+## Requirements
+
+- The meeting workspace shows a visible Back button with a left-chevron icon.
+- Back returns to the agenda bucket used to open the current workspace.
+- If there is no stored source bucket, Back returns to `Today`.
+- Existing meeting selection, recording start, stop recording, export, retry transcription, summary, and speaker label behaviors remain unchanged.
+- The implementation stays inside the existing `MainWindowView` destination model.
+
+## Non-Requirements
+
+- No browser-style multi-step history.
+- No changes to meeting persistence.
+- No sidebar redesign.
+- No new keyboard shortcut.
+
+## Affected Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+## Testing
+
+Add focused layout/source regression coverage for:
+
+- `MeetingDetailView` accepting and invoking `backToMeetings`.
+- `MeetingCommandCenterView` rendering a Back button with `chevron.left`.
+- Agenda bucket and recording entry paths recording the return destination before switching to `.workspace`.
+- No-source workspace entry paths defaulting to `Today`.
+
+Run `make test` before completion.


### PR DESCRIPTION
## Summary

Fixes #99

- Adds a Back button to the meeting workspace.
- Returns users to the agenda bucket they used to open the workspace, falling back to Today.
- Captures the return target before async recording startup so later navigation cannot overwrite it.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - stores workspace return destination, routes workspace entry through a helper, and renders the Back button.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - adds source-layout regression tests for return routing and Back button rendering.
- `docs/superpowers/specs/2026-04-29-meeting-workspace-back-button-design.md` - records approved design.
- `docs/superpowers/plans/2026-04-29-meeting-workspace-back-button.md` - records implementation plan.
- `docs/mistakes/2026-04-29T11-42-31Z.md` - records async UI state lesson.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceBackButtonReturnsToSourceBucket` passed; `swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceRendersBackButton` passed; `make test` passed, 484 tests, coverage gate passed
- [x] E2E/integration: skipped, no E2E convention for this SwiftUI source-layout UI change
- [x] Code review: PASS after fixing async return-target capture
- [x] Manual verification: source review of workspace entry paths and Back callback wiring
