### PR TITLE
feat: move agenda edit entry to workspace header

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -610,10 +610,7 @@ private struct MeetingCommandCenterView: View {
 
                 AgendaContextStrip(
                     meeting: meeting,
-                    attendees: meeting.attendees,
-                    topics: meeting.agendaTopics,
-                    goalTitle: meeting.meetingGoal?.title,
-                    editAgenda: beginDetailAgendaEdit
+                    topics: meeting.agendaTopics
                 )
 
                 HStack(spacing: 0) {
@@ -672,6 +669,26 @@ private struct MeetingCommandCenterView: View {
             .buttonStyle(.plain)
             .font(CommandCenterTypography.button)
             .foregroundStyle(CommandCenterPalette.primary)
+
+            Button(action: beginDetailAgendaEdit) {
+                CommandCenterChip(
+                    title: goalDisplay,
+                    tint: CommandCenterPalette.primary,
+                    filled: meeting.meetingGoal != nil
+                )
+            }
+            .buttonStyle(.plain)
+            .help("Edit meeting goal")
+
+            Button(action: beginDetailAgendaEdit) {
+                CommandCenterChip(
+                    title: attendeesDisplay,
+                    tint: CommandCenterPalette.cyan,
+                    filled: !meeting.attendees.isEmpty
+                )
+            }
+            .buttonStyle(.plain)
+            .help("Edit attendees")
 
             Spacer()
 
@@ -750,6 +767,15 @@ private struct MeetingCommandCenterView: View {
         .help("Meeting actions")
     }
 
+    private var goalDisplay: String {
+        let normalized = meeting.meetingGoal?.title.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return normalized.isEmpty ? "No goal" : normalized
+    }
+
+    private var attendeesDisplay: String {
+        meeting.attendees.isEmpty ? "No attendees" : "\(meeting.attendees.count) attendees"
+    }
+
     private func beginDetailAgendaEdit() {
         editAgendaTarget = meeting
         draft = AgendaDraft(meeting: meeting)
@@ -778,15 +804,10 @@ private struct MeetingCommandCenterView: View {
 
 private struct AgendaContextStrip: View {
     let meeting: MeetingRecord
-    let attendees: [MeetingAttendee]
     let topics: [MeetingAgendaTopic]
-    let goalTitle: String?
-    let editAgenda: () -> Void
 
     var body: some View {
         HStack(spacing: 8) {
-            CommandCenterChip(title: goalDisplay, tint: CommandCenterPalette.primary, filled: goalTitle != nil)
-            CommandCenterChip(title: "\(attendees.count) attendees", tint: CommandCenterPalette.cyan)
             ForEach(topics.prefix(3)) { topic in
                 CommandCenterChip(title: topic.title)
             }
@@ -794,10 +815,6 @@ private struct AgendaContextStrip: View {
                 CommandCenterChip(title: "+\(topics.count - 3) topics")
             }
             Spacer()
-            Button(action: editAgenda) {
-                Label("Edit Agenda", systemImage: "square.and.pencil")
-            }
-            .buttonStyle(CommandCenterActionButtonStyle())
             if let scheduledStartAt = meeting.scheduledStartAt {
                 CommandCenterChip(title: scheduledStartAt.formatted(date: .omitted, time: .shortened))
             }
@@ -810,11 +827,6 @@ private struct AgendaContextStrip: View {
                 .fill(CommandCenterPalette.border)
                 .frame(height: 1)
         }
-    }
-
-    private var goalDisplay: String {
-        let normalized = goalTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return normalized.isEmpty ? "No goal" : normalized
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -139,6 +139,10 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("meeting.attendees"))
         XCTAssertTrue(source.contains("meeting.agendaTopics"))
         XCTAssertTrue(source.contains("meeting.meetingGoal?.title"))
+        XCTAssertTrue(source.contains("Button(action: beginDetailAgendaEdit)"))
+        XCTAssertTrue(source.contains("title: goalDisplay"))
+        XCTAssertTrue(source.contains("title: attendeesDisplay"))
+        XCTAssertFalse(source.contains("Label(\"Edit Agenda\", systemImage: \"square.and.pencil\")"))
     }
 
     func testMeetingWorkspaceBackButtonReturnsToSourceBucket() throws {
@@ -370,11 +374,13 @@ final class MainWindowViewLayoutTests: XCTestCase {
         let source = try appSource(named: "MainWindowView.swift")
 
         XCTAssertTrue(source.contains("saveAgenda: { meetingID, update in"))
-        XCTAssertTrue(source.contains("editAgenda: beginDetailAgendaEdit"))
+        XCTAssertTrue(source.contains("Button(action: beginDetailAgendaEdit)"))
+        XCTAssertTrue(source.contains(".help(\"Edit meeting goal\")"))
+        XCTAssertTrue(source.contains(".help(\"Edit attendees\")"))
         XCTAssertTrue(source.contains("editAgendaTarget = meeting"))
         XCTAssertTrue(source.contains("AgendaEditorView("))
         XCTAssertTrue(source.contains("try saveAgenda(meetingID, draft.update())"))
-        XCTAssertTrue(source.contains("Label(\"Edit Agenda\", systemImage: \"square.and.pencil\")"))
+        XCTAssertFalse(source.contains("Label(\"Edit Agenda\", systemImage: \"square.and.pencil\")"))
 
         let agendaSource = try appSource(named: "TodayAgendaView.swift")
         XCTAssertTrue(agendaSource.contains("labeledTextEditor(\"Meeting Goal\", text: $draft.goalText)"))

--- a/docs/mistakes/2026-04-29T12-49-56Z.md
+++ b/docs/mistakes/2026-04-29T12-49-56Z.md
@@ -1,0 +1,14 @@
+# [107] Run sibling source-layout guards after changing UI entry points
+
+**Date**: 2026-04-29
+**Category**: test-mistake
+
+### What went wrong
+After moving the agenda edit entry into the workspace header, the focused new layout guard passed, but another existing `MainWindowViewLayoutTests` guard still asserted the removed `Edit Agenda` label.
+
+### Correct approach
+When changing a visible UI entry point covered by source-layout tests, run the whole sibling layout test class after the focused regression test.
+
+### How to avoid
+For UI source guard updates, search and run every test class that references the removed label or callback before full verification.
+

--- a/docs/superpowers/plans/2026-04-29-header-agenda-edit.md
+++ b/docs/superpowers/plans/2026-04-29-header-agenda-edit.md
@@ -1,0 +1,114 @@
+# Header Agenda Edit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move meeting goal and attendees into the workspace back/header row and make them direct agenda edit entry points.
+
+**Architecture:** `MeetingCommandCenterView` keeps the existing agenda draft and save flow. `topCommandRow` renders goal and attendee buttons beside Back, both opening the existing `AgendaEditorView`; `AgendaContextStrip` keeps passive topic/time context and no longer renders an explicit Edit Agenda button.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source layout guards.
+
+---
+
+### Task 1: Add Layout Regression
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Extend `testLiveWorkspaceShowsAgendaContextStrip`**
+
+Replace the test body with assertions that the workspace still wires meeting agenda metadata and that the top row owns the edit affordance:
+
+```swift
+func testLiveWorkspaceShowsAgendaContextStrip() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("AgendaContextStrip("))
+    XCTAssertTrue(source.contains("meeting.attendees"))
+    XCTAssertTrue(source.contains("meeting.agendaTopics"))
+    XCTAssertTrue(source.contains("meeting.meetingGoal?.title"))
+    XCTAssertTrue(source.contains("Button(action: beginDetailAgendaEdit)"))
+    XCTAssertTrue(source.contains("CommandCenterChip(title: goalDisplay"))
+    XCTAssertTrue(source.contains("CommandCenterChip(title: attendeesDisplay"))
+    XCTAssertFalse(source.contains("Label(\"Edit Agenda\", systemImage: \"square.and.pencil\")"))
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify failure**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testLiveWorkspaceShowsAgendaContextStrip`
+
+Expected before implementation: FAIL because the top row does not contain goal/attendee buttons and the old `Edit Agenda` label still exists.
+
+### Task 2: Move Goal And Attendees Into Header
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Update `topCommandRow`**
+
+Insert the agenda edit buttons immediately after Back:
+
+```swift
+Button(action: beginDetailAgendaEdit) {
+    CommandCenterChip(title: goalDisplay, tint: CommandCenterPalette.primary, filled: meeting.meetingGoal != nil)
+}
+.buttonStyle(.plain)
+.help("Edit meeting goal")
+
+Button(action: beginDetailAgendaEdit) {
+    CommandCenterChip(title: attendeesDisplay, tint: CommandCenterPalette.cyan, filled: !meeting.attendees.isEmpty)
+}
+.buttonStyle(.plain)
+.help("Edit attendees")
+```
+
+Add helper properties on `MeetingCommandCenterView`:
+
+```swift
+private var goalDisplay: String {
+    let normalized = meeting.meetingGoal?.title.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    return normalized.isEmpty ? "No goal" : normalized
+}
+
+private var attendeesDisplay: String {
+    meeting.attendees.isEmpty ? "No attendees" : "\(meeting.attendees.count) attendees"
+}
+```
+
+- [ ] **Step 2: Simplify `AgendaContextStrip`**
+
+Remove `attendees`, `goalTitle`, and `editAgenda` from the view input. Keep `meeting` and `topics`, then delete the `Edit Agenda` button and the local `goalDisplay`. The strip should show only topic chips, overflow topic count, spacer, and scheduled time.
+
+- [ ] **Step 3: Run the focused layout test**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testLiveWorkspaceShowsAgendaContextStrip`
+
+Expected: PASS.
+
+### Task 3: Verify And Commit
+
+**Files:**
+- Modified files from Task 1 and Task 2.
+
+- [ ] **Step 1: Build the app**
+
+Run: `swift build --product MeetingAgentApp`
+
+Expected: build succeeds.
+
+- [ ] **Step 2: Run required unit verification**
+
+Run: `make test`
+
+Expected: tests and coverage succeed.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/plans/2026-04-29-header-agenda-edit.md
+git commit -m "feat: move agenda edit entry to workspace header (#107)"
+```
+


### PR DESCRIPTION
## Summary

Fixes #107

- Moves meeting goal and attendee edit entry points into the workspace header beside Back.
- Removes the separate Edit Agenda button from the agenda context strip.
- Keeps the existing agenda editor and save flow for goal, attendees, topics, and schedule edits.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - adds clickable goal and attendee chips to the top command row and simplifies the context strip.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - updates layout guards for the new header edit affordance.
- `docs/superpowers/plans/2026-04-29-header-agenda-edit.md` - records the implementation plan.
- `docs/mistakes/2026-04-29T12-49-56Z.md` - records the reusable test lesson.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testLiveWorkspaceShowsAgendaContextStrip` passed; `swift test --filter MainWindowViewLayoutTests` passed; `make test` passed with coverage gate
- [x] E2E/integration: skipped; no E2E convention for this narrow SwiftUI source-layout change
- [x] Code review: PASS via manual Swift review because available code-review skill only supports TS/Java
- [x] Manual verification: source-layout guards verify the new header entry and old button removal
