### PR TITLE
feat: consolidate meeting workspace actions

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -598,16 +598,7 @@ private struct MeetingCommandCenterView: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             VStack(spacing: 0) {
-                HStack {
-                    Button(action: backToMeetings) {
-                        Label("Back", systemImage: "chevron.left")
-                    }
-                    .buttonStyle(.plain)
-                    .font(CommandCenterTypography.button)
-                    .foregroundStyle(CommandCenterPalette.primary)
-
-                    Spacer()
-                }
+                topCommandRow
                 .padding(.horizontal, 22)
                 .padding(.vertical, 10)
                 .background(CommandCenterPalette.surface)
@@ -640,8 +631,6 @@ private struct MeetingCommandCenterView: View {
                         liveCaptionTurns: liveCaptionTurns,
                         transcriptText: transcriptText,
                         transcriptionStatusText: transcriptionStatusText,
-                        stopRecording: stopRecording,
-                        retryTranscription: retryTranscription,
                         updateSpeakerLabel: updateSpeakerLabel
                     )
                     .frame(minWidth: 520)
@@ -653,12 +642,7 @@ private struct MeetingCommandCenterView: View {
                         meeting: meeting,
                         isRecording: isRecording,
                         summary: summary,
-                        recommendedQuestions: recommendedQuestions,
-                        copySummary: copySummary,
-                        exportTranscript: exportTranscript,
-                        exportMeetingData: exportMeetingData,
-                        exportSRT: exportSRT,
-                        exportVTT: exportVTT
+                        recommendedQuestions: recommendedQuestions
                     )
                     .frame(minWidth: 360, idealWidth: 440, maxWidth: 520)
                 }
@@ -672,18 +656,98 @@ private struct MeetingCommandCenterView: View {
                     save: saveDetailAgenda,
                     cancel: cancelDetailAgendaEdit
                 )
-                .frame(width: 360)
-                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(CommandCenterPalette.border, lineWidth: 1)
-                )
                 .shadow(color: .black.opacity(0.24), radius: 18, x: 0, y: 12)
                 .padding(.top, 54)
                 .padding(.trailing, 18)
             }
         }
         .background(CommandCenterPalette.window)
