### PR TITLE
feat: restore sidebar app title

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -19,6 +19,12 @@ struct MainWindowView: View {
         NavigationSplitView {
             VStack(spacing: 0) {
                 VStack(spacing: 6) {
+                    Text("Meeting Agent")
+                        .font(CommandCenterTypography.sectionTitle)
+                        .foregroundStyle(CommandCenterPalette.secondaryText)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.bottom, 6)
+
                     Button("Today") {
                         destination = .today
                     }

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -371,13 +371,20 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("destination = .settings"))
     }
 
-    func testSidebarRemovesFixedApplicationTitleHeader() throws {
+    func testSidebarRestoresApplicationTitleAtTopOfNavigation() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
         let source = try String(contentsOf: sourceURL)
 
+        guard let titleRange = source.range(of: "Text(\"Meeting Agent\")") else {
+            return XCTFail("Sidebar application title is missing")
+        }
+        guard let todayRange = source.range(of: "Button(\"Today\")") else {
+            return XCTFail("Today navigation button is missing")
+        }
+
+        XCTAssertLessThan(titleRange.lowerBound, todayRange.lowerBound)
         XCTAssertFalse(source.contains("sidebarHeader"))
-        XCTAssertFalse(source.contains("Text(\"Meeting Agent\")"))
         XCTAssertFalse(source.contains(".navigationTitle(\"Meeting Agent\")"))
     }
 

--- a/docs/mistakes/2026-04-29T14-32-34Z.md
+++ b/docs/mistakes/2026-04-29T14-32-34Z.md
@@ -1,0 +1,13 @@
+# [115] Verify design-system tokens before writing implementation plans
+
+**Date**: 2026-04-29
+**Category**: wrong-assumption
+
+### What went wrong
+The first implementation plan referenced `CommandCenterTypography.label`, but the app design system did not define that font token.
+
+### Correct approach
+Inspect the existing design-system token file before naming concrete typography or palette members in a plan.
+
+### How to avoid
+When a plan includes exact UI token names, verify those names against the source before committing the plan.

--- a/docs/superpowers/plans/2026-04-29-nav-title.md
+++ b/docs/superpowers/plans/2026-04-29-nav-title.md
@@ -1,0 +1,83 @@
+# Navigation Title Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore `Meeting Agent` as a compact left navigation title while avoiding a duplicated top system navigation title.
+
+**Architecture:** Keep the current `NavigationSplitView` and sidebar `VStack`. Add the title as a static SwiftUI `Text` view inside the sidebar button group, then update the source-layout guard that previously asserted the title was absent.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest source-layout tests.
+
+---
+
+### Task 1: Sidebar Title Regression
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+
+- [ ] **Step 1: Update the failing test**
+
+Replace `testSidebarRemovesFixedApplicationTitleHeader` with a regression that expects a sidebar title and checks ordering:
+
+```swift
+func testSidebarRestoresApplicationTitleAtTopOfNavigation() throws {
+    let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")
+    let source = try String(contentsOf: sourceURL)
+
+    guard let titleRange = source.range(of: "Text(\"Meeting Agent\")") else {
+        return XCTFail("Sidebar application title is missing")
+    }
+    guard let todayRange = source.range(of: "Button(\"Today\")") else {
+        return XCTFail("Today navigation button is missing")
+    }
+
+    XCTAssertLessThan(titleRange.lowerBound, todayRange.lowerBound)
+    XCTAssertFalse(source.contains("sidebarHeader"))
+    XCTAssertFalse(source.contains(".navigationTitle(\"Meeting Agent\")"))
+}
+```
+
+- [ ] **Step 2: Run focused test and confirm it fails**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testSidebarRestoresApplicationTitleAtTopOfNavigation`
+
+Expected: FAIL with `Sidebar application title is missing`.
+
+- [ ] **Step 3: Add the minimal sidebar title**
+
+Insert this before `Button("Today")` in `MainWindowView`:
+
+```swift
+Text("Meeting Agent")
+    .font(CommandCenterTypography.label)
+    .foregroundStyle(CommandCenterPalette.secondaryText)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.bottom, 6)
+```
+
+- [ ] **Step 4: Run focused test and confirm it passes**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testSidebarRestoresApplicationTitleAtTopOfNavigation`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run sibling layout tests**
+
+Run: `swift test --filter MainWindowViewLayoutTests`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full required verification**
+
+Run: `make test`
+
+Expected: PASS with coverage gate satisfied.
+
+- [ ] **Step 7: Commit implementation**
+
+```bash
+git add Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+git commit -m "feat: restore sidebar app title (#115)"
+```

