### PR TITLE
feat: optimize workspace layout space

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -18,8 +18,6 @@ struct MainWindowView: View {
     var body: some View {
         NavigationSplitView {
             VStack(spacing: 0) {
-                sidebarHeader
-
                 VStack(spacing: 6) {
                     Button("Today") {
                         destination = .today
@@ -55,7 +53,7 @@ struct MainWindowView: View {
                 .background(destination == .settings ? CommandCenterPalette.primary.opacity(0.12) : Color.clear)
             }
             .background(CommandCenterPalette.surface)
-            .frame(minWidth: 260, idealWidth: 300)
+            .frame(minWidth: 180, idealWidth: 210)
         } detail: {
             switch destination {
             case .settings:
@@ -208,22 +206,6 @@ struct MainWindowView: View {
         workspaceReturnDestination = destination.agendaReturnDestination
         viewModel.selectMeeting(meeting.id)
         self.destination = .workspace
-    }
-
-    private var sidebarHeader: some View {
-        HStack {
-            Text("Meeting Agent")
-                .commandCenterEyebrow()
-            Spacer()
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 16)
-        .background(CommandCenterPalette.surface)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(CommandCenterPalette.border)
-                .frame(height: 1)
-        }
     }
 
     private func meetings(for destination: MainWindowDestination) -> [MeetingRecord] {
@@ -608,11 +590,6 @@ private struct MeetingCommandCenterView: View {
                         .frame(height: 1)
                 }
 
-                AgendaContextStrip(
-                    meeting: meeting,
-                    topics: meeting.agendaTopics
-                )
-
                 HStack(spacing: 0) {
                     TranscriptPaneView(
                         meeting: meeting,
@@ -799,34 +776,6 @@ private struct MeetingCommandCenterView: View {
         draft = agendaRecordBackedDraft
         editAgendaTarget = nil
         agendaSaveError = nil
-    }
-}
-
-private struct AgendaContextStrip: View {
-    let meeting: MeetingRecord
-    let topics: [MeetingAgendaTopic]
-
-    var body: some View {
-        HStack(spacing: 8) {
-            ForEach(topics.prefix(3)) { topic in
-                CommandCenterChip(title: topic.title)
-            }
-            if topics.count > 3 {
-                CommandCenterChip(title: "+\(topics.count - 3) topics")
-            }
-            Spacer()
-            if let scheduledStartAt = meeting.scheduledStartAt {
-                CommandCenterChip(title: scheduledStartAt.formatted(date: .omitted, time: .shortened))
-            }
-        }
-        .padding(.horizontal, 22)
-        .padding(.vertical, 10)
-        .background(CommandCenterPalette.surface)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(CommandCenterPalette.border)
-                .frame(height: 1)
-        }
     }
 }
 
@@ -1186,48 +1135,47 @@ private struct UnifiedTranscriptView: View {
     let editSpeaker: (LiveCaptionTurn) -> Void
 
     var body: some View {
-        CommandCenterPanel {
-            VStack(alignment: .leading, spacing: 14) {
-                HStack {
-                    Text("Transcript").commandCenterEyebrow()
-                    Spacer()
-                    if !autoFollowsLatest, !turns.isEmpty {
-                        Button("Return to latest") {
-                            returnToLatest()
-                        }
-                        .buttonStyle(CommandCenterActionButtonStyle())
+        VStack(alignment: .leading, spacing: 14) {
+            HStack {
+                Text("Transcript").commandCenterEyebrow()
+                Spacer()
+                if !autoFollowsLatest, !turns.isEmpty {
+                    Button("Return to latest") {
+                        returnToLatest()
                     }
-                }
-
-                if turns.isEmpty {
-                    fallbackTranscript
-                } else {
-                    LazyVStack(alignment: .leading, spacing: 20) {
-                        let groups = LiveCaptionSpeakerGroup.groups(from: turns)
-                        ForEach(groups) { group in
-                            BilingualTranscriptGroup(
-                                group: group,
-                                sourceLocale: sourceLocale,
-                                targetLocale: targetLocale,
-                                editSpeaker: group.speaker.identifier == nil ? nil : {
-                                    if let firstTurn = group.turns.first {
-                                        editSpeaker(firstTurn)
-                                    }
-                                }
-                            )
-                            .id(group.id)
-                        }
-                    }
-                    .simultaneousGesture(
-                        DragGesture(minimumDistance: 8).onChanged { _ in
-                            if isRecording {
-                                pauseFollowing()
-                            }
-                        }
-                    )
+                    .buttonStyle(CommandCenterActionButtonStyle())
                 }
             }
+
+            if turns.isEmpty {
+                fallbackTranscript
+            } else {
+                LazyVStack(alignment: .leading, spacing: 20) {
+                    let groups = LiveCaptionSpeakerGroup.groups(from: turns)
+                    ForEach(groups) { group in
+                        BilingualTranscriptGroup(
+                            group: group,
+                            sourceLocale: sourceLocale,
+                            targetLocale: targetLocale,
+                            editSpeaker: group.speaker.identifier == nil ? nil : {
+                                if let firstTurn = group.turns.first {
+                                    editSpeaker(firstTurn)
+                                }
+                            }
+                        )
+                        .id(group.id)
+                    }
+                }
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 8).onChanged { _ in
+                        if isRecording {
+                            pauseFollowing()
+                        }
+                    }
+                )
+            }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var fallbackTranscript: some View {

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -17,7 +17,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        XCTAssertTrue(source.contains(".frame(minWidth: 260, idealWidth: 300)"))
+        XCTAssertTrue(source.contains(".frame(minWidth: 180, idealWidth: 210)"))
     }
 
     func testMainWindowRoutesThroughMeetingRecordBuckets() throws {
@@ -132,12 +132,11 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("resetDraftFromSelection()"))
     }
 
-    func testLiveWorkspaceShowsAgendaContextStrip() throws {
+    func testLiveWorkspaceKeepsAgendaContextInTopRow() throws {
         let source = try appSource(named: "MainWindowView.swift")
 
-        XCTAssertTrue(source.contains("AgendaContextStrip("))
-        XCTAssertTrue(source.contains("meeting.attendees"))
-        XCTAssertTrue(source.contains("meeting.agendaTopics"))
+        XCTAssertFalse(source.contains("AgendaContextStrip("))
+        XCTAssertFalse(source.contains("private struct AgendaContextStrip"))
         XCTAssertTrue(source.contains("meeting.meetingGoal?.title"))
         XCTAssertTrue(source.contains("Button(action: beginDetailAgendaEdit)"))
         XCTAssertTrue(source.contains("title: goalDisplay"))
@@ -208,10 +207,10 @@ final class MainWindowViewLayoutTests: XCTestCase {
         guard let workspaceRange = source.range(of: "private struct MeetingCommandCenterView") else {
             return XCTFail("Meeting workspace view is missing")
         }
-        guard let agendaRange = source.range(of: "private struct AgendaContextStrip", range: workspaceRange.upperBound..<source.endIndex) else {
+        guard let transcriptPaneRange = source.range(of: "private struct TranscriptPaneView", range: workspaceRange.upperBound..<source.endIndex) else {
             return XCTFail("Meeting workspace boundary is missing")
         }
-        let workspaceSource = source[workspaceRange.lowerBound..<agendaRange.lowerBound]
+        let workspaceSource = source[workspaceRange.lowerBound..<transcriptPaneRange.lowerBound]
 
         XCTAssertTrue(workspaceSource.contains("Label(\"Back\", systemImage: \"chevron.left\")"))
         XCTAssertTrue(workspaceSource.contains("Label(\"Stop Recording\", systemImage: \"stop.fill\")"))
@@ -341,13 +340,13 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("destination = .settings"))
     }
 
-    func testSidebarTitleUsesCommandCenterStylingInsteadOfSystemNavigationTitle() throws {
+    func testSidebarRemovesFixedApplicationTitleHeader() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
-        XCTAssertTrue(source.contains("Text(\"Meeting Agent\")"))
-        XCTAssertTrue(source.contains(".commandCenterEyebrow()"))
+        XCTAssertFalse(source.contains("sidebarHeader"))
+        XCTAssertFalse(source.contains("Text(\"Meeting Agent\")"))
         XCTAssertFalse(source.contains(".navigationTitle(\"Meeting Agent\")"))
     }
 
@@ -431,6 +430,15 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("ForEach(liveCaptionTurns.suffix(8))"))
         XCTAssertFalse(source.contains("Text(turn.isFinal ? \"final\" : \"partial\")"))
         XCTAssertFalse(source.contains("\" turns\""))
+
+        guard let unifiedRange = source.range(of: "private struct UnifiedTranscriptView") else {
+            return XCTFail("UnifiedTranscriptView is missing")
+        }
+        guard let groupRange = source.range(of: "private struct BilingualTranscriptGroup", range: unifiedRange.upperBound..<source.endIndex) else {
+            return XCTFail("UnifiedTranscriptView boundary is missing")
+        }
+        let unifiedSource = source[unifiedRange.lowerBound..<groupRange.lowerBound]
+        XCTAssertFalse(unifiedSource.contains("CommandCenterPanel"))
     }
 
     func testUnifiedTranscriptPreservesFallbackAndQuietCorrectionControls() throws {

--- a/docs/mistakes/2026-04-29T14-03-10Z.md
+++ b/docs/mistakes/2026-04-29T14-03-10Z.md
@@ -1,0 +1,13 @@
+# [112] Update source-layout test boundaries after deleting view types
+
+**Date**: 2026-04-29
+**Category**: test-mistake
+
+### What went wrong
+After removing `AgendaContextStrip`, one existing source-layout test still used that deleted type as the boundary for extracting the workspace source block.
+
+### Correct approach
+When deleting a SwiftUI view type, update any source-layout tests that use the deleted type as a range boundary before rerunning the focused test class.
+
+### How to avoid
+Search layout tests for both direct assertions and range-boundary references to any removed view type.

--- a/docs/superpowers/plans/2026-04-29-workspace-layout-space.md
+++ b/docs/superpowers/plans/2026-04-29-workspace-layout-space.md
@@ -1,0 +1,179 @@
+# Workspace Layout Space Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Optimize the meeting workspace layout so the navigation and transcript areas use screen space more efficiently.
+
+**Architecture:** Keep the existing `MainWindowView.swift` component structure but trim nonessential framing: shrink the sidebar, remove the fixed app header and separate agenda strip, and let transcript content render directly in the scroll area. Preserve all existing callbacks and action controls.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout guards.
+
+---
+
+### Task 1: Update Workspace Layout Guards
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Change the sidebar width expectation**
+
+Replace the assertion in `testAgendaSidebarUsesWiderDefaultWidth` with:
+
+```swift
+XCTAssertTrue(source.contains(".frame(minWidth: 180, idealWidth: 210)"))
+```
+
+- [ ] **Step 2: Change the sidebar title test into a removal guard**
+
+Update `testSidebarTitleUsesCommandCenterStylingInsteadOfSystemNavigationTitle` so it asserts:
+
+```swift
+XCTAssertFalse(source.contains("sidebarHeader"))
+XCTAssertFalse(source.contains("Text(\"Meeting Agent\")"))
+XCTAssertFalse(source.contains(".navigationTitle(\"Meeting Agent\")"))
+```
+
+- [ ] **Step 3: Add a workspace strip removal guard**
+
+Add or update a test near `testLiveWorkspaceShowsAgendaContextStrip` to assert the workspace no longer renders `AgendaContextStrip(` and still contains goal/attendee edit chips in the top row:
+
+```swift
+XCTAssertFalse(source.contains("AgendaContextStrip("))
+XCTAssertFalse(source.contains("private struct AgendaContextStrip"))
+XCTAssertTrue(source.contains("Button(action: beginDetailAgendaEdit)"))
+XCTAssertTrue(source.contains("title: goalDisplay"))
+XCTAssertTrue(source.contains("title: attendeesDisplay"))
+```
+
+- [ ] **Step 4: Add a transcript panel removal guard**
+
+Update `testTranscriptPaneUsesUnifiedTranscriptSurface` to check that `UnifiedTranscriptView` does not wrap its content in `CommandCenterPanel`:
+
+```swift
+guard let unifiedRange = source.range(of: "private struct UnifiedTranscriptView") else {
+    return XCTFail("UnifiedTranscriptView is missing")
+}
+guard let groupRange = source.range(of: "private struct BilingualTranscriptGroup", range: unifiedRange.upperBound..<source.endIndex) else {
+    return XCTFail("UnifiedTranscriptView boundary is missing")
+}
+let unifiedSource = source[unifiedRange.lowerBound..<groupRange.lowerBound]
+XCTAssertFalse(unifiedSource.contains("CommandCenterPanel"))
+```
+
+- [ ] **Step 5: Run focused tests and confirm failure**
+
+Run:
+
+```sh
+swift test --filter MainWindowViewLayoutTests
+```
+
+Expected: FAIL because implementation still uses the old sidebar width, header, agenda strip, and transcript panel.
+
+### Task 2: Trim MainWindowView Layout
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Remove the sidebar header from the rendered sidebar**
+
+In the `NavigationSplitView` sidebar `VStack`, remove the `sidebarHeader` line so the sidebar starts with the navigation button group.
+
+- [ ] **Step 2: Narrow the sidebar**
+
+Change:
+
+```swift
+.frame(minWidth: 260, idealWidth: 300)
+```
+
+to:
+
+```swift
+.frame(minWidth: 180, idealWidth: 210)
+```
+
+- [ ] **Step 3: Delete the unused sidebarHeader property**
+
+Remove the entire `private var sidebarHeader: some View` computed property from `MainWindowView`.
+
+- [ ] **Step 4: Remove the separate agenda context strip from the workspace**
+
+In `MeetingCommandCenterView.body`, remove:
+
+```swift
+AgendaContextStrip(
+    meeting: meeting,
+    topics: meeting.agendaTopics
+)
+```
+
+- [ ] **Step 5: Delete the unused AgendaContextStrip type**
+
+Remove the entire `private struct AgendaContextStrip: View` declaration.
+
+- [ ] **Step 6: Let UnifiedTranscriptView render unframed**
+
+Change `UnifiedTranscriptView.body` from:
+
+```swift
+CommandCenterPanel {
+    VStack(alignment: .leading, spacing: 14) {
+        ...
+    }
+}
+```
+
+to:
+
+```swift
+VStack(alignment: .leading, spacing: 14) {
+    ...
+}
+.frame(maxWidth: .infinity, alignment: .leading)
+```
+
+- [ ] **Step 7: Run focused tests and confirm pass**
+
+Run:
+
+```sh
+swift test --filter MainWindowViewLayoutTests
+```
+
+Expected: PASS.
+
+### Task 3: Full Verification And Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Run required verification**
+
+Run:
+
+```sh
+make test
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Review diff**
+
+Run:
+
+```sh
+git diff -- Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+```
+
+Expected: Only the workspace layout trim and matching tests are changed.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```sh
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: optimize workspace layout space (#112)"
+```

--- a/docs/superpowers/specs/2026-04-29-workspace-layout-space-design.md
+++ b/docs/superpowers/specs/2026-04-29-workspace-layout-space-design.md
@@ -1,0 +1,60 @@
+# Workspace Layout Space Design
+
+## Context
+
+Issue #112 asks to optimize the meeting workspace layout:
+
+- Reduce the navigation width.
+- Remove the fixed top `Meeting Agent` header.
+- Remove the empty band below the back row.
+- Let the transcript area use the full available space instead of sitting inside a framed panel.
+
+The current implementation is concentrated in `Sources/MeetingAgentApp/MainWindowView.swift`. The sidebar uses a fixed `260/300` width and renders a custom `sidebarHeader`. The workspace renders a top command row, a separate `AgendaContextStrip`, and then a two-pane content area. The transcript content is wrapped by `UnifiedTranscriptView`, which currently renders its own `CommandCenterPanel`.
+
+## Goals
+
+- Make the workspace feel denser and give more space to transcript reading.
+- Keep existing workspace navigation and action behavior intact.
+- Preserve the current dark command-center visual system.
+- Cover the layout change with source-layout tests, matching existing project test conventions.
+
+## Non-Goals
+
+- Do not redesign the whole workspace information architecture.
+- Do not add new meeting data, new actions, or new transcript behavior.
+- Do not change recording, export, summary, or translation logic.
+- Do not remove the back button or existing action menu.
+
+## Selected Approach
+
+Use a focused shell layout trim:
+
+1. Narrow the left sidebar from the current `minWidth: 260, idealWidth: 300` to a compact width near `180/210`.
+2. Remove the custom `sidebarHeader` from the sidebar stack so the fixed `Meeting Agent` title no longer consumes vertical space.
+3. Remove the workspace `AgendaContextStrip` band. The top command row already carries the back action plus goal and attendee chips, so it remains the compact workspace context surface.
+4. Remove the `CommandCenterPanel` wrapper from `UnifiedTranscriptView`, leaving the transcript header and transcript groups directly in the transcript scroll content.
+5. Update `MainWindowViewLayoutTests` to assert the new layout contract and prevent regressions.
+
+## Affected Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+## Testing
+
+Run focused layout tests first:
+
+```sh
+swift test --filter MainWindowViewLayoutTests
+```
+
+Then run the repository-required verification:
+
+```sh
+make test
+```
+
+## Risks
+
+- Source-layout tests are string-based, so they must be updated carefully to check the intended structure without becoming brittle.
+- Removing `AgendaContextStrip` must not remove the only visible way to edit goal or attendees. The top command row retains those edit affordances.


### PR DESCRIPTION
## Summary

Fixes #112

- Narrows the left navigation and removes the fixed Meeting Agent sidebar header.
- Removes the extra workspace agenda strip below the command row.
- Lets transcript content render directly in the scroll area instead of inside a framed panel.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - trims sidebar, workspace header stack, and transcript framing.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - updates layout guards for the compact workspace.
- `docs/superpowers/specs/2026-04-29-workspace-layout-space-design.md` - records the approved design.
- `docs/superpowers/plans/2026-04-29-workspace-layout-space.md` - records the implementation plan.
- `docs/mistakes/2026-04-29T14-03-10Z.md` - records the source-layout boundary lesson.

## Test plan

- [x] Build/lint: `swift test --filter MainWindowViewLayoutTests` passed after implementation.
- [x] Unit tests: `make test` passed, 488 tests, coverage gate passed.
- [x] E2E/integration: skipped; no E2E convention for this source-layout SwiftUI shell change.
- [x] Code review: PASS via manual Swift review; code-review skill is TS/Java-only.
- [x] Manual verification: not run; behavior is covered by source-layout tests.