+    }
+
+    private var topCommandRow: some View {
+        HStack(spacing: 12) {
+            Button(action: backToMeetings) {
+                Label("Back", systemImage: "chevron.left")
+            }
+            .buttonStyle(.plain)
+            .font(CommandCenterTypography.button)
+            .foregroundStyle(CommandCenterPalette.primary)
+
+            Spacer()
+
+            recordingCommand
+            overflowMenu
+        }
+    }
+
+    @ViewBuilder
+    private var recordingCommand: some View {
+        if isRecording {
+            Button {
+                stopRecording()
+            } label: {
+                Label("Stop Recording", systemImage: "stop.fill")
+            }
+            .buttonStyle(CommandCenterActionButtonStyle(variant: .danger))
+        } else {
+            Button {
+            } label: {
+                Label("Record", systemImage: "record.circle")
+            }
+            .buttonStyle(CommandCenterActionButtonStyle())
+            .disabled(true)
+            .help("Recording can be started from an agenda item.")
+        }
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            Button {
+                copySummary()
+            } label: {
+                Label("Copy Summary", systemImage: "doc.on.clipboard")
+            }
+            .disabled(isRecording || meeting.summaryURL == nil)
+
+            Button {
+                exportTranscript()
+            } label: {
+                Label("Export Transcript", systemImage: "doc.text")
+            }
+            .disabled(isRecording || meeting.transcriptURL == nil)
+
+            Button {
+                exportMeetingData()
+            } label: {
+                Label("Export Meeting JSON", systemImage: "curlybraces")
+            }
+
+            Button {
+                exportSRT()
+            } label: {
+                Label("Export SRT", systemImage: "captions.bubble")
+            }
+
+            Button {
+                exportVTT()
+            } label: {
+                Label("Export VTT", systemImage: "captions.bubble")
+            }
+
+            Divider()
+
+            Button {
+                retryTranscription()
+            } label: {
+                Label("Retry Transcription", systemImage: "arrow.clockwise")
+            }
+            .disabled(isRecording || meeting.audioURL == nil)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .accessibilityLabel("Meeting actions")
+        }
+        .buttonStyle(CommandCenterIconButtonStyle())
+        .help("Meeting actions")
     }
 
     private func beginDetailAgendaEdit() {
@@ -768,8 +832,6 @@ private struct TranscriptPaneView: View {
     let liveCaptionTurns: [LiveCaptionTurn]
     let transcriptText: String
     let transcriptionStatusText: String
-    let stopRecording: () -> Void
-    let retryTranscription: () -> Void
     let updateSpeakerLabel: (String, String) -> Void
     @State private var speakerEditTarget: LiveCaptionTurn?
     @State private var speakerLabelDraft = ""
@@ -782,7 +844,6 @@ private struct TranscriptPaneView: View {
                 CommandCenterScrollView(content: {
                     VStack(alignment: .leading, spacing: 22) {
                         metadata
-                        recordingActions
                         failureReason
                         UnifiedTranscriptView(
                             turns: liveCaptionTurns,
@@ -892,22 +953,6 @@ private struct TranscriptPaneView: View {
                     CommandCenterChip(title: "Ended \(endedAt.formatted(date: .omitted, time: .shortened))")
                 }
             }
-        }
-    }
-
-    private var recordingActions: some View {
-        HStack(spacing: 10) {
-            Button("Stop Recording") {
-                stopRecording()
-            }
-            .buttonStyle(CommandCenterActionButtonStyle(variant: .danger))
-            .disabled(!isRecording)
-
-            Button("Retry Transcription") {
-                retryTranscription()
-            }
-            .buttonStyle(CommandCenterActionButtonStyle())
-            .disabled(isRecording || meeting.audioURL == nil)
         }
     }
 
@@ -1040,11 +1085,6 @@ private struct InsightPaneView: View {
     let isRecording: Bool
     let summary: MeetingSummary?
     let recommendedQuestions: [FollowUpQuestionSuggestion]
-    let copySummary: () -> Void
-    let exportTranscript: () -> Void
-    let exportMeetingData: () -> Void
-    let exportSRT: () -> Void
-    let exportVTT: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -1054,7 +1094,6 @@ private struct InsightPaneView: View {
                         RecommendedQuestionsPanel(questions: recommendedQuestions)
                     }
                     phaseSummary
-                    exports
                     summaryPanel
                 }
                 .padding(22)
@@ -1074,53 +1113,6 @@ private struct InsightPaneView: View {
                 HStack {
                     CommandCenterChip(title: isRecording ? "ACTIVE" : "RECORDED", tint: CommandCenterPalette.primary, filled: true)
                     CommandCenterChip(title: summary == nil ? "Summary pending" : "Summary ready", tint: summary == nil ? CommandCenterPalette.warning : CommandCenterPalette.primary)
-                }
-            }
-        }
-    }
-
-    private var exports: some View {
-        CommandCenterPanel {
-            VStack(alignment: .leading, spacing: 12) {
-                Text("Exports").commandCenterEyebrow()
-                HStack {
-                    Button {
-                        copySummary()
-                    } label: {
-                        Label("Copy Summary", systemImage: "doc.on.clipboard")
-                    }
-                    .buttonStyle(CommandCenterActionButtonStyle())
-                    .disabled(isRecording || meeting.summaryURL == nil)
-
-                    Button {
-                        exportTranscript()
-                    } label: {
-                        Label("Transcript", systemImage: "doc.text")
-                    }
-                    .buttonStyle(CommandCenterActionButtonStyle())
-                    .disabled(isRecording || meeting.transcriptURL == nil)
-                }
-                HStack {
-                    Button {
-                        exportMeetingData()
-                    } label: {
-                        Label("Meeting JSON", systemImage: "curlybraces")
-                    }
-                    .buttonStyle(CommandCenterActionButtonStyle())
-
-                    Button {
-                        exportSRT()
-                    } label: {
-                        Label("SRT", systemImage: "captions.bubble")
-                    }
-                    .buttonStyle(CommandCenterActionButtonStyle())
-
-                    Button {
-                        exportVTT()
-                    } label: {
-                        Label("VTT", systemImage: "captions.bubble")
-                    }
-                    .buttonStyle(CommandCenterActionButtonStyle())
                 }
             }
         }

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -173,11 +173,11 @@ final class MainWindowViewLayoutTests: XCTestCase {
         guard let metadataRange = source.range(of: "private var metadata: some View") else {
             return XCTFail("Pipeline metadata section is missing")
         }
-        guard let actionsRange = source.range(of: "private var recordingActions: some View", range: metadataRange.upperBound..<source.endIndex) else {
-            return XCTFail("Recording actions section is missing")
+        guard let failureReasonRange = source.range(of: "private var failureReason: some View", range: metadataRange.upperBound..<source.endIndex) else {
+            return XCTFail("Pipeline metadata boundary is missing")
         }
 
-        let metadataSource = source[metadataRange.lowerBound..<actionsRange.lowerBound]
+        let metadataSource = source[metadataRange.lowerBound..<failureReasonRange.lowerBound]
         XCTAssertTrue(metadataSource.contains("Image(systemName: \"exclamationmark.circle\")"))
         XCTAssertTrue(metadataSource.contains(".help(pipelineDebugHelpText)"))
         XCTAssertTrue(metadataSource.contains("CommandCenterChip(title: transcriptionStatusText"))
@@ -196,27 +196,52 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("caption_translation_attached"))
     }
 
-    func testRecordingAndRetryButtonsShareActionRow() throws {
+    func testMeetingWorkspaceConsolidatesActionsIntoTopRow() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        guard let stopRange = source.range(of: "Button(\"Stop Recording\")") else {
-            return XCTFail("Stop Recording button is missing")
+        guard let workspaceRange = source.range(of: "private struct MeetingCommandCenterView") else {
+            return XCTFail("Meeting workspace view is missing")
         }
-        guard let retryRange = source.range(of: "Button(\"Retry Transcription\")") else {
-            return XCTFail("Retry Transcription button is missing")
+        guard let agendaRange = source.range(of: "private struct AgendaContextStrip", range: workspaceRange.upperBound..<source.endIndex) else {
+            return XCTFail("Meeting workspace boundary is missing")
         }
-        XCTAssertLessThan(stopRange.lowerBound, retryRange.lowerBound)
+        let workspaceSource = source[workspaceRange.lowerBound..<agendaRange.lowerBound]
 
-        let precedingSource = source[..<stopRange.lowerBound]
-        guard let actionRowStart = precedingSource.range(of: "HStack", options: .backwards) else {
-            return XCTFail("Recording action row is missing")
-        }
+        XCTAssertTrue(workspaceSource.contains("Label(\"Back\", systemImage: \"chevron.left\")"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Stop Recording\", systemImage: \"stop.fill\")"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Record\", systemImage: \"record.circle\")"))
+        XCTAssertTrue(workspaceSource.contains("Menu {"))
+        XCTAssertTrue(workspaceSource.contains("Image(systemName: \"ellipsis.circle\")"))
+        XCTAssertTrue(workspaceSource.contains(".accessibilityLabel(\"Meeting actions\")"))
+        XCTAssertTrue(workspaceSource.contains(".help(\"Meeting actions\")"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Copy Summary\", systemImage: \"doc.on.clipboard\")"))
+        XCTAssertTrue(workspaceSource.contains(".disabled(isRecording || meeting.summaryURL == nil)"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Export Transcript\", systemImage: \"doc.text\")"))
+        XCTAssertTrue(workspaceSource.contains(".disabled(isRecording || meeting.transcriptURL == nil)"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Export Meeting JSON\", systemImage: \"curlybraces\")"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Export SRT\", systemImage: \"captions.bubble\")"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Export VTT\", systemImage: \"captions.bubble\")"))
+        XCTAssertTrue(workspaceSource.contains("Label(\"Retry Transcription\", systemImage: \"arrow.clockwise\")"))
+        XCTAssertTrue(workspaceSource.contains(".disabled(isRecording || meeting.audioURL == nil)"))
 
-        let actionRow = source[actionRowStart.lowerBound..<retryRange.upperBound]
-        XCTAssertTrue(actionRow.contains("Button(\"Stop Recording\")"))
-        XCTAssertTrue(actionRow.contains("Button(\"Retry Transcription\")"))
+        guard let transcriptRange = source.range(of: "private struct TranscriptPaneView") else {
+            return XCTFail("Transcript pane is missing")
+        }
+        guard let insightRange = source.range(of: "private struct InsightPaneView", range: transcriptRange.upperBound..<source.endIndex) else {
+            return XCTFail("Insight pane boundary is missing")
+        }
+        let transcriptSource = source[transcriptRange.lowerBound..<insightRange.lowerBound]
+        XCTAssertFalse(transcriptSource.contains("private var recordingActions: some View"))
+        XCTAssertFalse(transcriptSource.contains("Button(\"Retry Transcription\")"))
+
+        guard let nextViewRange = source.range(of: "private struct RecommendedQuestionsPanel", range: insightRange.upperBound..<source.endIndex) else {
+            return XCTFail("Insight pane boundary is missing")
+        }
+        let insightSource = source[insightRange.lowerBound..<nextViewRange.lowerBound]
+        XCTAssertFalse(insightSource.contains("private var exports: some View"))
+        XCTAssertFalse(insightSource.contains("Text(\"Exports\")"))
     }
 
     func testSummaryDownloadAndRegenerateControlsAreRemoved() throws {
@@ -458,15 +483,15 @@ final class MainWindowViewLayoutTests: XCTestCase {
 """))
     }
 
-    func testExportsPanelExposesImplementedExportActionsOnly() throws {
+    func testActionMenuExposesImplementedExportActionsOnly() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
         XCTAssertTrue(source.contains("exportSRT"))
         XCTAssertTrue(source.contains("exportVTT"))
-        XCTAssertTrue(source.contains("Label(\"SRT\", systemImage: \"captions.bubble\")"))
-        XCTAssertTrue(source.contains("Label(\"VTT\", systemImage: \"captions.bubble\")"))
+        XCTAssertTrue(source.contains("Label(\"Export SRT\", systemImage: \"captions.bubble\")"))
+        XCTAssertTrue(source.contains("Label(\"Export VTT\", systemImage: \"captions.bubble\")"))
         XCTAssertTrue(source.contains("viewModel.exportSubtitles(for: meeting.id, format: .srt"))
         XCTAssertTrue(source.contains("viewModel.exportSubtitles(for: meeting.id, format: .vtt"))
         XCTAssertFalse(source.contains("exportReadinessReport"))

--- a/docs/superpowers/plans/2026-04-29-meeting-action-row.md
+++ b/docs/superpowers/plans/2026-04-29-meeting-action-row.md
@@ -1,0 +1,193 @@
+# Meeting Action Row Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate meeting workspace actions into the top Back row and move export/debug actions behind an overflow menu.
+
+**Architecture:** Keep the existing `MeetingCommandCenterView` as the owner of page-level workspace actions. Move recording, retry transcription, and export callbacks up to that view's top command row, then simplify `TranscriptPaneView` and `InsightPaneView` so they only render transcript and insight content.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout tests, macOS 14.2+ Swift Package.
+
+---
+
+### Task 1: Add Layout Regression Coverage
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Replace the old recording/retry row test**
+
+Replace `testRecordingAndRetryButtonsShareActionRow` with a test that reads `MainWindowView.swift`, slices `MeetingCommandCenterView`, and asserts the command row contains `Label("Back", systemImage: "chevron.left")`, `Label("Stop Recording", systemImage: "stop.fill")`, `Label("Record", systemImage: "record.circle")`, `Menu`, and `Image(systemName: "ellipsis.circle")`.
+
+- [ ] **Step 2: Add assertions for removed visible surfaces**
+
+In the same test or a second focused test, assert that `TranscriptPaneView` no longer contains `private var recordingActions: some View`, and that `InsightPaneView` no longer contains `private var exports: some View` or `Text("Exports")`.
+
+- [ ] **Step 3: Add assertions for overflow menu actions**
+
+Assert that `MeetingCommandCenterView` contains menu labels for `Copy Summary`, `Export Transcript`, `Export Meeting JSON`, `Export SRT`, `Export VTT`, and `Retry Transcription`, plus disabled conditions for summary, transcript, retry, and recording-sensitive actions.
+
+- [ ] **Step 4: Run focused test and confirm failure**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceConsolidatesActionsIntoTopRow
+```
+
+Expected: fails until `MainWindowView.swift` is updated.
+
+### Task 2: Move Actions Into Top Command Row
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Extend `MeetingCommandCenterView` top row**
+
+Change the first `HStack` in `MeetingCommandCenterView.body` so it calls a helper such as `topCommandRow`.
+
+The helper should render:
+
+```swift
+Button(action: backToMeetings) {
+    Label("Back", systemImage: "chevron.left")
+}
+.buttonStyle(.plain)
+.font(CommandCenterTypography.button)
+.foregroundStyle(CommandCenterPalette.primary)
+
+Spacer()
+
+recordingCommand
+overflowMenu
+```
+
+- [ ] **Step 2: Add `recordingCommand`**
+
+Add a `@ViewBuilder private var recordingCommand: some View` inside `MeetingCommandCenterView`.
+
+When `isRecording` is true, render:
+
+```swift
+Button {
+    stopRecording()
+} label: {
+    Label("Stop Recording", systemImage: "stop.fill")
+}
+.buttonStyle(CommandCenterActionButtonStyle(variant: .danger))
+```
+
+When `isRecording` is false, render:
+
+```swift
+Button {
+} label: {
+    Label("Record", systemImage: "record.circle")
+}
+.buttonStyle(CommandCenterActionButtonStyle())
+.disabled(true)
+.help("Recording can be started from an agenda item.")
+```
+
+- [ ] **Step 3: Add `overflowMenu`**
+
+Add a `private var overflowMenu: some View` using `Menu`.
+
+The menu content should call existing closures:
+
+```swift
+Button { copySummary() } label: {
+    Label("Copy Summary", systemImage: "doc.on.clipboard")
+}
+.disabled(isRecording || meeting.summaryURL == nil)
+
+Button { exportTranscript() } label: {
+    Label("Export Transcript", systemImage: "doc.text")
+}
+.disabled(isRecording || meeting.transcriptURL == nil)
+
+Button { exportMeetingData() } label: {
+    Label("Export Meeting JSON", systemImage: "curlybraces")
+}
+
+Button { exportSRT() } label: {
+    Label("Export SRT", systemImage: "captions.bubble")
+}
+
+Button { exportVTT() } label: {
+    Label("Export VTT", systemImage: "captions.bubble")
+}
+
+Divider()
+
+Button { retryTranscription() } label: {
+    Label("Retry Transcription", systemImage: "arrow.clockwise")
+}
+.disabled(isRecording || meeting.audioURL == nil)
+```
+
+Use this menu label:
+
+```swift
+Image(systemName: "ellipsis.circle")
+    .accessibilityLabel("Meeting actions")
+```
+
+Apply `CommandCenterIconButtonStyle()` and `.help("Meeting actions")`.
+
+- [ ] **Step 4: Remove now-unused child callbacks**
+
+Stop passing `stopRecording` and `retryTranscription` into `TranscriptPaneView`. Remove those stored properties from `TranscriptPaneView`.
+
+Stop passing export closures into `InsightPaneView`. Keep `copySummary` only if the summary panel still needs it; otherwise remove it too.
+
+- [ ] **Step 5: Remove old visible action blocks**
+
+Delete `recordingActions` from `TranscriptPaneView` and remove the `recordingActions` call from the transcript scroll content.
+
+Delete `exports` from `InsightPaneView` and remove the `exports` call from its scroll content.
+
+### Task 3: Verify and Commit Implementation
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Run focused layout test**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceConsolidatesActionsIntoTopRow
+```
+
+Expected: passes.
+
+- [ ] **Step 2: Build app product**
+
+Run:
+
+```bash
+swift build --product MeetingAgentApp
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Run required unit verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: exits 0 and coverage threshold passes.
+
+- [ ] **Step 4: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: consolidate meeting workspace actions (#103)"
+```

--- a/docs/superpowers/specs/2026-04-29-meeting-action-row-design.md
+++ b/docs/superpowers/specs/2026-04-29-meeting-action-row-design.md
@@ -1,0 +1,67 @@
+# Meeting Action Row Design
+
+## Issue
+
+GitHub issue #103 asks to optimize the meeting page action layout. The current workspace spreads actions across the page: Back is alone in the top row, recording and retry transcription controls live below pipeline metadata, and export/debug actions appear as a visible exports block in the insight pane.
+
+## Goal
+
+Consolidate meeting workspace actions into the same top command row so the page has one predictable action surface:
+
+- Back remains on the left.
+- Recording control moves to the right side of the same row.
+- Retry Transcription is removed as a first-class visible button.
+- Export/debug actions move behind a three-dot overflow menu.
+
+## Selected Approach
+
+Use a compact top command bar. Keep the existing top row in `MeetingCommandCenterView`, but extend it so Back stays left while the right side contains a record/stop action and a three-dot menu.
+
+This approach preserves the current page structure: the agenda strip remains below the command bar, the transcript pane keeps its live status header and pipeline metadata, and the insight pane stays focused on summary and recommended questions. It avoids merging too much state into the transcript header and avoids leaving important actions split across multiple page regions.
+
+## Alternatives Considered
+
+### Title-centered command bar
+
+The command row could also contain the meeting title and live status. This would reduce vertical chrome but creates a dense row and duplicates information already handled by the transcript header.
+
+### Transcript-local recording control
+
+Recording could remain beside transcript context while only Back and debug actions move up. This keeps recording close to live transcript state, but it fails the issue goal of converging actions into the Back row.
+
+## UI Behavior
+
+The command row contains:
+
+- `Back` with `chevron.left`, using the existing return destination behavior.
+- A recording button on the right:
+  - Shows `Stop Recording` with a danger style while recording.
+  - Shows `Record` disabled when the workspace is not currently recording, because the workspace does not currently own a start-recording callback.
+- A three-dot overflow menu using `ellipsis.circle`.
+
+The overflow menu contains:
+
+- `Copy Summary`, disabled while recording or when no summary exists.
+- `Export Transcript`, disabled while recording or when no transcript exists.
+- `Export Meeting JSON`.
+- `Export SRT`.
+- `Export VTT`.
+- `Retry Transcription`, disabled while recording or when no audio exists.
+
+The visible `Retry Transcription` row is removed from `TranscriptPaneView`. The visible `Exports` panel is removed from `InsightPaneView`.
+
+## Affected Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+## Testing
+
+Update source-layout tests to verify:
+
+- The meeting workspace top row contains Back, recording control, and overflow actions.
+- `TranscriptPaneView` no longer renders the old visible `Retry Transcription` action row.
+- `InsightPaneView` no longer renders the old visible `Exports` panel.
+- Overflow menu entries include export/debug actions and retry transcription with the expected disabled conditions.
+
+Run `make test` as the required verification entrypoint.


### PR DESCRIPTION
## Summary

Fixes #103

- Consolidates meeting workspace actions into the top command row.
- Moves summary/export/retry actions behind a three-dot overflow menu.
- Removes the visible retry transcription row and exports panel from the page body.

## Changes

- Sources/MeetingAgentApp/MainWindowView.swift - adds the top action row controls and overflow menu; simplifies transcript and insight panes.
- Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift - updates layout guards for the consolidated action surface.
- docs/superpowers/specs/2026-04-29-meeting-action-row-design.md - records the approved design.
- docs/superpowers/plans/2026-04-29-meeting-action-row.md - records the implementation plan.

## Test plan

- [x] Build: swift build --product MeetingAgentApp passed
- [x] Focused layout test: swift test --filter MainWindowViewLayoutTests/testMeetingWorkspaceConsolidatesActionsIntoTopRow passed
- [x] Layout suite: swift test --filter MainWindowViewLayoutTests passed
- [x] Unit tests: make test passed, 484 tests, coverage gate passed
- [x] E2E/integration: skipped; no E2E convention for this static SwiftUI layout change
- [x] Code review: PASS, manual Swift review because available code-review skill targets Java/TypeScript
- [x] Manual verification: visual design option A approved before implementation