--- a/docs/superpowers/plans/2026-04-29-nav-title.md
+++ b/docs/superpowers/plans/2026-04-29-nav-title.md
@@ -51,7 +51,7 @@ Insert this before `Button("Today")` in `MainWindowView`:
 
 ```swift
 Text("Meeting Agent")
-    .font(CommandCenterTypography.label)
+    .font(CommandCenterTypography.sectionTitle)
     .foregroundStyle(CommandCenterPalette.secondaryText)
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.bottom, 6)

--- a/docs/superpowers/specs/2026-04-29-nav-title-design.md
+++ b/docs/superpowers/specs/2026-04-29-nav-title-design.md
@@ -1,0 +1,43 @@
+# Navigation Title Design
+
+## Issue
+
+GitHub issue #115 asks to remove the topmost "Meeting Agent" title and restore "Meeting Agent" at the top of the navigation area.
+
+## User Intent
+
+The app should avoid a duplicated or overly prominent top application title while keeping a clear product label in the left navigation column.
+
+## Requirements
+
+- Show a compact `Meeting Agent` title at the top of the sidebar navigation in `MainWindowView`.
+- Keep the title above `Today`, `Meetings`, and `Library`.
+- Do not use `.navigationTitle("Meeting Agent")` for the main window, because that renders through the system navigation chrome and can reintroduce a top title.
+- Preserve the existing sidebar destinations, selected styles, settings placement, and `NavigationSplitView` structure.
+
+## Non-Requirements
+
+- Do not rename the app bundle, menu bar app, or `WindowGroup`.
+- Do not redesign the sidebar navigation rows.
+- Do not change meeting routing, agenda filtering, or workspace behavior.
+
+## Selected Approach
+
+Add a small `Text("Meeting Agent")` header inside the existing sidebar `VStack` before the navigation buttons. This directly matches the requested nav-top placement and avoids changes to macOS window chrome.
+
+## Alternatives Considered
+
+- Window title only: too subtle and does not restore a nav-top label.
+- Toolbar title: risks recreating the topmost title the issue asks to remove.
+- Sidebar title: closest to the requested placement and lowest risk.
+
+## Affected Files
+
+- `Sources/MeetingAgentApp/MainWindowView.swift`
+- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+## Test Plan
+
+- Update the source-layout regression so it proves the sidebar title exists before the first navigation button.
+- Keep a regression assertion that `.navigationTitle("Meeting Agent")` is absent.
+- Run the focused layout test class and the required `make test` verification.


### PR DESCRIPTION
## Summary

Fixes #115

- Restores a compact `Meeting Agent` title at the top of the left navigation column.
- Keeps the main window from using `.navigationTitle("Meeting Agent")`, avoiding a duplicate top title.

## Changes

- `Sources/MeetingAgentApp/MainWindowView.swift` - adds the sidebar app title above the navigation rows.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - updates the layout regression to verify title placement and absence of system navigation title.
- `docs/superpowers/specs/2026-04-29-nav-title-design.md` - records the approved design.
- `docs/superpowers/plans/2026-04-29-nav-title.md` - records the implementation plan.
- `docs/mistakes/2026-04-29T14-32-34Z.md` - records a reusable planning lesson.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests/testSidebarRestoresApplicationTitleAtTopOfNavigation` failed before implementation, passed after implementation
- [x] Unit tests: `swift test --filter MainWindowViewLayoutTests` passed
- [x] Full verification: `make test` passed with coverage gate
- [x] E2E/integration: skipped, no E2E convention for this static SwiftUI layout change
- [x] Code review: PASS, manual Swift review because available code-review skill only covers TypeScript/Java