### PR TITLE
feat: add meeting goals list

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -116,6 +116,7 @@ struct MainWindowView: View {
                     isRecording: viewModel.isRecording,
                     liveCaptionTurns: viewModel.liveCaptionTurns,
                     recommendedQuestions: viewModel.recommendedQuestions,
+                    meetingProgressState: viewModel.meetingProgressState,
                     backToMeetings: {
                         destination = workspaceReturnDestination
                     },
@@ -378,6 +379,7 @@ private struct MeetingDetailView: View {
     let isRecording: Bool
     let liveCaptionTurns: [LiveCaptionTurn]
     let recommendedQuestions: [FollowUpQuestionSuggestion]
+    let meetingProgressState: MeetingProgressState?
     let backToMeetings: () -> Void
     let saveAgenda: (UUID, MeetingAgendaUpdate) throws -> Void
     let stopRecording: () -> Void
@@ -410,6 +412,7 @@ private struct MeetingDetailView: View {
                     transcriptionStatusText: transcriptionStatusText(for: meeting),
                     summary: summary(for: meeting),
                     recommendedQuestions: recommendedQuestions,
+                    meetingProgressState: meetingProgressState,
                     saveAgenda: saveAgenda,
                     stopRecording: stopRecording,
                     copySummary: { copySummary(meeting) },
@@ -563,6 +566,7 @@ private struct MeetingCommandCenterView: View {
     let transcriptionStatusText: String
     let summary: MeetingSummary?
     let recommendedQuestions: [FollowUpQuestionSuggestion]
+    let meetingProgressState: MeetingProgressState?
     let saveAgenda: (UUID, MeetingAgendaUpdate) throws -> Void
     let stopRecording: () -> Void
     let copySummary: () -> Void
@@ -616,7 +620,8 @@ private struct MeetingCommandCenterView: View {
                         meeting: meeting,
                         isRecording: isRecording,
                         summary: summary,
-                        recommendedQuestions: recommendedQuestions
+                        recommendedQuestions: recommendedQuestions,
+                        meetingProgressState: meetingProgressState
                     )
                     .frame(minWidth: 360, idealWidth: 440, maxWidth: 520)
                 }
@@ -745,8 +750,10 @@ private struct MeetingCommandCenterView: View {
     }
 
     private var goalDisplay: String {
-        let normalized = meeting.meetingGoal?.title.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return normalized.isEmpty ? "No goal" : normalized
+        let titles = meetingGoalTitles(for: meeting)
+        guard let first = titles.first else { return "No goals" }
+        let remaining = titles.count - 1
+        return remaining > 0 ? "\(first) +\(remaining)" : first
     }
 
     private var attendeesDisplay: String {
@@ -1046,11 +1053,16 @@ private struct InsightPaneView: View {
     let isRecording: Bool
     let summary: MeetingSummary?
     let recommendedQuestions: [FollowUpQuestionSuggestion]
+    let meetingProgressState: MeetingProgressState?
 
     var body: some View {
         VStack(spacing: 0) {
             CommandCenterScrollView(background: CommandCenterPalette.surface, content: {
                 VStack(alignment: .leading, spacing: 16) {
+                    GoalTrackerPanel(
+                        meeting: meeting,
+                        meetingProgressState: meetingProgressState
+                    )
                     if !recommendedQuestions.isEmpty {
                         RecommendedQuestionsPanel(questions: recommendedQuestions)
                     }
@@ -1098,6 +1110,80 @@ private struct InsightPaneView: View {
             }
         }
     }
+}
+
+private struct GoalTrackerPanel: View {
+    let meeting: MeetingRecord
+    let meetingProgressState: MeetingProgressState?
+
+    var body: some View {
+        CommandCenterPanel {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Goals").commandCenterEyebrow()
+                let titles = meetingGoalTitles(for: meeting)
+                if titles.isEmpty {
+                    Text("No goals set.")
+                        .commandCenterCaption(CommandCenterPalette.secondaryText)
+                } else {
+                    ForEach(Array(titles.enumerated()), id: \.offset) { index, title in
+                        HStack(spacing: 10) {
+                            Text(title)
+                                .font(CommandCenterTypography.secondaryBody)
+                                .foregroundStyle(CommandCenterPalette.text)
+                                .lineLimit(2)
+                            Spacer(minLength: 8)
+                            CommandCenterChip(
+                                title: statusText(forGoalAt: index),
+                                tint: statusTint(forGoalAt: index),
+                                filled: index == 0 && firstGoalHasProgress
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var firstGoalHasProgress: Bool {
+        guard let progressGoalID = meetingProgressState?.goal.id,
+              let firstGoalID = goalList.first?.id
+        else {
+            return false
+        }
+        return progressGoalID == firstGoalID
+    }
+
+    private var goalList: [MeetingGoal] {
+        meeting.meetingGoals.isEmpty ? meeting.meetingGoal.map { [$0] } ?? [] : meeting.meetingGoals
+    }
+
+    private func statusText(forGoalAt index: Int) -> String {
+        guard index == 0, firstGoalHasProgress else { return "Pending" }
+        return meetingProgressState?.status.displayText ?? "Pending"
+    }
+
+    private func statusTint(forGoalAt index: Int) -> Color {
+        guard index == 0, let status = meetingProgressState?.status, firstGoalHasProgress else {
+            return CommandCenterPalette.secondaryText
+        }
+        switch status {
+        case .blocked:
+            return CommandCenterPalette.danger
+        case .partiallyCovered:
+            return CommandCenterPalette.warning
+        case .onTrack:
+            return CommandCenterPalette.primary
+        case .notStarted:
+            return CommandCenterPalette.secondaryText
+        }
+    }
+}
+
+private func meetingGoalTitles(for meeting: MeetingRecord) -> [String] {
+    let goals = meeting.meetingGoals.isEmpty ? meeting.meetingGoal.map { [$0] } ?? [] : meeting.meetingGoals
+    return goals
+        .map { $0.title.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
 }
 
 private struct RecommendedQuestionsPanel: View {

--- a/Sources/MeetingAgentApp/TodayAgendaView.swift
+++ b/Sources/MeetingAgentApp/TodayAgendaView.swift
@@ -445,8 +445,10 @@ private struct AgendaRowView: View {
     }
 
     private var goalText: String {
-        let title = meeting.meetingGoal?.title.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return title.isEmpty ? "No goal" : title
+        let titles = meetingGoalTitles(for: meeting)
+        guard let first = titles.first else { return "No goals" }
+        let remaining = titles.count - 1
+        return remaining > 0 ? "\(first) +\(remaining)" : first
     }
 
     private var timeRange: String {
@@ -454,6 +456,13 @@ private struct AgendaRowView: View {
         guard let end = meeting.scheduledEndAt else { return start }
         return "\(start)\n\(end.formatted(date: .omitted, time: .shortened))"
     }
+}
+
+private func meetingGoalTitles(for meeting: MeetingRecord) -> [String] {
+    let goals = meeting.meetingGoals.isEmpty ? meeting.meetingGoal.map { [$0] } ?? [] : meeting.meetingGoals
+    return goals
+        .map { $0.title.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
 }
 
 private struct MeetingArtifactCard: View {
@@ -584,7 +593,7 @@ struct AgendaEditorView: View {
                     labeledDatePicker("Scheduled End", date: $draft.scheduledEndAt)
                     labeledTextEditor("Attendees", text: $draft.attendeesText)
                     labeledTextEditor("Topics", text: $draft.topicsText)
-                    labeledTextEditor("Meeting Goal", text: $draft.goalText)
+                    goalsEditor
 
                     // Dirty navigation confirmation uses Save / Discard / Cancel.
                     HStack {
@@ -639,6 +648,39 @@ struct AgendaEditorView: View {
         }
     }
 
+    private var goalsEditor: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Goals").commandCenterEyebrow()
+            ForEach(draft.goalTexts.indices, id: \.self) { index in
+                HStack(spacing: 8) {
+                    TextField("Goal", text: $draft.goalTexts[index])
+                        .textFieldStyle(.plain)
+                        .font(CommandCenterTypography.secondaryBody)
+                        .foregroundStyle(CommandCenterPalette.text)
+                        .padding(10)
+                        .background(CommandCenterPalette.panelRaised)
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .stroke(CommandCenterPalette.border, lineWidth: 1)
+                        )
+                    Button {
+                        draft.removeGoal(at: index)
+                    } label: {
+                        Image(systemName: "trash")
+                            .accessibilityLabel("Remove Goal")
+                    }
+                    .buttonStyle(CommandCenterIconButtonStyle())
+                    .disabled(draft.goalTexts.count == 1)
+                }
+            }
+            Button("Add Goal") {
+                draft.addGoal()
+            }
+            .buttonStyle(CommandCenterActionButtonStyle())
+        }
+    }
+
     private func labeledDatePicker(_ title: String, date: Binding<Date?>) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Text(title).commandCenterEyebrow()
@@ -663,7 +705,7 @@ struct AgendaDraft: Equatable {
     var topicsText = ""
     var scheduledStartAt: Date?
     var scheduledEndAt: Date?
-    var goalText = ""
+    var goalTexts: [String] = [""]
 
     init() {}
 
@@ -680,11 +722,25 @@ struct AgendaDraft: Equatable {
         topicsText = meeting.agendaTopics.map(\.title).joined(separator: "\n")
         scheduledStartAt = meeting.scheduledStartAt ?? meeting.startedAt
         scheduledEndAt = meeting.scheduledEndAt
-        goalText = meeting.meetingGoal?.title ?? ""
+        let goals = meeting.meetingGoals.isEmpty ? meeting.meetingGoal.map { [$0] } ?? [] : meeting.meetingGoals
+        goalTexts = goals.map(\.title)
+        ensureGoalRow()
     }
 
     func update() -> MeetingAgendaUpdate {
-        MeetingAgendaUpdate(
+        let goalValues = goalTexts
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map {
+                MeetingGoal(
+                    title: $0,
+                    objectives: [],
+                    requiredQuestions: [],
+                    expectedDecisions: [],
+                    keyTerms: []
+                )
+            }
+        return MeetingAgendaUpdate(
             name: name,
             attendees: attendeesText
                 .split(whereSeparator: \.isNewline)
@@ -697,13 +753,24 @@ struct AgendaDraft: Equatable {
                 .map { MeetingAgendaTopic(title: String($0)) },
             scheduledStartAt: scheduledStartAt,
             scheduledEndAt: scheduledEndAt,
-            meetingGoal: MeetingGoal(
-                title: goalText,
-                objectives: [],
-                requiredQuestions: [],
-                expectedDecisions: [],
-                keyTerms: []
-            )
+            meetingGoal: goalValues.first,
+            meetingGoals: goalValues
         )
+    }
+
+    mutating func addGoal() {
+        goalTexts.append("")
+    }
+
+    mutating func removeGoal(at index: Int) {
+        guard goalTexts.indices.contains(index) else { return }
+        goalTexts.remove(at: index)
+        ensureGoalRow()
+    }
+
+    private mutating func ensureGoalRow() {
+        if goalTexts.isEmpty {
+            goalTexts = [""]
+        }
     }
 }

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -294,7 +294,9 @@ public final class MeetingAgentViewModel: ObservableObject {
         record.agendaTopics = update.agendaTopics.compactMap(Self.normalizedAgendaTopic)
         record.scheduledStartAt = update.scheduledStartAt
         record.scheduledEndAt = update.scheduledEndAt
-        record.meetingGoal = Self.normalizedMeetingGoal(update.meetingGoal)
+        let normalizedGoals = Self.normalizedMeetingGoals(update.meetingGoals, legacyGoal: update.meetingGoal)
+        record.meetingGoals = normalizedGoals
+        record.meetingGoal = normalizedGoals.first
 
         try store.save(record)
         meetings[index] = record
@@ -766,6 +768,18 @@ public final class MeetingAgentViewModel: ObservableObject {
         return goal.title.isEmpty ? nil : goal
     }
 
+    private static func normalizedMeetingGoals(_ goals: [MeetingGoal], legacyGoal: MeetingGoal?) -> [MeetingGoal] {
+        let sourceGoals: [MeetingGoal]
+        if !goals.isEmpty {
+            sourceGoals = goals
+        } else if let legacyGoal {
+            sourceGoals = [legacyGoal]
+        } else {
+            sourceGoals = []
+        }
+        return sourceGoals.compactMap(normalizedMeetingGoal)
+    }
+
     private static func derivedBilingualPipelineProfileID(
         transcriptionExecutionMode: ProviderExecutionMode,
         translationExecutionMode: ProviderExecutionMode
@@ -858,7 +872,9 @@ public final class MeetingAgentViewModel: ObservableObject {
         else {
             return
         }
-        meetings[index].meetingGoal = meetingGoal
+        let goals = meetingGoal.map { [$0] } ?? []
+        meetings[index].meetingGoals = goals
+        meetings[index].meetingGoal = goals.first
         try? store.save(meetings[index])
     }
 

--- a/Sources/MeetingAgentCore/MeetingRecord.swift
+++ b/Sources/MeetingAgentCore/MeetingRecord.swift
@@ -37,6 +37,7 @@ public struct MeetingAgendaUpdate: Equatable {
     public var scheduledStartAt: Date?
     public var scheduledEndAt: Date?
     public var meetingGoal: MeetingGoal?
+    public var meetingGoals: [MeetingGoal]
 
     public init(
         name: String,
@@ -44,14 +45,22 @@ public struct MeetingAgendaUpdate: Equatable {
         agendaTopics: [MeetingAgendaTopic],
         scheduledStartAt: Date?,
         scheduledEndAt: Date?,
-        meetingGoal: MeetingGoal?
+        meetingGoal: MeetingGoal?,
+        meetingGoals: [MeetingGoal] = []
     ) {
         self.name = name
         self.attendees = attendees
         self.agendaTopics = agendaTopics
         self.scheduledStartAt = scheduledStartAt
         self.scheduledEndAt = scheduledEndAt
-        self.meetingGoal = meetingGoal
+        if !meetingGoals.isEmpty {
+            self.meetingGoals = meetingGoals
+        } else if let meetingGoal {
+            self.meetingGoals = [meetingGoal]
+        } else {
+            self.meetingGoals = []
+        }
+        self.meetingGoal = meetingGoal ?? self.meetingGoals.first
     }
 }
 
@@ -75,6 +84,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
     public var transcriptionProviderID: String
     public var speechLocaleIdentifier: String
     public var meetingGoal: MeetingGoal?
+    public var meetingGoals: [MeetingGoal]
     public var attendees: [MeetingAttendee]
     public var agendaTopics: [MeetingAgendaTopic]
     public var scheduledStartAt: Date?
@@ -100,6 +110,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         transcriptionProviderID: String? = nil,
         speechLocaleIdentifier: String = "en-US",
         meetingGoal: MeetingGoal? = nil,
+        meetingGoals: [MeetingGoal]? = nil,
         attendees: [MeetingAttendee] = [],
         agendaTopics: [MeetingAgendaTopic] = [],
         scheduledStartAt: Date? = nil,
@@ -126,7 +137,14 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
             fallback: speechProvider.rawValue
         ) ?? speechProvider.rawValue
         self.speechLocaleIdentifier = SpeechTranscriptionConfiguration.normalized(speechLocaleIdentifier, fallback: "en-US") ?? "en-US"
-        self.meetingGoal = meetingGoal
+        if let meetingGoals {
+            self.meetingGoals = meetingGoals
+        } else if let meetingGoal {
+            self.meetingGoals = [meetingGoal]
+        } else {
+            self.meetingGoals = []
+        }
+        self.meetingGoal = meetingGoal ?? self.meetingGoals.first
         self.attendees = attendees
         self.agendaTopics = agendaTopics
         self.scheduledStartAt = scheduledStartAt
@@ -153,6 +171,7 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         case transcriptionProviderID
         case speechLocaleIdentifier
         case meetingGoal
+        case meetingGoals
         case attendees
         case agendaTopics
         case scheduledStartAt
@@ -180,7 +199,15 @@ public struct MeetingRecord: Codable, Identifiable, Equatable {
         transcriptionProviderID = try container.decodeIfPresent(String.self, forKey: .transcriptionProviderID)
             ?? speechProvider.rawValue
         speechLocaleIdentifier = try container.decodeIfPresent(String.self, forKey: .speechLocaleIdentifier) ?? "en-US"
-        meetingGoal = try container.decodeIfPresent(MeetingGoal.self, forKey: .meetingGoal)
+        let decodedMeetingGoal = try container.decodeIfPresent(MeetingGoal.self, forKey: .meetingGoal)
+        if let decodedMeetingGoals = try container.decodeIfPresent([MeetingGoal].self, forKey: .meetingGoals) {
+            meetingGoals = decodedMeetingGoals
+        } else if let decodedMeetingGoal {
+            meetingGoals = [decodedMeetingGoal]
+        } else {
+            meetingGoals = []
+        }
+        meetingGoal = decodedMeetingGoal ?? meetingGoals.first
         attendees = try container.decodeIfPresent([MeetingAttendee].self, forKey: .attendees) ?? []
         agendaTopics = try container.decodeIfPresent([MeetingAgendaTopic].self, forKey: .agendaTopics) ?? []
         scheduledStartAt = try container.decodeIfPresent(Date.self, forKey: .scheduledStartAt)

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -102,6 +102,18 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("Save / Discard / Cancel"))
     }
 
+    func testTodayAgendaViewDefinesGoalListEditor() throws {
+        let source = try appSource(named: "TodayAgendaView.swift")
+
+        XCTAssertTrue(source.contains("var goalTexts: [String] = [\"\"]"))
+        XCTAssertTrue(source.contains("goalsEditor"))
+        XCTAssertTrue(source.contains("Button(\"Add Goal\")"))
+        XCTAssertTrue(source.contains("func addGoal()"))
+        XCTAssertTrue(source.contains("func removeGoal(at index: Int)"))
+        XCTAssertTrue(source.contains("meetingGoals: goalValues"))
+        XCTAssertFalse(source.contains("labeledTextEditor(\"Meeting Goal\", text: $draft.goalText)"))
+    }
+
     func testTodayAgendaUsesTodayWorkflowSections() throws {
         let source = try appSource(named: "TodayAgendaView.swift")
 
@@ -137,7 +149,8 @@ final class MainWindowViewLayoutTests: XCTestCase {
 
         XCTAssertFalse(source.contains("AgendaContextStrip("))
         XCTAssertFalse(source.contains("private struct AgendaContextStrip"))
-        XCTAssertTrue(source.contains("meeting.meetingGoal?.title"))
+        XCTAssertTrue(source.contains("meeting.attendees"))
+        XCTAssertTrue(source.contains("meeting.meetingGoals"))
         XCTAssertTrue(source.contains("Button(action: beginDetailAgendaEdit)"))
         XCTAssertTrue(source.contains("title: goalDisplay"))
         XCTAssertTrue(source.contains("title: attendeesDisplay"))
@@ -275,6 +288,24 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(insightSource.contains("\"Summary ready\""))
     }
 
+    func testWorkspaceInsightPaneShowsGoalTracker() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("meetingProgressState: viewModel.meetingProgressState"))
+        XCTAssertTrue(source.contains("let meetingProgressState: MeetingProgressState?"))
+        XCTAssertTrue(source.contains("GoalTrackerPanel("))
+        XCTAssertTrue(source.contains("private struct GoalTrackerPanel"))
+        XCTAssertTrue(source.contains("meeting.meetingGoals"))
+
+        guard let trackerRange = source.range(of: "GoalTrackerPanel(") else {
+            return XCTFail("GoalTrackerPanel call is missing")
+        }
+        guard let phaseRange = source.range(of: "phaseSummary", range: trackerRange.upperBound..<source.endIndex) else {
+            return XCTFail("phaseSummary after tracker is missing")
+        }
+        XCTAssertLessThan(trackerRange.lowerBound, phaseRange.lowerBound)
+    }
+
     func testInsightsPaneShowsRecommendedQuestionsOnlyWhenAvailable() throws {
         let source = try appSource(named: "MainWindowView.swift")
 
@@ -401,7 +432,9 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains("Label(\"Edit Agenda\", systemImage: \"square.and.pencil\")"))
 
         let agendaSource = try appSource(named: "TodayAgendaView.swift")
-        XCTAssertTrue(agendaSource.contains("labeledTextEditor(\"Meeting Goal\", text: $draft.goalText)"))
+        XCTAssertTrue(agendaSource.contains("goalsEditor"))
+        XCTAssertTrue(agendaSource.contains("Button(\"Add Goal\")"))
+        XCTAssertFalse(agendaSource.contains("labeledTextEditor(\"Meeting Goal\", text: $draft.goalText)"))
     }
 
     func testMainWindowRemovesUnimplementedMeetingGoalDashboardStructure() throws {

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -2655,7 +2655,30 @@ final class MeetingAgentViewModelTests: XCTestCase {
                     requiredQuestions: [],
                     expectedDecisions: [],
                     keyTerms: []
-                )
+                ),
+                meetingGoals: [
+                    MeetingGoal(
+                        title: " Align on rollout ",
+                        objectives: [],
+                        requiredQuestions: [],
+                        expectedDecisions: [],
+                        keyTerms: []
+                    ),
+                    MeetingGoal(
+                        title: " Confirm launch owner ",
+                        objectives: [],
+                        requiredQuestions: [],
+                        expectedDecisions: [],
+                        keyTerms: []
+                    ),
+                    MeetingGoal(
+                        title: "   ",
+                        objectives: [],
+                        requiredQuestions: [],
+                        expectedDecisions: [],
+                        keyTerms: []
+                    )
+                ]
             )
         )
 
@@ -2668,6 +2691,9 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(saved.scheduledStartAt, Date(timeIntervalSince1970: 500))
         XCTAssertEqual(saved.scheduledEndAt, Date(timeIntervalSince1970: 800))
         XCTAssertEqual(saved.meetingGoal?.title, "Align on rollout")
+        XCTAssertEqual(saved.meetingGoals.map(\.title), ["Align on rollout", "Confirm launch owner"])
+        XCTAssertEqual(loaded.meetingGoals.map(\.title), ["Align on rollout", "Confirm launch owner"])
+        XCTAssertEqual(loaded.meetingGoal?.title, "Align on rollout")
         XCTAssertEqual(loaded, saved)
     }
 

--- a/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecordTests.swift
@@ -31,6 +31,24 @@ final class MeetingRecordTests: XCTestCase {
                 expectedDecisions: [],
                 keyTerms: [MeetingKeyTerm(value: "launch")]
             ),
+            meetingGoals: [
+                MeetingGoal(
+                    id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+                    title: "Confirm launch plan",
+                    objectives: [MeetingObjective(id: "owner", title: "Confirm launch owner")],
+                    requiredQuestions: ["Have we confirmed the deadline?"],
+                    expectedDecisions: [],
+                    keyTerms: [MeetingKeyTerm(value: "launch")]
+                ),
+                MeetingGoal(
+                    id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+                    title: "Align support plan",
+                    objectives: [],
+                    requiredQuestions: [],
+                    expectedDecisions: [],
+                    keyTerms: []
+                )
+            ],
             attendees: [
                 MeetingAttendee(
                     id: UUID(uuidString: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")!,
@@ -69,6 +87,97 @@ final class MeetingRecordTests: XCTestCase {
         XCTAssertEqual(record.speechProvider, .whisper)
         XCTAssertEqual(record.transcriptionProviderID, "whisper")
         XCTAssertEqual(record.speechLocaleIdentifier, "en-US")
+    }
+
+    func testMeetingRecordInitializerDerivesMeetingGoalsFromLegacyGoal() {
+        let goal = MeetingGoal(
+            id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            title: "Confirm launch plan",
+            objectives: [],
+            requiredQuestions: [],
+            expectedDecisions: [],
+            keyTerms: []
+        )
+
+        let record = MeetingRecord(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            name: "Google Meet",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            endedAt: nil,
+            audioURL: nil,
+            transcriptURL: nil,
+            meetingGoal: goal
+        )
+
+        XCTAssertEqual(record.meetingGoal?.title, "Confirm launch plan")
+        XCTAssertEqual(record.meetingGoals.map(\.title), ["Confirm launch plan"])
+    }
+
+    func testMeetingRecordInitializerDefaultsToNoGoals() {
+        let record = MeetingRecord(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            name: "Google Meet",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            endedAt: nil,
+            audioURL: nil,
+            transcriptURL: nil
+        )
+
+        XCTAssertNil(record.meetingGoal)
+        XCTAssertEqual(record.meetingGoals, [])
+    }
+
+    func testMeetingRecordInitializerFallsBackFromBlankProviderAndLocale() {
+        let record = MeetingRecord(
+            id: UUID(uuidString: "33333333-3333-3333-3333-333333333333")!,
+            name: "Google Meet",
+            startedAt: Date(timeIntervalSince1970: 1_777_000_000),
+            endedAt: nil,
+            audioURL: nil,
+            transcriptURL: nil,
+            transcriptionProviderID: "   ",
+            speechLocaleIdentifier: "   "
+        )
+
+        XCTAssertEqual(record.transcriptionProviderID, "whisper")
+        XCTAssertEqual(record.speechLocaleIdentifier, "en-US")
+    }
+
+    func testMeetingAgendaUpdateDerivesMeetingGoalsFromLegacyGoal() {
+        let goal = MeetingGoal(
+            id: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            title: "Confirm launch plan",
+            objectives: [],
+            requiredQuestions: [],
+            expectedDecisions: [],
+            keyTerms: []
+        )
+
+        let update = MeetingAgendaUpdate(
+            name: "Planning",
+            attendees: [],
+            agendaTopics: [],
+            scheduledStartAt: nil,
+            scheduledEndAt: nil,
+            meetingGoal: goal
+        )
+
+        XCTAssertEqual(update.meetingGoal?.title, "Confirm launch plan")
+        XCTAssertEqual(update.meetingGoals.map(\.title), ["Confirm launch plan"])
+    }
+
+    func testMeetingAgendaUpdateDefaultsToNoGoals() {
+        let update = MeetingAgendaUpdate(
+            name: "Planning",
+            attendees: [],
+            agendaTopics: [],
+            scheduledStartAt: nil,
+            scheduledEndAt: nil,
+            meetingGoal: nil
+        )
+
+        XCTAssertNil(update.meetingGoal)
+        XCTAssertEqual(update.meetingGoals, [])
     }
 
     func testActiveRecordHasNoEndTime() {
@@ -164,6 +273,70 @@ final class MeetingRecordTests: XCTestCase {
         XCTAssertNil(decoded.meetingGoal)
     }
 
+    func testDecodesLegacyMeetingGoalIntoMeetingGoals() throws {
+        let json = """
+        {
+          "audioURL" : "file:\\/\\/\\/tmp\\/audio.wav",
+          "endedAt" : null,
+          "id" : "11111111-1111-1111-1111-111111111111",
+          "meetingGoal" : {
+            "expectedDecisions" : [],
+            "id" : "22222222-2222-2222-2222-222222222222",
+            "keyTerms" : [],
+            "objectives" : [],
+            "requiredQuestions" : [],
+            "title" : "Confirm launch plan"
+          },
+          "name" : "Google Meet",
+          "startedAt" : "2026-04-25T10:00:00Z",
+          "transcriptJSONURL" : "file:\\/\\/\\/tmp\\/transcript.json",
+          "transcriptURL" : "file:\\/\\/\\/tmp\\/transcript.txt"
+        }
+        """
+
+        let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.meetingGoals.map(\.title), ["Confirm launch plan"])
+        XCTAssertEqual(decoded.meetingGoal?.title, "Confirm launch plan")
+    }
+
+    func testDecodesMeetingGoalsIntoLegacyFirstGoal() throws {
+        let json = """
+        {
+          "audioURL" : "file:\\/\\/\\/tmp\\/audio.wav",
+          "endedAt" : null,
+          "id" : "11111111-1111-1111-1111-111111111111",
+          "meetingGoals" : [
+            {
+              "expectedDecisions" : [],
+              "id" : "22222222-2222-2222-2222-222222222222",
+              "keyTerms" : [],
+              "objectives" : [],
+              "requiredQuestions" : [],
+              "title" : "Align rollout"
+            },
+            {
+              "expectedDecisions" : [],
+              "id" : "33333333-3333-3333-3333-333333333333",
+              "keyTerms" : [],
+              "objectives" : [],
+              "requiredQuestions" : [],
+              "title" : "Confirm owner"
+            }
+          ],
+          "name" : "Google Meet",
+          "startedAt" : "2026-04-25T10:00:00Z",
+          "transcriptJSONURL" : "file:\\/\\/\\/tmp\\/transcript.json",
+          "transcriptURL" : "file:\\/\\/\\/tmp\\/transcript.txt"
+        }
+        """
+
+        let decoded = try JSONDecoder.meetingAgent.decode(MeetingRecord.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.meetingGoals.map(\.title), ["Align rollout", "Confirm owner"])
+        XCTAssertEqual(decoded.meetingGoal?.title, "Align rollout")
+    }
+
     func testDecodesLegacyMetadataWithoutAgendaFields() throws {
         let json = """
         {
@@ -181,6 +354,7 @@ final class MeetingRecordTests: XCTestCase {
 
         XCTAssertEqual(decoded.attendees, [])
         XCTAssertEqual(decoded.agendaTopics, [])
+        XCTAssertEqual(decoded.meetingGoals, [])
         XCTAssertNil(decoded.scheduledStartAt)
         XCTAssertNil(decoded.scheduledEndAt)
     }

--- a/docs/mistakes/2026-04-29T14-07-26Z.md
+++ b/docs/mistakes/2026-04-29T14-07-26Z.md
@@ -1,0 +1,13 @@
+# [111] Avoid tiny uncovered Swift fallback closures in covered core code
+
+**Date**: 2026-04-29
+**Category**: test-mistake
+
+### What went wrong
+The first multi-goal compatibility implementation used compact `map` fallback closures in core model initialization paths. The behavior was tested, but Swift coverage counted those tiny closures as separate methods and the method coverage gate stayed below 95%.
+
+### Correct approach
+Use explicit fallback branches for small compatibility paths in coverage-enforced core code, especially when the closure does not improve readability.
+
+### How to avoid
+When adding core model fallback logic under method coverage gates, prefer explicit branches over one-off optional closure expressions.

--- a/docs/superpowers/plans/2026-04-29-meeting-goals-list.md
+++ b/docs/superpowers/plans/2026-04-29-meeting-goals-list.md
@@ -1,0 +1,146 @@
+# Meeting Goals List Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add title-only multiple meeting goals, editable as a list and visible in a fixed workspace tracker.
+
+**Architecture:** `MeetingRecord` gains canonical `meetingGoals` while retaining `meetingGoal` as a compatibility bridge. Agenda drafts edit `[String]` goal titles and convert them to normalized `MeetingGoal` values. The workspace right pane renders a `GoalTrackerPanel` above existing insight content, using existing first-goal progress state when available.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Package Manager, XCTest.
+
+---
+
+### Task 1: Model and View-Model Goal Arrays
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingRecord.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingRecordTests.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Write model regression tests**
+
+Add tests that construct JSON with only `meetingGoal` and verify `meetingGoals` contains that goal, and JSON with `meetingGoals` and verify the first value remains the legacy `meetingGoal`.
+
+- [ ] **Step 2: Write save regression test**
+
+Extend `testSaveAgendaNormalizesAndPersistsEditableMetadata` so `MeetingAgendaUpdate` includes multiple goal titles, an empty title, and asserts saved/loaded `meetingGoals.map(\.title)` is trimmed and the legacy `meetingGoal?.title` equals the first saved goal.
+
+- [ ] **Step 3: Implement model compatibility**
+
+Add `meetingGoals: [MeetingGoal]` to `MeetingAgendaUpdate` and `MeetingRecord`, decode it with fallback from `meetingGoal`, encode it normally, and initialize it from either explicit goals or the legacy single goal.
+
+- [ ] **Step 4: Implement view-model normalization**
+
+Add a helper that normalizes goal arrays by trimming titles and dropping blanks. In `saveAgenda`, persist the normalized array and assign `record.meetingGoal = normalizedGoals.first`.
+
+- [ ] **Step 5: Verify focused tests**
+
+Run:
+
+```bash
+swift test --filter MeetingRecordTests
+swift test --filter MeetingAgentViewModelTests/testSaveAgendaNormalizesAndPersistsEditableMetadata
+```
+
+Expected: both pass.
+
+### Task 2: Agenda Goal List Editor
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/TodayAgendaView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write source-layout regression**
+
+Add a layout test that verifies `AgendaDraft` has `goalTexts`, `AgendaEditorView` calls a `goalsEditor`, the UI includes `Add Goal`, and the old `labeledTextEditor("Meeting Goal", text: $draft.goalText)` call is gone.
+
+- [ ] **Step 2: Change `AgendaDraft`**
+
+Replace `goalText` with `goalTexts: [String]`. Load from `meeting.meetingGoals`, fall back to `meeting.meetingGoal`, and ensure the editor always has at least one row. Build `MeetingAgendaUpdate` with `meetingGoals` created from non-empty title rows and `meetingGoal` set to the first goal for compatibility.
+
+- [ ] **Step 3: Add editor controls**
+
+Add a `goalsEditor` section in `AgendaEditorView` with one `TextField` per goal, a remove icon button per row, and an `Add Goal` button that appends an empty row.
+
+- [ ] **Step 4: Update row display**
+
+Change agenda row goal copy to summarize `meeting.meetingGoals`: first title, `+N` suffix for more goals, or `No goals`.
+
+- [ ] **Step 5: Verify focused layout test**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testTodayAgendaViewDefinesGoalListEditor
+```
+
+Expected: pass.
+
+### Task 3: Workspace Goal Tracker
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write source-layout regression**
+
+Add a layout test that verifies `MeetingCommandCenterView` passes `meetingProgressState`, `InsightPaneView` accepts `meetingProgressState`, renders `GoalTrackerPanel`, and the panel appears before `phaseSummary`.
+
+- [ ] **Step 2: Pass progress into right pane**
+
+Add `meetingProgressState: MeetingProgressState?` to `MeetingCommandCenterView` and `InsightPaneView`, pass `viewModel.meetingProgressState` from the main workspace construction, and pass the value into `InsightPaneView`.
+
+- [ ] **Step 3: Add `GoalTrackerPanel`**
+
+Create a private SwiftUI view in `MainWindowView.swift` that renders `meeting.meetingGoals`, or `meeting.meetingGoal` fallback, as title rows. The first goal uses `meetingProgressState.status.displayText` when IDs match; other goals show `Pending`.
+
+- [ ] **Step 4: Update header chip**
+
+Change `goalDisplay` to summarize `meeting.meetingGoals`: first goal title plus `+N`, or `No goals`.
+
+- [ ] **Step 5: Verify focused layout tests**
+
+Run:
+
+```bash
+swift test --filter MainWindowViewLayoutTests/testWorkspaceInsightPaneShowsGoalTracker
+swift test --filter MainWindowViewLayoutTests/testLiveWorkspaceShowsAgendaContextStrip
+```
+
+Expected: both pass.
+
+### Task 4: Full Verification and Commit
+
+**Files:**
+- Modify: implementation and tests from Tasks 1-3
+- Modify: `docs/superpowers/plans/2026-04-29-meeting-goals-list.md`
+
+- [ ] **Step 1: Run build**
+
+Run:
+
+```bash
+swift build --product MeetingAgentApp
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 2: Run required verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: all tests and coverage checks pass.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/MeetingRecord.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Sources/MeetingAgentApp/TodayAgendaView.swift Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MeetingRecordTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/plans/2026-04-29-meeting-goals-list.md
+git commit -m "feat: add meeting goals list (#111)"
+```

--- a/docs/superpowers/specs/2026-04-29-meeting-goals-list-design.md
+++ b/docs/superpowers/specs/2026-04-29-meeting-goals-list-design.md
@@ -1,0 +1,58 @@
+# Meeting Goals List Design
+
+GitHub issue #111 asks to optimize meeting goals so goals are an array, can be added multiple times, and are tracked in a fixed right-side area. The issue is an enhancement and the selected design is the editor list plus workspace tracker option.
+
+## Goals
+
+- Let managers enter multiple meeting goals for one meeting.
+- Show goals as simple title-only rows in the agenda editor, with add and remove controls.
+- Keep the live workspace right pane anchored around goal progress by rendering a goals tracker above summary/details.
+- Preserve existing analyzer and summary behavior by adapting the new list into the current single-goal progress pipeline for this increment.
+
+## Non-Goals
+
+- No UI for per-goal objectives, required questions, expected decisions, or key terms.
+- No LLM-backed multi-goal progress analyzer in this issue.
+- No redesign of transcript, summary generation, export, or recording controls beyond goal display changes.
+
+## Data Model
+
+Add `meetingGoals: [MeetingGoal]` to `MeetingRecord` and `MeetingAgendaUpdate`. Keep `meetingGoal` as a compatibility bridge for existing code and persisted data during this increment.
+
+The canonical editable value becomes `meetingGoals`. When loading older records that only have `meetingGoal`, decode that single value into `meetingGoals`. When saving, normalize the title-only list, remove empty rows, and set the legacy `meetingGoal` to the first saved goal so existing progress, summary, and header code keep working.
+
+## Editor UI
+
+Replace the `AgendaDraft.goalText` textarea with `goalTexts: [String]`. `AgendaEditorView` renders a compact list:
+
+- one text field per goal title
+- a plus button to append a blank row
+- a remove button per row when more than one row exists
+- a fallback blank row when a meeting has no goals yet
+
+Agenda rows and workspace header chips summarize the list by showing the first goal title plus a count when more goals exist, such as `Align rollout +2`.
+
+## Workspace Tracker
+
+`InsightPaneView` gets the meeting's goal list and renders `GoalTrackerPanel` at the top of the right pane. The panel shows each goal title with a compact status chip. The first goal can use the existing `MeetingProgressState` status when it belongs to the selected meeting's active progress goal; additional goals show a neutral pending status until a future multi-goal analyzer exists.
+
+This satisfies fixed right-side tracking without pretending the current analyzer evaluates every goal independently.
+
+## Data Flow
+
+1. `AgendaDraft` loads `meeting.meetingGoals`, falling back through `meeting.meetingGoal`.
+2. Saving an agenda builds `MeetingAgendaUpdate.meetingGoals` from non-empty title rows.
+3. `MeetingAgentViewModel.saveAgenda` persists normalized `meetingGoals` and keeps `meetingGoal` equal to the first goal for compatibility.
+4. `MeetingCommandCenterView` passes `meeting.meetingGoals` and `meetingProgressState` into the right pane.
+5. `InsightPaneView` renders the fixed tracker before recommended questions, summary, and details.
+
+## Error Handling
+
+Saving keeps the existing agenda save error path. Empty goal rows are ignored. If all rows are empty, no goals are saved and the legacy `meetingGoal` is cleared, which also clears progress state through the existing view-model path.
+
+## Testing
+
+- Add model tests for decoding legacy single-goal records into the new goals array.
+- Add view-model tests for saving multiple goals, trimming empty rows, and preserving the first goal as the legacy progress goal.
+- Add source-layout tests that verify `AgendaEditorView` renders list-style goal editing controls and `InsightPaneView` renders a goal tracker before summary/details.
+- Run `make test` as the required verification entrypoint.


### PR DESCRIPTION
## Summary

Fixes #111

- Add canonical multi-goal storage while preserving the existing single-goal compatibility path.
- Replace the agenda goal textarea with title-only add/remove goal rows.
- Pin a goals tracker at the top of the workspace insight pane.

## Changes

- `Sources/MeetingAgentCore/MeetingRecord.swift` - adds `meetingGoals` and legacy decode/initializer fallback behavior.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - normalizes and persists multi-goal agenda updates while keeping `meetingGoal` as the first goal.
- `Sources/MeetingAgentApp/TodayAgendaView.swift` - renders the list-style goal editor and compact row summary.
- `Sources/MeetingAgentApp/MainWindowView.swift` - adds the fixed right-side goals tracker.
- `Tests/MeetingAgentCoreTests/*` - covers compatibility, normalization, and source-layout regressions.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/tmp/meeting-agent-coverage-111d make test` passed, 497 tests, line 96.55%, method 95.12%
- [x] E2E/integration: skipped; no E2E convention for this SwiftUI/source-layout scope
- [x] Code review: PASS manual Swift review; plovr code-review skill is Java/TypeScript-only
- [x] Manual verification: visual design reviewed via brainstorming companion; selected option B