### PR TITLE
feat: remove summary status badges

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -1110,10 +1110,6 @@ private struct InsightPaneView: View {
                     .commandCenterBody()
                     .lineSpacing(4)
                     .textSelection(.enabled)
-                HStack {
-                    CommandCenterChip(title: isRecording ? "ACTIVE" : "RECORDED", tint: CommandCenterPalette.primary, filled: true)
-                    CommandCenterChip(title: summary == nil ? "Summary pending" : "Summary ready", tint: summary == nil ? CommandCenterPalette.warning : CommandCenterPalette.primary)
-                }
             }
         }
     }

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -253,6 +253,25 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("Button(\"Regenerate Summary\")"))
     }
 
+    func testInsightPaneDoesNotRenderSummaryStatusBadges() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        guard let insightRange = source.range(of: "private struct InsightPaneView") else {
+            return XCTFail("InsightPaneView is missing")
+        }
+        guard let summaryListRange = source.range(of: "private struct SummaryListView", range: insightRange.upperBound..<source.endIndex) else {
+            return XCTFail("InsightPaneView boundary is missing")
+        }
+
+        let insightSource = source[insightRange.lowerBound..<summaryListRange.lowerBound]
+        XCTAssertTrue(insightSource.contains("Text(\"Summary\").commandCenterEyebrow()"))
+        XCTAssertTrue(insightSource.contains("Meeting summary will appear here after recording stops."))
+        XCTAssertFalse(insightSource.contains("\"ACTIVE\""))
+        XCTAssertFalse(insightSource.contains("\"RECORDED\""))
+        XCTAssertFalse(insightSource.contains("\"Summary pending\""))
+        XCTAssertFalse(insightSource.contains("\"Summary ready\""))
+    }
+
     func testInsightsPaneShowsRecommendedQuestionsOnlyWhenAvailable() throws {
         let source = try appSource(named: "MainWindowView.swift")
 

--- a/docs/superpowers/plans/2026-04-29-remove-summary-status-badges.md
+++ b/docs/superpowers/plans/2026-04-29-remove-summary-status-badges.md
@@ -1,0 +1,100 @@
+# Remove Summary Status Badges Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the recording and summary-ready chips from the summary area while preserving summary content and agenda/list artifact badges.
+
+**Architecture:** Keep the change scoped to the SwiftUI summary pane. Delete the chip row from `InsightPaneView.phaseSummary` and add a layout regression that checks only the `InsightPaneView` source slice, so `TodayAgendaView` can keep its existing `Summary ready` artifact text.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout tests, Swift Package Manager, project `make test`.
+
+---
+
+### Task 1: Remove Summary-Area Status Chips
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write the failing layout regression**
+
+Add this test to `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` near the existing summary/workspace layout tests:
+
+```swift
+func testInsightPaneDoesNotRenderSummaryStatusBadges() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    guard let insightRange = source.range(of: "private struct InsightPaneView") else {
+        return XCTFail("InsightPaneView is missing")
+    }
+    guard let summaryListRange = source.range(of: "private struct SummaryListView", range: insightRange.upperBound..<source.endIndex) else {
+        return XCTFail("InsightPaneView boundary is missing")
+    }
+
+    let insightSource = source[insightRange.lowerBound..<summaryListRange.lowerBound]
+    XCTAssertTrue(insightSource.contains("Text(\"Summary\").commandCenterEyebrow()"))
+    XCTAssertTrue(insightSource.contains("Meeting summary will appear here after recording stops."))
+    XCTAssertFalse(insightSource.contains("\"ACTIVE\""))
+    XCTAssertFalse(insightSource.contains("\"RECORDED\""))
+    XCTAssertFalse(insightSource.contains("\"Summary pending\""))
+    XCTAssertFalse(insightSource.contains("\"Summary ready\""))
+}
+```
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testInsightPaneDoesNotRenderSummaryStatusBadges
+```
+
+Expected: FAIL because `InsightPaneView.phaseSummary` still contains the status chip row.
+
+- [ ] **Step 3: Remove the chip row**
+
+In `Sources/MeetingAgentApp/MainWindowView.swift`, update `phaseSummary` by deleting this block:
+
+```swift
+HStack {
+    CommandCenterChip(title: isRecording ? "ACTIVE" : "RECORDED", tint: CommandCenterPalette.primary, filled: true)
+    CommandCenterChip(title: summary == nil ? "Summary pending" : "Summary ready", tint: summary == nil ? CommandCenterPalette.warning : CommandCenterPalette.primary)
+}
+```
+
+Do not change the `Summary` eyebrow, overview text, fallback copy, or `summaryPanel`.
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testInsightPaneDoesNotRenderSummaryStatusBadges
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS with coverage checks satisfied.
+
+- [ ] **Step 6: Commit the implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/specs/2026-04-29-remove-summary-status-badges-design.md docs/superpowers/plans/2026-04-29-remove-summary-status-badges.md
+git commit -m "feat: remove summary status badges (#108)"
+```
+
+## Self-Review
+
+- Spec coverage: the plan removes only summary-area chips, preserves overview and fallback copy, and leaves agenda/list artifact text untouched.
+- Placeholder scan: no placeholders remain.
+- Type consistency: all referenced files, view names, and test helper names exist in the current codebase.

--- a/docs/superpowers/specs/2026-04-29-remove-summary-status-badges-design.md
+++ b/docs/superpowers/specs/2026-04-29-remove-summary-status-badges-design.md
@@ -1,0 +1,22 @@
+# Remove Summary Status Badges Design
+
+GitHub issue #108 asks to remove the recorded and summary-ready badges from the summary area. The scope is limited to the right-side meeting summary panel in the main workspace. Agenda and library list artifact badges, including `Summary ready`, remain unchanged because they are outside the summary area and still help scan meeting cards.
+
+## Requirements
+
+- Remove the two chip badges currently rendered under the summary overview in `InsightPaneView.phaseSummary`.
+- Remove both recording state text (`ACTIVE` / `RECORDED`) and summary artifact state text (`Summary pending` / `Summary ready`) from that summary area.
+- Preserve the `Summary` heading, summary overview text, pending-summary fallback text, and details list below it.
+- Preserve all summary generation, copy, export, agenda, and meeting-list behavior.
+- Preserve summary-ready artifact text in `TodayAgendaView`.
+
+## Approach
+
+Update `Sources/MeetingAgentApp/MainWindowView.swift` only in `InsightPaneView.phaseSummary`, deleting the `HStack` that contains the two `CommandCenterChip` instances. This keeps the visual structure simple and avoids adding a configuration switch for a one-surface removal.
+
+Add a source-layout regression in `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` that scopes assertions to `InsightPaneView`. The test verifies the summary pane no longer contains the removed chip titles while the broader agenda-card `Summary ready` text remains covered by the existing agenda test.
+
+## Testing
+
+- Run a focused layout test for `MainWindowViewLayoutTests`.
+- Run `make test` from the worktree as the required full unit-test entrypoint.


### PR DESCRIPTION
## Summary

Fixes #108

- Removed the recorded/active and summary-ready/pending chips from the summary area in the meeting insight pane.
- Preserved summary overview/details rendering and agenda/list artifact badges.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - removes the `InsightPaneView.phaseSummary` status chip row.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - adds a scoped layout regression for the summary pane.
- `docs/superpowers/specs/2026-04-29-remove-summary-status-badges-design.md` - records the approved design.
- `docs/superpowers/plans/2026-04-29-remove-summary-status-badges.md` - records the implementation plan.

## Test plan

- [x] Focused regression: `swift test --filter MainWindowViewLayoutTests/testInsightPaneDoesNotRenderSummaryStatusBadges` failed before fix and passed after fix.
- [x] Unit tests: `make test` passed, 488 tests, coverage gate passed.
- [x] E2E/integration: skipped; no E2E convention for this static SwiftUI source-layout removal.
- [x] Code review: PASS.
- [x] Manual verification: source diff checked to confirm only `InsightPaneView` summary-area chips were removed; `TodayAgendaView` artifact text remains unchanged.