### PR TITLE
feat: buffer active transcript persistence

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -844,7 +844,17 @@ public final class MeetingAgentViewModel: ObservableObject {
             configuration: speechConfiguration,
             translationProvider: translationProvider,
             performanceEventLogger: currentPerformanceEventLogger(),
-            persistTranslation: { turn, translatedText, isFinal in
+            persistTranslation: { [weak self] turn, translatedText, isFinal in
+                if let self, self.activeMeetingID == self.selectedMeetingID {
+                    if (try? self.recorder.updateActiveTranscriptTranslation(
+                        segmentID: turn.sourceSegmentID,
+                        text: translatedText,
+                        targetLocale: turn.targetLocale,
+                        isFinal: isFinal
+                    )) == true {
+                        return
+                    }
+                }
                 try? TranscriptFileWriter.updateSegmentTranslation(
                     segmentID: turn.sourceSegmentID,
                     text: translatedText,

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -259,6 +259,23 @@ public final class MeetingRecorder {
         transcriptUpdateSink?.drainResults() ?? []
     }
 
+    @discardableResult
+    public func updateActiveTranscriptTranslation(
+        segmentID: String,
+        text: String,
+        targetLocale: String,
+        isFinal: Bool
+    ) throws -> Bool {
+        guard let transcriptUpdateSink else { return false }
+        try transcriptUpdateSink.updateSegmentTranslation(
+            segmentID: segmentID,
+            text: text,
+            targetLocale: targetLocale,
+            isFinal: isFinal
+        )
+        return true
+    }
+
     public func stopRecording(
         at endedAt: Date = Date(),
         endedReason: CaptureEndedReason = .saved
@@ -362,14 +379,13 @@ public final class MeetingRecorder {
 }
 
 private final class RecordingTranscriptUpdateSink: TranscriptUpdateSink {
-    private let writer: TranscriptFileWriter
+    private let store: RecordingTranscriptPersistenceStore
     private let performanceEventLogger: PerformanceEventLogger?
-    private var accumulator = TranscriptSegmentAccumulator()
     private var pendingResults: [TranscriptSegmentAccumulationResult] = []
     private let lock = NSLock()
 
     init(transcriptURL: URL, performanceEventLogger: PerformanceEventLogger?) throws {
-        self.writer = try TranscriptFileWriter(url: transcriptURL)
+        self.store = try RecordingTranscriptPersistenceStore(transcriptURL: transcriptURL)
         self.performanceEventLogger = performanceEventLogger
     }
 
@@ -377,9 +393,7 @@ private final class RecordingTranscriptUpdateSink: TranscriptUpdateSink {
         lock.lock()
         defer { lock.unlock() }
         logEmitted(update)
-        let result = accumulator.apply(update)
-        pendingResults.append(result)
-        persist(result)
+        persist(update)
     }
 
     func drainResults() -> [TranscriptSegmentAccumulationResult] {
@@ -391,32 +405,54 @@ private final class RecordingTranscriptUpdateSink: TranscriptUpdateSink {
     }
 
     func close() {
-        try? writer.close()
+        lock.lock()
+        defer { lock.unlock() }
+        try? store.close()
     }
 
-    private func persist(_ result: TranscriptSegmentAccumulationResult) {
+    func updateSegmentTranslation(
+        segmentID: String,
+        text: String,
+        targetLocale: String,
+        isFinal: Bool
+    ) throws {
+        let update = TranscriptSegmentUpdate.translationPatch(
+            segmentID: segmentID,
+            text: text,
+            targetLocale: targetLocale,
+            isFinal: isFinal
+        )
+        lock.lock()
+        defer { lock.unlock() }
+        logEmitted(update)
+        let result = try store.apply(update)
+        pendingResults.append(result)
+        logPersisted(result)
+    }
+
+    private func persist(_ update: TranscriptSegmentUpdate) {
+        do {
+            let result = try store.apply(update)
+            pendingResults.append(result)
+            logPersisted(result)
+        } catch {
+            return
+        }
+    }
+
+    private func logPersisted(_ result: TranscriptSegmentAccumulationResult) {
         if let text = result.plainTextReplacement {
-            do {
-                try writer.replace(with: text)
-                performanceEventLogger?.log(
-                    "transcript_segment_persisted",
-                    textLength: text.count,
-                    metadata: ["update": "replaceWithPlainText"]
-                )
-            } catch {
-                return
-            }
+            performanceEventLogger?.log(
+                "transcript_segment_persisted",
+                textLength: text.count,
+                metadata: ["update": "replaceWithPlainText"]
+            )
         } else {
-            do {
-                try writer.replace(with: result.document.segments)
-                for segment in result.document.segments where result.changedSegmentIDs.contains(segment.id) {
-                    performanceEventLogger?.logSegment(
-                        "transcript_segment_persisted",
-                        segment: segment
-                    )
-                }
-            } catch {
-                return
+            for segment in result.document.segments where result.changedSegmentIDs.contains(segment.id) {
+                performanceEventLogger?.logSegment(
+                    "transcript_segment_persisted",
+                    segment: segment
+                )
             }
         }
     }
@@ -434,6 +470,17 @@ private final class RecordingTranscriptUpdateSink: TranscriptUpdateSink {
                 "transcript_segment_emitted",
                 textLength: text.count,
                 metadata: ["update": "replaceWithPlainText"]
+            )
+        case .translationPatch(let segmentID, let text, let targetLocale, let isFinal):
+            performanceEventLogger?.log(
+                "transcript_segment_emitted",
+                segmentID: segmentID,
+                isFinal: isFinal,
+                textLength: text.count,
+                metadata: [
+                    "update": "translationPatch",
+                    "targetLocale": targetLocale
+                ]
             )
         }
     }

--- a/Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift
+++ b/Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift
@@ -1,0 +1,221 @@
+import Foundation
+
+final class RecordingTranscriptPersistenceStore {
+    private let transcriptURL: URL
+    private let eventLogURL: URL
+    private let writer: TranscriptFileWriter
+    private let snapshotInterval: TimeInterval
+    private let now: () -> Date
+    private var accumulator: TranscriptSegmentAccumulator
+    private var lastSnapshotAt: Date
+    private var plainTextReplacement: String?
+
+    init(
+        transcriptURL: URL,
+        snapshotInterval: TimeInterval = 2,
+        now: @escaping () -> Date = Date.init
+    ) throws {
+        self.transcriptURL = transcriptURL
+        self.eventLogURL = transcriptURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("transcript-events.jsonl")
+        self.snapshotInterval = snapshotInterval
+        self.now = now
+        self.lastSnapshotAt = now()
+        let structuredURL = transcriptURL.deletingPathExtension().appendingPathExtension("json")
+        let initialDocument = try TranscriptFileWriter.readDocument(from: structuredURL)
+        self.writer = try TranscriptFileWriter(url: transcriptURL, structuredURL: structuredURL)
+        self.accumulator = TranscriptSegmentAccumulator(document: initialDocument)
+        try replayEvents()
+    }
+
+    var currentDocument: TranscriptDocument {
+        accumulator.currentDocument
+    }
+
+    @discardableResult
+    func apply(_ update: TranscriptSegmentUpdate, forceSnapshot: Bool = false) throws -> TranscriptSegmentAccumulationResult {
+        try validate(update)
+        try appendEvent(for: update)
+        let result = applyInMemory(update)
+        if forceSnapshot || shouldForceSnapshot(for: update) || shouldWriteDebouncedSnapshot() {
+            try flushSnapshot()
+        }
+        return result
+    }
+
+    func flushSnapshot() throws {
+        if let plainTextReplacement {
+            try writer.replace(with: plainTextReplacement)
+        } else {
+            try writer.replace(with: accumulator.currentDocument.segments)
+        }
+        lastSnapshotAt = now()
+    }
+
+    func close() throws {
+        try flushSnapshot()
+        try writer.close()
+    }
+
+    private func replayEvents() throws {
+        guard FileManager.default.fileExists(atPath: eventLogURL.path) else { return }
+        let data = try Data(contentsOf: eventLogURL)
+        guard let contents = String(data: data, encoding: .utf8) else { return }
+        for line in contents.split(whereSeparator: \.isNewline) {
+            let eventData = Data(line.utf8)
+            let event = try JSONDecoder.meetingAgent.decode(RecordingTranscriptEvent.self, from: eventData)
+            _ = applyInMemory(try event.makeUpdate())
+        }
+    }
+
+    private func applyInMemory(_ update: TranscriptSegmentUpdate) -> TranscriptSegmentAccumulationResult {
+        let result = accumulator.apply(update)
+        if let text = result.plainTextReplacement {
+            plainTextReplacement = text
+        } else {
+            plainTextReplacement = nil
+        }
+        return result
+    }
+
+    private func appendEvent(for update: TranscriptSegmentUpdate) throws {
+        try FileManager.default.createDirectory(
+            at: eventLogURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try Self.eventEncoder.encode(RecordingTranscriptEvent(update: update))
+        if FileManager.default.fileExists(atPath: eventLogURL.path) {
+            let handle = try FileHandle(forWritingTo: eventLogURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+            try handle.write(contentsOf: Data([0x0A]))
+        } else {
+            var line = data
+            line.append(0x0A)
+            try line.write(to: eventLogURL, options: .atomic)
+        }
+    }
+
+    private func shouldForceSnapshot(for update: TranscriptSegmentUpdate) -> Bool {
+        switch update {
+        case .replaceAll, .replaceWithPlainText:
+            return true
+        case .upsert, .translationPatch:
+            return false
+        }
+    }
+
+    private func shouldWriteDebouncedSnapshot() -> Bool {
+        now().timeIntervalSince(lastSnapshotAt) >= snapshotInterval
+    }
+
+    private func validate(_ update: TranscriptSegmentUpdate) throws {
+        switch update {
+        case .translationPatch(let segmentID, let text, let targetLocale, _):
+            let normalizedSegmentID = segmentID.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let normalizedTargetLocale = targetLocale.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalizedSegmentID.isEmpty, !normalizedText.isEmpty, !normalizedTargetLocale.isEmpty else {
+                throw ProbeError.invalidArguments("Segment ID, translated text, and target locale are required")
+            }
+            guard accumulator.currentDocument.segments.contains(where: { $0.id == normalizedSegmentID }) else {
+                throw ProbeError.invalidArguments("Transcript segment not found")
+            }
+        case .upsert, .replaceAll, .replaceWithPlainText:
+            return
+        }
+    }
+
+    private static var eventEncoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }
+}
+
+private struct RecordingTranscriptEvent: Codable {
+    let type: EventType
+    let segment: TranscriptSegment?
+    let segments: [TranscriptSegment]?
+    let text: String?
+    let segmentID: String?
+    let targetLocale: String?
+    let isFinal: Bool?
+
+    init(update: TranscriptSegmentUpdate) {
+        switch update {
+        case .upsert(let segment):
+            self.type = .upsert
+            self.segment = segment
+            self.segments = nil
+            self.text = nil
+            self.segmentID = nil
+            self.targetLocale = nil
+            self.isFinal = nil
+        case .replaceAll(let segments):
+            self.type = .replaceAll
+            self.segment = nil
+            self.segments = segments
+            self.text = nil
+            self.segmentID = nil
+            self.targetLocale = nil
+            self.isFinal = nil
+        case .replaceWithPlainText(let text):
+            self.type = .replaceWithPlainText
+            self.segment = nil
+            self.segments = nil
+            self.text = text
+            self.segmentID = nil
+            self.targetLocale = nil
+            self.isFinal = nil
+        case .translationPatch(let segmentID, let text, let targetLocale, let isFinal):
+            self.type = .translationPatch
+            self.segment = nil
+            self.segments = nil
+            self.text = text
+            self.segmentID = segmentID
+            self.targetLocale = targetLocale
+            self.isFinal = isFinal
+        }
+    }
+
+    func makeUpdate() throws -> TranscriptSegmentUpdate {
+        switch type {
+        case .upsert:
+            guard let segment else {
+                throw ProbeError.invalidArguments("Transcript event is missing a segment payload")
+            }
+            return .upsert(segment)
+        case .replaceAll:
+            guard let segments else {
+                throw ProbeError.invalidArguments("Transcript event is missing a segment list payload")
+            }
+            return .replaceAll(segments)
+        case .replaceWithPlainText:
+            guard let text else {
+                throw ProbeError.invalidArguments("Transcript event is missing a plain-text payload")
+            }
+            return .replaceWithPlainText(text)
+        case .translationPatch:
+            guard let segmentID, let text, let targetLocale, let isFinal else {
+                throw ProbeError.invalidArguments("Transcript event is missing a translation patch payload")
+            }
+            return .translationPatch(
+                segmentID: segmentID,
+                text: text,
+                targetLocale: targetLocale,
+                isFinal: isFinal
+            )
+        }
+    }
+
+    enum EventType: String, Codable {
+        case upsert
+        case replaceAll
+        case replaceWithPlainText
+        case translationPatch
+    }
+}

--- a/Sources/MeetingAgentCore/TranscriptSegmentAccumulator.swift
+++ b/Sources/MeetingAgentCore/TranscriptSegmentAccumulator.swift
@@ -4,6 +4,7 @@ public enum TranscriptSegmentUpdate: Equatable {
     case upsert(TranscriptSegment)
     case replaceAll([TranscriptSegment])
     case replaceWithPlainText(String)
+    case translationPatch(segmentID: String, text: String, targetLocale: String, isFinal: Bool)
 }
 
 public struct TranscriptSegmentAccumulationResult: Equatable {
@@ -42,7 +43,55 @@ public struct TranscriptSegmentAccumulator {
                 changedSegmentIDs: [],
                 plainTextReplacement: text
             )
+        case .translationPatch(let segmentID, let text, let targetLocale, let isFinal):
+            return applyTranslationPatch(
+                segmentID: segmentID,
+                text: text,
+                targetLocale: targetLocale,
+                isFinal: isFinal
+            )
         }
+    }
+
+    private mutating func applyTranslationPatch(
+        segmentID: String,
+        text: String,
+        targetLocale: String,
+        isFinal: Bool
+    ) -> TranscriptSegmentAccumulationResult {
+        let normalizedSegmentID = segmentID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedTargetLocale = targetLocale.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let index = document.segments.firstIndex(where: { $0.id == normalizedSegmentID }) else {
+            return TranscriptSegmentAccumulationResult(
+                document: document,
+                changedSegmentIDs: [],
+                plainTextReplacement: nil
+            )
+        }
+        let segment = document.segments[index]
+        document.segments[index] = TranscriptSegment(
+            id: segment.id,
+            speaker: segment.speaker,
+            startTimeSeconds: segment.startTimeSeconds,
+            endTimeSeconds: segment.endTimeSeconds,
+            text: segment.text,
+            language: segment.language,
+            sourceProvider: segment.sourceProvider,
+            isFinal: segment.isFinal,
+            speechFinal: segment.speechFinal,
+            confidence: segment.confidence,
+            createdAt: segment.createdAt,
+            timingSource: segment.timingSource,
+            translatedText: normalizedText,
+            translationTargetLocale: normalizedTargetLocale,
+            translationIsFinal: isFinal
+        )
+        return TranscriptSegmentAccumulationResult(
+            document: document,
+            changedSegmentIDs: [normalizedSegmentID],
+            plainTextReplacement: nil
+        )
     }
 
     private mutating func applyUpsert(_ segment: TranscriptSegment) -> TranscriptSegmentAccumulationResult {

--- a/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
@@ -289,7 +289,7 @@ final class MeetingRecorderTests: XCTestCase {
         XCTAssertEqual(updates.flatMap { $0.document.segments.map(\.text) }, ["hello live"])
     }
 
-    func testRecorderPersistsCanonicalTranscriptFromUpdates() async throws {
+    func testRecorderBuffersTranscriptArtifactsUntilStop() async throws {
         let fixture = try RecorderFixture()
         defer { try? FileManager.default.removeItem(at: fixture.storeRoot) }
         let record = try fixture.recorder.prepareRecord(for: fixture.target, startedAt: Date(timeIntervalSince1970: 100))
@@ -305,8 +305,55 @@ final class MeetingRecorderTests: XCTestCase {
 
         _ = fixture.recorder.drainTranscriptUpdates()
 
+        XCTAssertEqual(try String(contentsOf: XCTUnwrap(record.transcriptURL), encoding: .utf8), "")
+        XCTAssertEqual(
+            try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL)).segments,
+            []
+        )
+
+        _ = try fixture.recorder.stopRecording(at: Date(timeIntervalSince1970: 200))
+
         let document = try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL))
         XCTAssertEqual(document.segments.map(\.text), ["persist me"])
+        XCTAssertEqual(try String(contentsOf: XCTUnwrap(record.transcriptURL), encoding: .utf8), "User A:\npersist me\n")
+        XCTAssertEqual(try transcriptEventLogLineCount(for: record), 1)
+    }
+
+    func testRecorderPatchesActiveTranscriptTranslationWithoutImmediateArtifactRewrite() async throws {
+        let fixture = try RecorderFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.storeRoot) }
+        let record = try fixture.recorder.prepareRecord(for: fixture.target, startedAt: Date(timeIntervalSince1970: 100))
+        try await fixture.recorder.startRecording(target: fixture.target, record: record)
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "Confirm owner.",
+            language: "en-US",
+            sourceProvider: "fake",
+            isFinal: true
+        )))
+
+        let didPatch = try fixture.recorder.updateActiveTranscriptTranslation(
+            segmentID: "segment-1",
+            text: "确认负责人。",
+            targetLocale: "zh-CN",
+            isFinal: true
+        )
+        let updates = fixture.recorder.drainTranscriptUpdates()
+
+        XCTAssertTrue(didPatch)
+        XCTAssertEqual(updates.last?.document.segments.first?.translatedText, "确认负责人。")
+        XCTAssertEqual(try String(contentsOf: XCTUnwrap(record.transcriptURL), encoding: .utf8), "")
+        XCTAssertEqual(
+            try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL)).segments,
+            []
+        )
+
+        _ = try fixture.recorder.stopRecording(at: Date(timeIntervalSince1970: 200))
+        let document = try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL))
+        XCTAssertEqual(document.segments.first?.translatedText, "确认负责人。")
+        XCTAssertEqual(document.segments.first?.translationTargetLocale, "zh-CN")
+        XCTAssertEqual(document.segments.first?.translationIsFinal, true)
+        XCTAssertEqual(try transcriptEventLogLineCount(for: record), 2)
     }
 
     func testTranscriptUpdatePipelineLogsEmittedAndPersistedEvents() async throws {
@@ -515,6 +562,15 @@ private func performanceEventNames(at url: URL) throws -> [String] {
     try String(contentsOf: url, encoding: .utf8)
         .split(separator: "\n")
         .map { try JSONDecoder.meetingAgent.decode(PerformanceEvent.self, from: Data($0.utf8)).event }
+}
+
+private func transcriptEventLogLineCount(for record: MeetingRecord) throws -> Int {
+    let eventLogURL = try XCTUnwrap(record.transcriptURL)
+        .deletingLastPathComponent()
+        .appendingPathComponent("transcript-events.jsonl")
+    return try String(contentsOf: eventLogURL, encoding: .utf8)
+        .split(whereSeparator: \.isNewline)
+        .count
 }
 
 private func XCTAssertThrowsErrorAsync(

--- a/Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+@testable import MeetingAgentCore
+
+final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
+    func testUpsertAppendsEventWithoutImmediateTextSnapshot() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "hello", isFinal: false)))
+
+        XCTAssertEqual(store.currentDocument.segments.map(\.id), ["segment-1"])
+        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "")
+        XCTAssertEqual(try TranscriptFileWriter.readDocument(from: fixture.structuredURL), TranscriptDocument())
+        XCTAssertEqual(try fixture.eventLogLineCount(), 1)
+    }
+
+    func testDebouncedSnapshotWritesCompleteArtifacts() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 2,
+            now: fixture.now
+        )
+
+        try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "hello", isFinal: true)))
+        fixture.currentDate = Date(timeIntervalSince1970: 3)
+        try store.apply(.upsert(TranscriptSegment(id: "segment-2", text: "world", isFinal: true)))
+
+        let document = try TranscriptFileWriter.readDocument(from: fixture.structuredURL)
+        XCTAssertEqual(document.segments.map(\.id), ["segment-1", "segment-2"])
+        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nhello world\n")
+    }
+
+    func testTranslationPatchDoesNotSnapshotBeforeDebounce() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "Confirm owner.", isFinal: true)))
+        try store.apply(.translationPatch(
+            segmentID: "segment-1",
+            text: "确认负责人。",
+            targetLocale: "zh-CN",
+            isFinal: true
+        ))
+
+        XCTAssertEqual(store.currentDocument.segments.first?.translatedText, "确认负责人。")
+        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "")
+        XCTAssertEqual(try fixture.eventLogLineCount(), 2)
+    }
+
+    func testCloseFlushesFinalSnapshot() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "hello", isFinal: true)))
+        try store.close()
+
+        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nhello\n")
+        XCTAssertEqual(
+            try TranscriptFileWriter.readDocument(from: fixture.structuredURL).segments.map(\.id),
+            ["segment-1"]
+        )
+    }
+
+    func testRecoversFromSnapshotPlusEventLog() throws {
+        let fixture = try StoreFixture()
+        try TranscriptFileWriter(url: fixture.transcriptURL).replace(with: [
+            TranscriptSegment(id: "snapshot-segment", text: "from snapshot", isFinal: true)
+        ])
+        var currentDate = Date(timeIntervalSince1970: 0)
+        let firstStore = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: { currentDate }
+        )
+        try firstStore.apply(.upsert(TranscriptSegment(id: "event-segment", text: "from event", isFinal: true)))
+
+        currentDate = Date(timeIntervalSince1970: 1)
+        let recovered = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: { currentDate }
+        )
+
+        XCTAssertEqual(recovered.currentDocument.segments.map(\.id), ["snapshot-segment", "event-segment"])
+        try recovered.flushSnapshot()
+        XCTAssertEqual(
+            try TranscriptFileWriter.readDocument(from: fixture.structuredURL).segments.map(\.id),
+            ["snapshot-segment", "event-segment"]
+        )
+    }
+
+    func testReplaceWithPlainTextForcesSnapshotAndClearsStructuredDocument() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "hello", isFinal: true)))
+        try store.apply(.replaceWithPlainText("Speech recognition unavailable"))
+
+        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "Speech recognition unavailable\n")
+        XCTAssertEqual(try TranscriptFileWriter.readDocument(from: fixture.structuredURL), TranscriptDocument())
+    }
+
+    func testReplaceAllForcesSnapshotAndCanBeReplayed() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        try store.apply(.replaceAll([
+            TranscriptSegment(id: "segment-1", text: "first", isFinal: true),
+            TranscriptSegment(id: "segment-2", text: "second", isFinal: true)
+        ]))
+
+        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nfirst second\n")
+        let recovered = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+        XCTAssertEqual(recovered.currentDocument.segments.map(\.id), ["segment-1", "segment-2"])
+    }
+
+    func testRecoveryReplaysTranslationPatchAndPlainTextReplacement() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "Confirm owner.", isFinal: true)))
+        try store.apply(.translationPatch(
+            segmentID: "segment-1",
+            text: "确认负责人。",
+            targetLocale: "zh-CN",
+            isFinal: true
+        ))
+        let recoveredTranslation = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        XCTAssertEqual(recoveredTranslation.currentDocument.segments.first?.translatedText, "确认负责人。")
+
+        try store.apply(.replaceWithPlainText("Speech recognition unavailable"))
+        let recoveredPlainText = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+        try recoveredPlainText.flushSnapshot()
+
+        XCTAssertEqual(recoveredPlainText.currentDocument, TranscriptDocument())
+        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "Speech recognition unavailable\n")
+    }
+
+    func testTranslationPatchRejectsBlankInputs() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+        try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "Confirm owner.", isFinal: true)))
+
+        XCTAssertThrowsError(try store.apply(.translationPatch(
+            segmentID: " ",
+            text: "确认负责人。",
+            targetLocale: "zh-CN",
+            isFinal: true
+        )))
+        XCTAssertThrowsError(try store.apply(.translationPatch(
+            segmentID: "segment-1",
+            text: " ",
+            targetLocale: "zh-CN",
+            isFinal: true
+        )))
+        XCTAssertThrowsError(try store.apply(.translationPatch(
+            segmentID: "segment-1",
+            text: "确认负责人。",
+            targetLocale: " ",
+            isFinal: true
+        )))
+    }
+
+    func testMalformedEventLogFailsRecovery() throws {
+        let fixture = try StoreFixture()
+        try #"{"type":"upsert"}"#.write(to: fixture.eventLogURL, atomically: true, encoding: .utf8)
+
+        XCTAssertThrowsError(try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        ))
+    }
+}
+
+private final class StoreFixture {
+    let directory: URL
+    let transcriptURL: URL
+    let structuredURL: URL
+    let eventLogURL: URL
+    var currentDate = Date(timeIntervalSince1970: 0)
+
+    init() throws {
+        directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "recording-transcript-store-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        transcriptURL = directory.appendingPathComponent("transcript.txt")
+        structuredURL = directory.appendingPathComponent("transcript.json")
+        eventLogURL = directory.appendingPathComponent("transcript-events.jsonl")
+    }
+
+    deinit {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    func now() -> Date {
+        currentDate
+    }
+
+    func eventLogLineCount() throws -> Int {
+        let contents = try String(contentsOf: eventLogURL, encoding: .utf8)
+        return contents.split(whereSeparator: \.isNewline).count
+    }
+}

--- a/Tests/MeetingAgentCoreTests/TranscriptSegmentAccumulatorTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptSegmentAccumulatorTests.swift
@@ -72,6 +72,60 @@ final class TranscriptSegmentAccumulatorTests: XCTestCase {
         XCTAssertEqual(result.document.segments.first?.translationIsFinal, true)
     }
 
+    func testTranslationPatchUpdatesMatchingSegment() {
+        var accumulator = TranscriptSegmentAccumulator(document: TranscriptDocument(segments: [
+            TranscriptSegment(id: "segment-1", text: "Confirm owner."),
+            TranscriptSegment(id: "segment-2", text: "Review timeline.")
+        ]))
+
+        let result = accumulator.apply(.translationPatch(
+            segmentID: "segment-2",
+            text: "复查时间线。",
+            targetLocale: "zh-CN",
+            isFinal: true
+        ))
+
+        XCTAssertEqual(result.changedSegmentIDs, ["segment-2"])
+        XCTAssertNil(result.document.segments[0].translatedText)
+        XCTAssertEqual(result.document.segments[1].translatedText, "复查时间线。")
+        XCTAssertEqual(result.document.segments[1].translationTargetLocale, "zh-CN")
+        XCTAssertEqual(result.document.segments[1].translationIsFinal, true)
+    }
+
+    func testTranslationPatchMissingSegmentLeavesDocumentUnchanged() {
+        let document = TranscriptDocument(segments: [
+            TranscriptSegment(id: "segment-1", text: "Confirm owner.")
+        ])
+        var accumulator = TranscriptSegmentAccumulator(document: document)
+
+        let result = accumulator.apply(.translationPatch(
+            segmentID: "missing",
+            text: "确认负责人。",
+            targetLocale: "zh-CN",
+            isFinal: false
+        ))
+
+        XCTAssertEqual(result.changedSegmentIDs, [])
+        XCTAssertEqual(result.document, document)
+    }
+
+    func testTranslationPatchNormalizesInputs() {
+        var accumulator = TranscriptSegmentAccumulator(document: TranscriptDocument(segments: [
+            TranscriptSegment(id: "segment-1", text: "Confirm owner.")
+        ]))
+
+        let result = accumulator.apply(.translationPatch(
+            segmentID: " segment-1 ",
+            text: " 确认负责人。 ",
+            targetLocale: " zh-CN ",
+            isFinal: false
+        ))
+
+        XCTAssertEqual(result.changedSegmentIDs, ["segment-1"])
+        XCTAssertEqual(result.document.segments.first?.translatedText, "确认负责人。")
+        XCTAssertEqual(result.document.segments.first?.translationTargetLocale, "zh-CN")
+    }
+
     func testFileBackedTranscriptUpdateSinkPersistsUpdates() throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("transcript-sink-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/docs/mistakes/2026-04-30T06-12-31Z.md
+++ b/docs/mistakes/2026-04-30T06-12-31Z.md
@@ -1,0 +1,13 @@
+# [85] Avoid optional fallback closures in coverage-enforced code
+
+**Date**: 2026-04-30
+**Category**: test-mistake
+
+### What went wrong
+The first JSONL transcript event replay implementation used compact `??` fallback expressions for missing event payloads. Swift coverage counted those tiny fallback closures as separate methods, keeping method coverage below the 95% gate even though behavior tests passed.
+
+### Correct approach
+Use explicit guard or if-let branches for payload validation and throw on malformed recovery events instead of synthesizing silent fallback values.
+
+### How to avoid
+In coverage-enforced core files, avoid compact optional fallback closures for Codable recovery paths; prefer explicit validation branches.

--- a/docs/superpowers/plans/2026-04-30-live-transcript-persistence.md
+++ b/docs/superpowers/plans/2026-04-30-live-transcript-persistence.md
@@ -1,0 +1,72 @@
+# Live Transcript Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build active-recording transcript persistence that avoids full artifact rewrites for every live segment and translation update.
+
+**Architecture:** Add a focused `RecordingTranscriptPersistenceStore` that owns active in-memory transcript state, JSONL mutation logging, recovery, debounced snapshots, and forced final flushes. Wire `MeetingRecorder` and live caption translation persistence to this active store while keeping `TranscriptFileWriter` as the final artifact renderer and legacy helper.
+
+**Tech Stack:** Swift 5.9, Foundation file APIs, XCTest, existing `TranscriptSegmentAccumulator`, `TranscriptFileWriter`, `MeetingRecorder`, and `LiveCaptionPipeline`.
+
+---
+
+### Task 1: Extend Transcript Mutation Semantics
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/TranscriptSegmentAccumulator.swift`
+- Test: `Tests/MeetingAgentCoreTests/TranscriptSegmentAccumulatorTests.swift`
+
+- [ ] Add a `translationPatch(segmentID:text:targetLocale:isFinal:)` case to `TranscriptSegmentUpdate`.
+- [ ] Implement accumulator support that updates the matching segment translation fields in memory.
+- [ ] Return the patched segment ID in `changedSegmentIDs`.
+- [ ] Add tests for successful patch and missing-segment no-op behavior.
+- [ ] Run `swift test --filter TranscriptSegmentAccumulatorTests`.
+
+### Task 2: Add Recording Transcript Persistence Store
+
+**Files:**
+- Create: `Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift`
+- Test: `Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift`
+
+- [ ] Define a Codable JSONL event wrapper for segment updates.
+- [ ] Initialize from `transcript.json`, then replay `transcript-events.jsonl`.
+- [ ] Append every mutation to `transcript-events.jsonl` immediately.
+- [ ] Keep `TranscriptDocument` canonical in memory.
+- [ ] Snapshot through `TranscriptFileWriter.replace(...)` only when forced or the configured interval has elapsed.
+- [ ] Add tests for no immediate text rewrite, debounced snapshot, forced flush, translation patch, and recovery.
+- [ ] Run `swift test --filter RecordingTranscriptPersistenceStoreTests`.
+
+### Task 3: Wire Active Store Into MeetingRecorder
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingRecorder.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift`
+
+- [ ] Replace the private sink's direct `TranscriptFileWriter.replace(...)` persistence with `RecordingTranscriptPersistenceStore`.
+- [ ] Keep pending UI drain results unchanged.
+- [ ] Force `flushSnapshot()` when the sink closes.
+- [ ] Add a recorder-level test proving stop writes final `transcript.json` and `transcript.txt`.
+- [ ] Run `swift test --filter MeetingRecorderTests`.
+
+### Task 4: Route Active Caption Translation Patches
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] Add an optional translation-patch capability without breaking existing `TranscriptUpdateSink` conformers.
+- [ ] Make `MeetingRecorder` expose a method that patches active transcript translation if an active sink exists.
+- [ ] In `MeetingAgentViewModel.makeLiveCaptionPipeline`, try the active recorder patch before falling back to `TranscriptFileWriter.updateSegmentTranslation(...)`.
+- [ ] Add or update tests so active recording translation persistence does not require full artifact rewrite per translation.
+- [ ] Run focused affected tests.
+
+### Task 5: Full Verification and Commit
+
+**Files:**
+- Verify all modified source and test files.
+
+- [ ] Run `swift build --product MeetingAgentApp`.
+- [ ] Run `make test`.
+- [ ] Inspect `git diff`.
+- [ ] Commit implementation with `feat: buffer active transcript persistence (#85)`.

--- a/docs/superpowers/specs/2026-04-30-live-transcript-persistence-design.md
+++ b/docs/superpowers/specs/2026-04-30-live-transcript-persistence-design.md
@@ -1,0 +1,72 @@
+# Live Transcript Persistence Design
+
+## Issue
+
+GitHub issue #85 asks the active recording path to stop rewriting complete transcript artifacts on every live segment or caption translation update. Existing meetings and exports must still use `transcript.json` and `transcript.txt`, and stopping a recording must leave complete final artifacts on disk.
+
+## Goals
+
+- Keep the canonical transcript document in memory while a recording is active.
+- Persist live mutations to an append-only `transcript-events.jsonl` event log.
+- Write `transcript.json` and `transcript.txt` only through a buffered snapshot path during active recording.
+- Force a complete snapshot flush when recording stops or the recorder closes the transcript persistence path.
+- Preserve backward compatibility for existing `transcript.json` and `transcript.txt` readers.
+- Let caption translation persistence update the active in-memory document without reading and rewriting the full artifact per update.
+
+## Non-Goals
+
+- Do not change the historical transcript artifact format.
+- Do not move live caption display ownership out of `LiveCaptionPipeline`.
+- Do not replace legacy static `TranscriptFileWriter` edit helpers used by post-recording manual edits.
+- Do not introduce a broad actor/concurrency rewrite of the recorder.
+
+## Selected Approach
+
+Add a small active-recording persistence store owned by `MeetingRecorder` for the lifetime of the recording. The store wraps `TranscriptSegmentAccumulator`, accepts structured transcript mutations, appends each mutation to `transcript-events.jsonl`, and snapshots the complete `TranscriptDocument` to the legacy artifacts only when the debounce policy says a snapshot is due or when callers explicitly flush.
+
+The existing `TranscriptFileWriter` remains the final artifact renderer and legacy helper. Active recording paths should use the new store through `RecordingTranscriptUpdateSink`, while retry/batch paths may keep using `FileBackedTranscriptUpdateSink`.
+
+## Data Flow
+
+1. `MeetingRecorder.startRecording` creates `RecordingTranscriptUpdateSink` with the active transcript URL.
+2. Streaming transcribers call `TranscriptUpdateSink.receive(.upsert(...))`, `.replaceAll(...)`, or `.replaceWithPlainText(...)`.
+3. `RecordingTranscriptUpdateSink` logs emitted updates, applies them to the active store, queues `TranscriptSegmentAccumulationResult` for the UI drain loop, and only snapshots when the store reports a due snapshot.
+4. Caption translation persistence calls an active sink translation patch when available. If no active sink is available, it falls back to `TranscriptFileWriter.updateSegmentTranslation(...)`.
+5. `MeetingRecorder.stopRecording` closes the active sink, forcing a final snapshot before the record is marked stopped.
+
+## Mutation Model
+
+Extend transcript mutations with:
+
+- `upsert(TranscriptSegment)`
+- `replaceAll([TranscriptSegment])`
+- `replaceWithPlainText(String)`
+- `translationPatch(segmentID:text:targetLocale:isFinal:)`
+
+The accumulator should apply translation patches to the in-memory document and preserve current validation behavior: segment ID, text, and target locale must be non-empty, and missing segment IDs should fail for throwing store APIs.
+
+## Event Log
+
+The event log lives beside the transcript artifacts as `transcript-events.jsonl`. Each line is a JSON object containing an event type and associated payload. Store initialization reads the current snapshot, then replays the event log so crash/restart recovery can rebuild state from the last snapshot plus subsequent mutations.
+
+## Snapshot Policy
+
+Use a deterministic, testable policy:
+
+- The store accepts a `snapshotInterval` and a `now` closure.
+- Segment upserts and translation patches append events immediately.
+- Snapshot writes occur when the interval has elapsed since the last snapshot.
+- `replaceAll`, `replaceWithPlainText`, and close/stop force snapshots because they are boundary or failure states.
+- Tests can set a long interval to prove no per-update text rewrite, then explicitly advance `now` or call flush to prove durable snapshots.
+
+## Testing
+
+Add unit tests for:
+
+- segment upsert updates in-memory state and event log without rewriting `transcript.txt` before the debounce interval
+- translation patch updates in-memory state and event log without a full snapshot before the debounce interval
+- debounced snapshot writes complete `transcript.json` and `transcript.txt`
+- close/stop flush writes complete final artifacts
+- recovery replays `transcript-events.jsonl` over an existing snapshot
+
+Existing `make test` remains the final verification command.


### PR DESCRIPTION
## Summary

Fixes #85

- Adds an active-recording transcript persistence store with in-memory canonical state, JSONL event logging, debounced snapshots, forced stop flush, and recovery from snapshot plus event log.
- Routes live segment updates and active caption translation patches through the active store instead of rewriting full transcript artifacts per update.
- Keeps legacy `transcript.json` / `transcript.txt` artifact compatibility for loading, export, stop, and non-active edit paths.

## Changes

- `Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift` - new active persistence store, JSONL events, recovery, debounce, and forced snapshot rendering.
- `Sources/MeetingAgentCore/TranscriptSegmentAccumulator.swift` - adds structured translation patch mutation.
- `Sources/MeetingAgentCore/MeetingRecorder.swift` - owns the active store through the recording sink and flushes on stop.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - sends caption translation persistence to the active recorder only for the selected active meeting, with legacy fallback.
- `Tests/MeetingAgentCoreTests/*` - regression coverage for upsert, translation patch, debounce, stop flush, event recovery, malformed events, and recorder integration.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `make test` passed, 563 tests, coverage line 97.05%, method 95.33%
- [x] E2E/integration: skipped; no E2E convention for core transcript persistence behavior
- [x] Code review: PASS, manual Swift review; `plovr-claude-code:code-review` is TypeScript/Java-only and not applicable to this Swift package
- [x] Manual verification: reviewed diff for event-log replay, stop flush, translation-patch routing, and selected-active-meeting guard