### PR TITLE
feat: edit meeting goals from detail view

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -121,6 +121,9 @@ struct MainWindowView: View {
                     backToMeetings: {
                         destination = workspaceReturnDestination
                     },
+                    saveAgenda: { meetingID, update in
+                        try viewModel.saveAgenda(for: meetingID, update: update)
+                    },
                     stopRecording: {
                         Task {
                             do {
@@ -394,6 +397,7 @@ private struct MeetingDetailView: View {
     let liveCaptionTurns: [LiveCaptionTurn]
     let recommendedQuestions: [FollowUpQuestionSuggestion]
     let backToMeetings: () -> Void
+    let saveAgenda: (UUID, MeetingAgendaUpdate) throws -> Void
     let stopRecording: () -> Void
     let copySummary: (MeetingRecord) -> Void
     let exportTranscript: (MeetingRecord) -> Void
@@ -424,6 +428,7 @@ private struct MeetingDetailView: View {
                     transcriptionStatusText: transcriptionStatusText(for: meeting),
                     summary: summary(for: meeting),
                     recommendedQuestions: recommendedQuestions,
+                    saveAgenda: saveAgenda,
                     stopRecording: stopRecording,
                     copySummary: { copySummary(meeting) },
                     exportTranscript: { exportTranscript(meeting) },
@@ -576,6 +581,7 @@ private struct MeetingCommandCenterView: View {
     let transcriptionStatusText: String
     let summary: MeetingSummary?
     let recommendedQuestions: [FollowUpQuestionSuggestion]
+    let saveAgenda: (UUID, MeetingAgendaUpdate) throws -> Void
     let stopRecording: () -> Void
     let copySummary: () -> Void
     let exportTranscript: () -> Void
@@ -584,74 +590,125 @@ private struct MeetingCommandCenterView: View {
     let exportVTT: () -> Void
     let retryTranscription: () -> Void
     let updateSpeakerLabel: (String, String) -> Void
+    @State private var editAgendaTarget: MeetingRecord?
+    @State private var draft = AgendaDraft()
+    @State private var agendaRecordBackedDraft = AgendaDraft()
+    @State private var agendaSaveError: String?
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button(action: backToMeetings) {
-                    Label("Back", systemImage: "chevron.left")
+        ZStack(alignment: .topTrailing) {
+            VStack(spacing: 0) {
+                HStack {
+                    Button(action: backToMeetings) {
+                        Label("Back", systemImage: "chevron.left")
+                    }
+                    .buttonStyle(.plain)
+                    .font(CommandCenterTypography.button)
+                    .foregroundStyle(CommandCenterPalette.primary)
+
+                    Spacer()
                 }
-                .buttonStyle(.plain)
-                .font(CommandCenterTypography.button)
-                .foregroundStyle(CommandCenterPalette.primary)
+                .padding(.horizontal, 22)
+                .padding(.vertical, 10)
+                .background(CommandCenterPalette.surface)
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(CommandCenterPalette.border)
+                        .frame(height: 1)
+                }
 
-                Spacer()
-            }
-            .padding(.horizontal, 22)
-            .padding(.vertical, 10)
-            .background(CommandCenterPalette.surface)
-            .overlay(alignment: .bottom) {
-                Rectangle()
-                    .fill(CommandCenterPalette.border)
-                    .frame(height: 1)
-            }
-
-            AgendaContextStrip(
-                meeting: meeting,
-                attendees: meeting.attendees,
-                topics: meeting.agendaTopics,
-                goalTitle: meeting.meetingGoal?.title
-            )
-
-            HStack(spacing: 0) {
-                TranscriptPaneView(
+                AgendaContextStrip(
                     meeting: meeting,
-                    pipelineDisplayName: pipelineDisplayName,
-                    transcriptionLinkText: transcriptionLinkText,
-                    transcriptionModelText: transcriptionModelText,
-                    preflightText: preflightText,
-                    actualTranscriptionSourceText: actualTranscriptionSourceText,
-                    statusText: statusText,
-                    isRecording: isRecording,
-                    sourceLocale: sourceLocale,
-                    targetLocale: targetLocale,
-                    liveCaptionTurns: liveCaptionTurns,
-                    transcriptText: transcriptText,
-                    transcriptionStatusText: transcriptionStatusText,
-                    stopRecording: stopRecording,
-                    retryTranscription: retryTranscription,
-                    updateSpeakerLabel: updateSpeakerLabel
+                    attendees: meeting.attendees,
+                    topics: meeting.agendaTopics,
+                    goalTitle: meeting.meetingGoal?.title,
+                    editAgenda: beginDetailAgendaEdit
                 )
-                .frame(minWidth: 520)
 
-                Divider()
-                    .overlay(CommandCenterPalette.border)
+                HStack(spacing: 0) {
+                    TranscriptPaneView(
+                        meeting: meeting,
+                        pipelineDisplayName: pipelineDisplayName,
+                        transcriptionLinkText: transcriptionLinkText,
+                        transcriptionModelText: transcriptionModelText,
+                        preflightText: preflightText,
+                        actualTranscriptionSourceText: actualTranscriptionSourceText,
+                        statusText: statusText,
+                        isRecording: isRecording,
+                        sourceLocale: sourceLocale,
+                        targetLocale: targetLocale,
+                        liveCaptionTurns: liveCaptionTurns,
+                        transcriptText: transcriptText,
+                        transcriptionStatusText: transcriptionStatusText,
+                        stopRecording: stopRecording,
+                        retryTranscription: retryTranscription,
+                        updateSpeakerLabel: updateSpeakerLabel
+                    )
+                    .frame(minWidth: 520)
 
-                InsightPaneView(
-                    meeting: meeting,
-                    isRecording: isRecording,
-                    summary: summary,
-                    recommendedQuestions: recommendedQuestions,
-                    copySummary: copySummary,
-                    exportTranscript: exportTranscript,
-                    exportMeetingData: exportMeetingData,
-                    exportSRT: exportSRT,
-                    exportVTT: exportVTT
+                    Divider()
+                        .overlay(CommandCenterPalette.border)
+
+                    InsightPaneView(
+                        meeting: meeting,
+                        isRecording: isRecording,
+                        summary: summary,
+                        recommendedQuestions: recommendedQuestions,
+                        copySummary: copySummary,
+                        exportTranscript: exportTranscript,
+                        exportMeetingData: exportMeetingData,
+                        exportSRT: exportSRT,
+                        exportVTT: exportVTT
+                    )
+                    .frame(minWidth: 360, idealWidth: 440, maxWidth: 520)
+                }
+            }
+
+            if editAgendaTarget != nil {
+                AgendaEditorView(
+                    meeting: editAgendaTarget,
+                    draft: $draft,
+                    saveError: agendaSaveError,
+                    save: saveDetailAgenda,
+                    cancel: cancelDetailAgendaEdit
                 )
-                .frame(minWidth: 360, idealWidth: 440, maxWidth: 520)
+                .frame(width: 360)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(CommandCenterPalette.border, lineWidth: 1)
+                )
+                .shadow(color: .black.opacity(0.24), radius: 18, x: 0, y: 12)
+                .padding(.top, 54)
+                .padding(.trailing, 18)
             }
         }
         .background(CommandCenterPalette.window)
+    }
+
+    private func beginDetailAgendaEdit() {
+        editAgendaTarget = meeting
+        draft = AgendaDraft(meeting: meeting)
+        agendaRecordBackedDraft = draft
+        agendaSaveError = nil
+    }
+
+    private func saveDetailAgenda() {
+        guard let meetingID = editAgendaTarget?.id else { return }
+        do {
+            try saveAgenda(meetingID, draft.update())
+            agendaRecordBackedDraft = draft
+            editAgendaTarget = nil
+            agendaSaveError = nil
+        } catch {
+            agendaSaveError = "Could not save agenda: \(error)"
+        }
+    }
+
+    private func cancelDetailAgendaEdit() {
+        draft = agendaRecordBackedDraft
+        editAgendaTarget = nil
+        agendaSaveError = nil
     }
 }
 
@@ -660,6 +717,7 @@ private struct AgendaContextStrip: View {
     let attendees: [MeetingAttendee]
     let topics: [MeetingAgendaTopic]
     let goalTitle: String?
+    let editAgenda: () -> Void
 
     var body: some View {
         HStack(spacing: 8) {
@@ -672,6 +730,10 @@ private struct AgendaContextStrip: View {
                 CommandCenterChip(title: "+\(topics.count - 3) topics")
             }
             Spacer()
+            Button(action: editAgenda) {
+                Label("Edit Agenda", systemImage: "square.and.pencil")
+            }
+            .buttonStyle(CommandCenterActionButtonStyle())
             if let scheduledStartAt = meeting.scheduledStartAt {
                 CommandCenterChip(title: scheduledStartAt.formatted(date: .omitted, time: .shortened))
             }

--- a/Sources/MeetingAgentApp/TodayAgendaView.swift
+++ b/Sources/MeetingAgentApp/TodayAgendaView.swift
@@ -547,7 +547,7 @@ private struct MeetingArtifactCard: View {
     }
 }
 
-private struct AgendaEditorView: View {
+struct AgendaEditorView: View {
     let meeting: MeetingRecord?
     @Binding var draft: AgendaDraft
     let saveError: String?
@@ -568,7 +568,7 @@ private struct AgendaEditorView: View {
                     Text("Selected Agenda")
                         .font(CommandCenterTypography.title)
                         .foregroundStyle(CommandCenterPalette.text)
-                    Text("Edit attendees, topics, time, and goal before opening the workspace.")
+                    Text("Edit attendees, topics, time, and goal for this meeting.")
                         .font(CommandCenterTypography.caption)
                         .foregroundStyle(CommandCenterPalette.secondaryText)
 
@@ -657,7 +657,7 @@ private struct AgendaEditorView: View {
     }
 }
 
-private struct AgendaDraft: Equatable {
+struct AgendaDraft: Equatable {
     var name = ""
     var attendeesText = ""
     var topicsText = ""

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -341,6 +341,20 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("actualTranscriptionSourceText(for: meeting)"))
     }
 
+    func testMeetingDetailAllowsEditingAgendaGoalThroughSaveAgenda() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("saveAgenda: { meetingID, update in"))
+        XCTAssertTrue(source.contains("editAgenda: beginDetailAgendaEdit"))
+        XCTAssertTrue(source.contains("editAgendaTarget = meeting"))
+        XCTAssertTrue(source.contains("AgendaEditorView("))
+        XCTAssertTrue(source.contains("try saveAgenda(meetingID, draft.update())"))
+        XCTAssertTrue(source.contains("Label(\"Edit Agenda\", systemImage: \"square.and.pencil\")"))
+
+        let agendaSource = try appSource(named: "TodayAgendaView.swift")
+        XCTAssertTrue(agendaSource.contains("labeledTextEditor(\"Meeting Goal\", text: $draft.goalText)"))
+    }
+
     func testMainWindowRemovesUnimplementedMeetingGoalDashboardStructure() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")

--- a/docs/mistakes/2026-04-29T12-16-35Z.md
+++ b/docs/mistakes/2026-04-29T12-16-35Z.md
@@ -1,0 +1,13 @@
+# [101] Audit reusable UI copy when sharing components
+
+**Date**: 2026-04-29
+**Category**: logic-error
+
+### What went wrong
+Reusing the agenda editor on the meeting detail page initially carried over copy that said the user was editing before opening the workspace, which was inaccurate after the workspace was already open.
+
+### Correct approach
+When a UI component moves to a second surface, make the shared copy context-neutral or inject context-specific copy from the caller.
+
+### How to avoid
+Before reusing a UI component, audit every visible string for assumptions about its original screen.

--- a/docs/superpowers/plans/2026-04-29-meeting-detail-goal-editing.md
+++ b/docs/superpowers/plans/2026-04-29-meeting-detail-goal-editing.md
@@ -1,0 +1,205 @@
+# Meeting Detail Goal Editing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users edit a meeting goal from the meeting detail page.
+
+**Architecture:** Reuse the existing agenda metadata save path from `MeetingAgentViewModel.saveAgenda(for:update:)`. `MeetingDetailView` passes a save closure into `MeetingCommandCenterView`, and the detail surface presents an agenda-style editor so goal changes persist with the same normalization and progress reset behavior as the agenda page.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Package Manager, XCTest.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentApp/MainWindowView.swift` to add the detail-page edit state, editor presentation, and `saveAgenda` closure wiring.
+- Modify `Sources/MeetingAgentApp/TodayAgendaView.swift` only if `AgendaDraft` or `AgendaEditorView` visibility must be widened for reuse.
+- Modify `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` with source-level regression coverage for the new detail-page editing path.
+
+### Task 1: Detail Page Goal Editing UI
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write the failing layout test**
+
+Add this test near the existing meeting-detail layout tests in `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`:
+
+```swift
+func testMeetingDetailAllowsEditingAgendaGoalThroughSaveAgenda() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("saveAgenda: { meetingID, update in"))
+    XCTAssertTrue(source.contains("editAgenda: { editAgendaTarget = meeting }"))
+    XCTAssertTrue(source.contains("AgendaEditorView("))
+    XCTAssertTrue(source.contains("try saveAgenda(meetingID, draft.update())"))
+    XCTAssertTrue(source.contains("Label(\"Edit Agenda\", systemImage: \"square.and.pencil\")"))
+    XCTAssertTrue(source.contains("labeledTextEditor(\"Meeting Goal\", text: $draft.goalText)"))
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testMeetingDetailAllowsEditingAgendaGoalThroughSaveAgenda
+```
+
+Expected: FAIL because the detail page has no `editAgenda` action, no detail editor presentation, and no `saveAgenda` closure.
+
+- [ ] **Step 3: Wire `saveAgenda` into `MeetingDetailView`**
+
+In `Sources/MeetingAgentApp/MainWindowView.swift`, update the `MeetingDetailView` call from the app detail switch to pass the existing view-model save path:
+
+```swift
+saveAgenda: { meetingID, update in
+    try viewModel.saveAgenda(for: meetingID, update: update)
+},
+```
+
+Add the matching stored property to `MeetingDetailView`:
+
+```swift
+let saveAgenda: (UUID, MeetingAgendaUpdate) throws -> Void
+```
+
+Pass it through to `MeetingCommandCenterView`:
+
+```swift
+saveAgenda: saveAgenda,
+```
+
+- [ ] **Step 4: Add detail-page editor state and presentation**
+
+In `MeetingCommandCenterView`, add:
+
+```swift
+let saveAgenda: (UUID, MeetingAgendaUpdate) throws -> Void
+@State private var editAgendaTarget: MeetingRecord?
+@State private var agendaDraft = AgendaDraft()
+@State private var agendaRecordBackedDraft = AgendaDraft()
+@State private var agendaSaveError: String?
+```
+
+Wrap the existing root `VStack` in a `ZStack(alignment: .topTrailing)` and present a side editor when `editAgendaTarget` is non-nil:
+
+```swift
+if let editAgendaTarget {
+    AgendaEditorView(
+        meeting: editAgendaTarget,
+        draft: $agendaDraft,
+        saveError: agendaSaveError,
+        save: saveDetailAgenda,
+        cancel: cancelDetailAgendaEdit
+    )
+    .frame(width: 360)
+    .padding(.top, 54)
+    .padding(.trailing, 18)
+}
+```
+
+Add helpers inside `MeetingCommandCenterView`:
+
+```swift
+private func beginDetailAgendaEdit() {
+    editAgendaTarget = meeting
+    agendaDraft = AgendaDraft(meeting: meeting)
+    agendaRecordBackedDraft = agendaDraft
+    agendaSaveError = nil
+}
+
+private func saveDetailAgenda() {
+    guard let meetingID = editAgendaTarget?.id else { return }
+    do {
+        try saveAgenda(meetingID, agendaDraft.update())
+        agendaRecordBackedDraft = agendaDraft
+        editAgendaTarget = nil
+        agendaSaveError = nil
+    } catch {
+        agendaSaveError = "Could not save agenda: \(error)"
+    }
+}
+
+private func cancelDetailAgendaEdit() {
+    agendaDraft = agendaRecordBackedDraft
+    editAgendaTarget = nil
+    agendaSaveError = nil
+}
+```
+
+- [ ] **Step 5: Add the edit action to the agenda context strip**
+
+Update `AgendaContextStrip` to accept an edit closure:
+
+```swift
+let editAgenda: () -> Void
+```
+
+Render the action near the right side of the strip:
+
+```swift
+Button(action: editAgenda) {
+    Label("Edit Agenda", systemImage: "square.and.pencil")
+}
+.buttonStyle(CommandCenterSecondaryButtonStyle())
+```
+
+Pass it from `MeetingCommandCenterView`:
+
+```swift
+editAgenda: beginDetailAgendaEdit
+```
+
+- [ ] **Step 6: Widen editor helper visibility only as needed**
+
+If the compiler reports `AgendaEditorView` or `AgendaDraft` is inaccessible from `MainWindowView.swift`, change their declarations in `Sources/MeetingAgentApp/TodayAgendaView.swift` from `private` to internal:
+
+```swift
+struct AgendaEditorView: View {
+```
+
+```swift
+struct AgendaDraft: Equatable {
+```
+
+Keep nested helper methods private unless the compiler requires otherwise.
+
+- [ ] **Step 7: Run focused tests and build**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testMeetingDetailAllowsEditingAgendaGoalThroughSaveAgenda
+swift build --product MeetingAgentApp
+```
+
+Expected: both commands pass.
+
+- [ ] **Step 8: Run full verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: unit tests pass and coverage check succeeds.
+
+- [ ] **Step 9: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Sources/MeetingAgentApp/TodayAgendaView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: edit meeting goals from detail view (#101)"
+```
+
+If `TodayAgendaView.swift` was not changed, omit it from `git add`.
+
+## Self-Review
+
+- Spec coverage: The plan adds a detail-page edit action, saves through existing agenda persistence, preserves metadata through `AgendaDraft(meeting:)`, updates visible state through existing view-model publication, and keeps recording/transcript/export controls untouched.
+- Placeholder scan: No placeholders remain.
+- Type consistency: The plan uses existing `MeetingAgendaUpdate`, `AgendaDraft`, `AgendaEditorView`, and `saveAgenda(for:update:)` names.

--- a/docs/superpowers/specs/2026-04-29-meeting-detail-goal-editing-design.md
+++ b/docs/superpowers/specs/2026-04-29-meeting-detail-goal-editing-design.md
@@ -1,0 +1,43 @@
+# Meeting Detail Goal Editing Design
+
+## Issue
+
+GitHub issue #101 asks for the meeting detail page to allow editing the meeting goal.
+
+## Context
+
+Meeting goals already exist on `MeetingRecord` and are persisted through `MeetingAgentViewModel.saveAgenda(for:update:)`. The agenda page has a full `AgendaEditorView` that can edit the meeting name, attendees, topics, schedule, and goal. The meeting detail page currently only renders the goal as a read-only chip in `AgendaContextStrip`.
+
+## Selected Approach
+
+Reuse the agenda editor pattern from the agenda page inside the meeting detail page.
+
+The meeting detail view will expose an edit action from the agenda context strip. Activating it will show the same agenda-style editing surface for the selected meeting, including the goal field. Saving will call the existing `saveAgenda(for:update:)` path so metadata normalization, persistence, selected-meeting refresh, progress-state reset, and coordinator reconfiguration remain centralized.
+
+## Requirements
+
+- The meeting detail page must expose an obvious way to edit the selected meeting's goal.
+- The editing flow must preserve existing meeting metadata unless the user changes it.
+- Saving an empty goal must clear the persisted goal, matching existing agenda normalization.
+- The detail page must update after save so the goal chip reflects the new goal.
+- Existing recording, transcript, export, and speaker-edit controls must remain available.
+
+## Non-Requirements
+
+- No new goal objective, required-question, expected-decision, or key-term editor is required.
+- No new persistence format is required.
+- No live meeting progress algorithm changes are required beyond the existing reset triggered by `saveAgenda`.
+
+## Affected Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+- `Sources/MeetingAgentApp/TodayAgendaView.swift` if small visibility changes are needed to reuse editor helpers
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` if a focused save/update regression is missing
+
+## Testing
+
+- Add layout/source coverage that `MeetingDetailView` wires a goal or agenda edit action into the detail page.
+- Add coverage that the detail page save path calls `saveAgenda` instead of a separate one-off goal persistence path.
+- Reuse existing view-model tests for agenda normalization and persistence where sufficient; add a focused regression only if the current tests do not cover clearing/updating a selected meeting goal via `saveAgenda`.
+- Run `make test` as the final verification command.


### PR DESCRIPTION
## Summary

Fixes #101

- Adds an Edit Agenda action to the meeting detail context strip so users can edit the meeting goal from the detail page.
- Reuses the existing agenda editor and `saveAgenda(for:update:)` persistence path to preserve normalization and progress reset behavior.
- Records design, implementation plan, and a reusable lesson about shared UI copy.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - wires detail-page agenda editing and save handling.
- `Sources/MeetingAgentApp/TodayAgendaView.swift` - makes agenda editor/draft reusable in the app target and updates shared editor copy.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - adds regression coverage for detail-page goal editing wiring.
- `docs/superpowers/specs/2026-04-29-meeting-detail-goal-editing-design.md` - design artifact.
- `docs/superpowers/plans/2026-04-29-meeting-detail-goal-editing.md` - implementation plan.
- `docs/mistakes/2026-04-29T12-16-35Z.md` - lesson learned.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testMeetingDetailAllowsEditingAgendaGoalThroughSaveAgenda` passed
- [x] Full verification: `make test` passed, coverage gate passed
- [x] Code review: PASS after fixing shared editor copy
- [ ] Manual verification: not run; UI wiring covered by source-level regression and app build