### PR TITLE
feat: budget caption translation requests

### DIFF
--- a/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
+++ b/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
@@ -107,10 +107,16 @@ public final class CaptionTranslationScheduler {
             store.markTranslationCompleteWithoutText(forTurnID: update.turnID)
         case .draftText(let text):
             store.attachTranslation(text, toTurnID: update.turnID)
+            if let request = update.request {
+                logAttached(request: request, textLength: text.count)
+            }
             persistTranslation?(current, text, false)
         case .finalText(let text):
             store.attachTranslation(text, toTurnID: update.turnID)
             store.markTranslationFinal(forTurnID: update.turnID)
+            if let request = update.request {
+                logAttached(request: request, textLength: text.count)
+            }
             persistTranslation?(current, text, true)
         case .failed(let message):
             store.markTranslationFailed(forTurnID: update.turnID, message: message)
@@ -337,18 +343,14 @@ public final class CaptionTranslationScheduler {
                 textLength: translatedText.count,
                 metadata: metadata
             )
-            logger?.log(
-                "caption_translation_attached",
-                segmentID: request.turn.id,
-                isFinal: !request.isDraft,
-                textLength: translatedText.count,
-                metadata: metadata
-            )
+            var completedRequest = request
+            completedRequest.queueDepth = queueDepth
+            completedRequest.inFlightCount = inFlightCount
             return CaptionTranslationUpdate(
                 turnID: request.turn.id,
                 key: request.key,
                 result: request.isDraft ? .draftText(translatedText) : .finalText(translatedText),
-                request: request
+                request: completedRequest
             )
         } catch {
             let nsError = error as NSError
@@ -427,6 +429,16 @@ public final class CaptionTranslationScheduler {
         )
     }
 
+    private func logAttached(request: ActiveCaptionTranslationRequest, textLength: Int) {
+        performanceEventLogger?.log(
+            "caption_translation_attached",
+            segmentID: request.turn.id,
+            isFinal: !request.isDraft,
+            textLength: textLength,
+            metadata: translationMetadata(for: request)
+        )
+    }
+
     private func translationMetadata(
         for request: ActiveCaptionTranslationRequest,
         extra: [String: String] = [:]
@@ -453,6 +465,12 @@ public final class CaptionTranslationScheduler {
         }
         if let boundaryReason = turn.boundaryReason {
             metadata["boundaryReason"] = boundaryReason.rawValue
+        }
+        if let queueDepth = request.queueDepth {
+            metadata["queueDepth"] = String(queueDepth)
+        }
+        if let inFlightCount = request.inFlightCount {
+            metadata["inFlightCount"] = String(inFlightCount)
         }
         for (key, value) in extra {
             metadata[key] = value
@@ -510,6 +528,8 @@ struct ActiveCaptionTranslationRequest: Equatable {
     var requestOrdinalForTurn: Int = 1
     var sourceText: String = ""
     var configuration: CaptionTranslationSchedulerConfiguration = CaptionTranslationSchedulerConfiguration()
+    var queueDepth: Int?
+    var inFlightCount: Int?
 }
 
 private struct CaptionTranslationExecution {
@@ -552,6 +572,12 @@ private enum CaptionTranslationExecutionMetadata {
         }
         if let boundaryReason = turn.boundaryReason {
             metadata["boundaryReason"] = boundaryReason.rawValue
+        }
+        if let queueDepth = request.queueDepth {
+            metadata["queueDepth"] = String(queueDepth)
+        }
+        if let inFlightCount = request.inFlightCount {
+            metadata["inFlightCount"] = String(inFlightCount)
         }
         return metadata
     }

--- a/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
+++ b/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
@@ -1,21 +1,39 @@
 import Foundation
 
+public struct CaptionTranslationSchedulerConfiguration: Equatable {
+    public var draftDebounceNanoseconds: UInt64
+    public var maxConcurrentTranslationRequests: Int
+
+    public init(
+        draftDebounceNanoseconds: UInt64 = 200_000_000,
+        maxConcurrentTranslationRequests: Int = 2
+    ) {
+        self.draftDebounceNanoseconds = draftDebounceNanoseconds
+        self.maxConcurrentTranslationRequests = max(1, maxConcurrentTranslationRequests)
+    }
+}
+
 @MainActor
 public final class CaptionTranslationScheduler {
     private let provider: TextTranslationProvider?
     private let performanceEventLogger: PerformanceEventLogger?
     private let persistTranslation: ((LiveCaptionTurn, String, Bool) -> Void)?
+    private let configuration: CaptionTranslationSchedulerConfiguration
     private var requestedFinalTranslationKeys: Set<String> = []
     private var activeRequestsByKey: [String: ActiveCaptionTranslationRequest] = [:]
+    private var pendingDraftTokensByTurnID: [String: UUID] = [:]
+    private var requestOrdinalsByTurnID: [String: Int] = [:]
 
     public init(
         provider: TextTranslationProvider?,
         performanceEventLogger: PerformanceEventLogger?,
-        persistTranslation: ((LiveCaptionTurn, String, Bool) -> Void)? = nil
+        persistTranslation: ((LiveCaptionTurn, String, Bool) -> Void)? = nil,
+        configuration: CaptionTranslationSchedulerConfiguration = CaptionTranslationSchedulerConfiguration()
     ) {
         self.provider = provider
         self.performanceEventLogger = performanceEventLogger
         self.persistTranslation = persistTranslation
+        self.configuration = configuration
     }
 
     public func scheduleTranslations(in store: inout LiveCaptionStore) async {
@@ -33,7 +51,7 @@ public final class CaptionTranslationScheduler {
     }
 
     private func translationUpdates(for store: LiveCaptionStore, includingDrafts: Bool) async -> [CaptionTranslationUpdate] {
-        var updates: [CaptionTranslationUpdate] = []
+        var executions: [CaptionTranslationExecution] = []
         let turns = store.turns
             .filter { $0.translationHealth == .pending }
             .filter { turn in
@@ -61,11 +79,11 @@ public final class CaptionTranslationScheduler {
                 return lhs.createdAt < rhs.createdAt
             }
         for turn in turns {
-            if let update = await translationUpdate(for: turn, in: store, includingDrafts: includingDrafts) {
-                updates.append(update)
+            if let execution = await translationExecution(for: turn, in: store, includingDrafts: includingDrafts) {
+                executions.append(execution)
             }
         }
-        return updates
+        return await execute(executions)
     }
 
     func apply(_ update: CaptionTranslationUpdate, to store: inout LiveCaptionStore) {
@@ -129,16 +147,23 @@ public final class CaptionTranslationScheduler {
         }
     }
 
-    private func translationUpdate(
+    private func translationExecution(
         for turn: LiveCaptionTurn,
         in store: LiveCaptionStore,
         includingDrafts: Bool
-    ) async -> CaptionTranslationUpdate? {
+    ) async -> CaptionTranslationExecution? {
         let isFinalTranslation = turn.displayState == .sealed && turn.boundaryStrength == .hard
         let key = translationKey(for: turn, isFinalTranslation: isFinalTranslation)
         let options = TranslationOptions(sourceLocale: turn.sourceLocale, targetLocale: turn.targetLocale)
         if options.isSameLanguage {
-            return CaptionTranslationUpdate(turnID: turn.id, key: key, result: .completeWithoutText, request: nil)
+            logSkipped(turn: turn, key: key, isFinalTranslation: isFinalTranslation, reason: "same_language")
+            return CaptionTranslationExecution(
+                request: nil,
+                segment: nil,
+                options: options,
+                provider: nil,
+                update: CaptionTranslationUpdate(turnID: turn.id, key: key, result: .completeWithoutText, request: nil)
+            )
         }
 
         guard isFinalTranslation || includingDrafts else {
@@ -147,22 +172,56 @@ public final class CaptionTranslationScheduler {
         guard let provider else {
             return nil
         }
+        if isFinalTranslation {
+            cancelDraftsSuperseded(by: [turn])
+            pendingDraftTokensByTurnID[turn.id] = nil
+        }
         guard !requestedFinalTranslationKeys.contains(key) else {
+            logSkipped(turn: turn, key: key, isFinalTranslation: isFinalTranslation, reason: "duplicate_key")
             return nil
         }
         requestedFinalTranslationKeys.insert(key)
         let requestID = "caption-translation-\(UUID().uuidString)"
+        let sourceText = translationSourceText(for: turn, in: store, final: isFinalTranslation)
+        let requestOrdinal = nextRequestOrdinal(forTurnID: turn.id)
         let request = ActiveCaptionTranslationRequest(
             id: requestID,
             turn: turn,
             key: key,
             isDraft: !isFinalTranslation,
-            revision: turn.translationRevision
+            revision: turn.translationRevision,
+            requestOrdinalForTurn: requestOrdinal,
+            sourceText: sourceText,
+            configuration: configuration
         )
         activeRequestsByKey[key] = request
-        let metadata = translationMetadata(
-            for: request
-        )
+        if request.isDraft,
+           configuration.draftDebounceNanoseconds > 0 {
+            let token = UUID()
+            let replaced = pendingDraftTokensByTurnID.updateValue(token, forKey: turn.id) != nil
+            performanceEventLogger?.log(
+                replaced ? "caption_translation_debounce_replaced" : "caption_translation_debounce_scheduled",
+                segmentID: turn.id,
+                isFinal: false,
+                textLength: turn.originalText.count,
+                metadata: translationMetadata(for: request)
+            )
+            try? await Task.sleep(nanoseconds: configuration.draftDebounceNanoseconds)
+            guard pendingDraftTokensByTurnID[turn.id] == token,
+                  activeRequestsByKey[key] != nil
+            else {
+                return nil
+            }
+            pendingDraftTokensByTurnID[turn.id] = nil
+            performanceEventLogger?.log(
+                "caption_translation_debounce_fired",
+                segmentID: turn.id,
+                isFinal: false,
+                textLength: turn.originalText.count,
+                metadata: translationMetadata(for: request)
+            )
+        }
+        let metadata = translationMetadata(for: request)
         performanceEventLogger?.log(
             "caption_translation_scheduled",
             segmentID: turn.id,
@@ -174,50 +233,128 @@ public final class CaptionTranslationScheduler {
         let segment = TranscriptSegment(
             id: turn.sourceSegmentID,
             speaker: turn.speaker,
-            text: translationSourceText(for: turn, in: store, final: isFinalTranslation),
+            text: sourceText,
             language: turn.sourceLocale,
             isFinal: isFinalTranslation,
             createdAt: turn.createdAt
         )
+        return CaptionTranslationExecution(request: request, segment: segment, options: options, provider: provider, update: nil)
+    }
+
+    private func execute(_ executions: [CaptionTranslationExecution]) async -> [CaptionTranslationUpdate] {
+        var immediateUpdates: [CaptionTranslationUpdate] = []
+        var requestExecutions: [CaptionTranslationExecution] = []
+        for execution in executions {
+            if let update = execution.update {
+                immediateUpdates.append(update)
+            } else {
+                requestExecutions.append(execution)
+            }
+        }
+        guard !requestExecutions.isEmpty else {
+            return immediateUpdates
+        }
+        let limit = min(configuration.maxConcurrentTranslationRequests, requestExecutions.count)
+        let logger = performanceEventLogger
+        var updates: [CaptionTranslationUpdate] = []
+        await withTaskGroup(of: CaptionTranslationUpdate?.self) { group in
+            var nextIndex = 0
+            var running = 0
+
+            func enqueueNext() {
+                guard nextIndex < requestExecutions.count else { return }
+                let execution = requestExecutions[nextIndex]
+                nextIndex += 1
+                running += 1
+                let inFlightCount = running
+                let queueDepth = requestExecutions.count - nextIndex
+                logger?.log(
+                    "caption_translation_enqueued",
+                    segmentID: execution.request?.turn.id,
+                    isFinal: execution.request.map { !$0.isDraft },
+                    textLength: execution.request?.turn.originalText.count,
+                    metadata: execution.request.map {
+                        var metadata = CaptionTranslationExecutionMetadata.metadata(for: $0)
+                        metadata["queueDepth"] = String(queueDepth)
+                        metadata["inFlightCount"] = String(inFlightCount)
+                        return metadata
+                    } ?? [:]
+                )
+                group.addTask {
+                    await Self.performTranslation(execution, inFlightCount: inFlightCount, queueDepth: queueDepth, logger: logger)
+                }
+            }
+
+            while running < limit, nextIndex < requestExecutions.count {
+                enqueueNext()
+            }
+            while let update = await group.next() {
+                running -= 1
+                if let update {
+                    updates.append(update)
+                }
+                while running < limit, nextIndex < requestExecutions.count {
+                    enqueueNext()
+                }
+            }
+        }
+        for update in updates {
+            activeRequestsByKey.removeValue(forKey: update.key)
+        }
+        return immediateUpdates + updates
+    }
+
+    private static func performTranslation(
+        _ execution: CaptionTranslationExecution,
+        inFlightCount: Int,
+        queueDepth: Int,
+        logger: PerformanceEventLogger?
+    ) async -> CaptionTranslationUpdate? {
+        guard let request = execution.request,
+              let segment = execution.segment,
+              let provider = execution.provider
+        else {
+            return execution.update
+        }
+        let metadata = execution.metadata(queueDepth: queueDepth, inFlightCount: inFlightCount)
         do {
-            performanceEventLogger?.log(
+            logger?.log(
                 "caption_translation_started",
-                segmentID: turn.id,
-                isFinal: true,
-                textLength: turn.originalText.count,
+                segmentID: request.turn.id,
+                isFinal: !request.isDraft,
+                textLength: request.turn.originalText.count,
                 metadata: metadata
             )
             let translated = try await provider.translate(
                 transcript: TranscriptDocument(segments: [segment]),
-                options: options
+                options: execution.options
             )
-            let translatedText = translated.segments.first { $0.id == turn.sourceSegmentID }?.targetText ?? ""
-            performanceEventLogger?.log(
+            let translatedText = translated.segments.first { $0.id == request.turn.sourceSegmentID }?.targetText ?? ""
+            logger?.log(
                 "caption_translation_finished",
-                segmentID: turn.id,
-                isFinal: true,
+                segmentID: request.turn.id,
+                isFinal: !request.isDraft,
                 textLength: translatedText.count,
                 metadata: metadata
             )
-            performanceEventLogger?.log(
+            logger?.log(
                 "caption_translation_attached",
-                segmentID: turn.id,
-                isFinal: true,
+                segmentID: request.turn.id,
+                isFinal: !request.isDraft,
                 textLength: translatedText.count,
                 metadata: metadata
             )
             return CaptionTranslationUpdate(
-                turnID: turn.id,
-                key: key,
-                result: isFinalTranslation ? .finalText(translatedText) : .draftText(translatedText),
-                request: activeRequestsByKey.removeValue(forKey: key) ?? request
+                turnID: request.turn.id,
+                key: request.key,
+                result: request.isDraft ? .draftText(translatedText) : .finalText(translatedText),
+                request: request
             )
         } catch {
-            activeRequestsByKey.removeValue(forKey: key)
             let nsError = error as NSError
             return CaptionTranslationUpdate(
-                turnID: turn.id,
-                key: key,
+                turnID: request.turn.id,
+                key: request.key,
                 result: .failed("\(nsError.domain) error \(nsError.code)"),
                 request: request
             )
@@ -304,7 +441,12 @@ public final class CaptionTranslationScheduler {
             "translationKind": request.isDraft ? "draft" : "final",
             "translationRequestID": request.id,
             "translationRevision": String(request.revision),
-            "translationKeyHash": String(request.key.hashValue)
+            "translationKeyHash": stableHash(request.key),
+            "sourceTextHash": stableHash(request.sourceText),
+            "sourceTextLength": String(request.sourceText.count),
+            "requestOrdinalForTurn": String(request.requestOrdinalForTurn),
+            "debounceMilliseconds": String(request.configuration.draftDebounceNanoseconds / 1_000_000),
+            "concurrencyLimit": String(request.configuration.maxConcurrentTranslationRequests)
         ]
         if let boundaryStrength = turn.boundaryStrength {
             metadata["boundaryStrength"] = String(describing: boundaryStrength)
@@ -317,6 +459,46 @@ public final class CaptionTranslationScheduler {
         }
         return metadata
     }
+
+    private func logSkipped(
+        turn: LiveCaptionTurn,
+        key: String,
+        isFinalTranslation: Bool,
+        reason: String
+    ) {
+        let request = ActiveCaptionTranslationRequest(
+            id: "caption-translation-skipped-\(UUID().uuidString)",
+            turn: turn,
+            key: key,
+            isDraft: !isFinalTranslation,
+            revision: turn.translationRevision,
+            requestOrdinalForTurn: requestOrdinalsByTurnID[turn.id, default: 0],
+            sourceText: turn.originalText,
+            configuration: configuration
+        )
+        performanceEventLogger?.log(
+            "caption_translation_skipped",
+            segmentID: turn.id,
+            isFinal: isFinalTranslation,
+            textLength: turn.originalText.count,
+            metadata: translationMetadata(for: request, extra: ["skipReason": reason])
+        )
+    }
+
+    private func nextRequestOrdinal(forTurnID turnID: String) -> Int {
+        let next = requestOrdinalsByTurnID[turnID, default: 0] + 1
+        requestOrdinalsByTurnID[turnID] = next
+        return next
+    }
+}
+
+private func stableHash(_ value: String) -> String {
+    var hash: UInt64 = 14_695_981_039_346_656_037
+    for byte in value.utf8 {
+        hash ^= UInt64(byte)
+        hash &*= 1_099_511_628_211
+    }
+    return String(hash, radix: 16)
 }
 
 struct ActiveCaptionTranslationRequest: Equatable {
@@ -325,6 +507,54 @@ struct ActiveCaptionTranslationRequest: Equatable {
     var key: String
     var isDraft: Bool
     var revision: Int
+    var requestOrdinalForTurn: Int = 1
+    var sourceText: String = ""
+    var configuration: CaptionTranslationSchedulerConfiguration = CaptionTranslationSchedulerConfiguration()
+}
+
+private struct CaptionTranslationExecution {
+    var request: ActiveCaptionTranslationRequest?
+    var segment: TranscriptSegment?
+    var options: TranslationOptions
+    var provider: TextTranslationProvider?
+    var update: CaptionTranslationUpdate?
+
+    func metadata(queueDepth: Int, inFlightCount: Int) -> [String: String] {
+        guard let request else { return [:] }
+        var metadata = CaptionTranslationExecutionMetadata.metadata(for: request)
+        metadata["queueDepth"] = String(queueDepth)
+        metadata["inFlightCount"] = String(inFlightCount)
+        return metadata
+    }
+}
+
+private enum CaptionTranslationExecutionMetadata {
+    static func metadata(for request: ActiveCaptionTranslationRequest) -> [String: String] {
+        let turn = request.turn
+        var metadata: [String: String] = [
+            "turnID": turn.id,
+            "sourceSegmentID": turn.sourceSegmentID,
+            "sourceSegmentIDs": turn.sourceSegmentIDs.joined(separator: ","),
+            "sourceLocale": turn.sourceLocale,
+            "targetLocale": turn.targetLocale,
+            "translationKind": request.isDraft ? "draft" : "final",
+            "translationRequestID": request.id,
+            "translationRevision": String(request.revision),
+            "translationKeyHash": stableHash(request.key),
+            "sourceTextHash": stableHash(request.sourceText),
+            "sourceTextLength": String(request.sourceText.count),
+            "requestOrdinalForTurn": String(request.requestOrdinalForTurn),
+            "debounceMilliseconds": String(request.configuration.draftDebounceNanoseconds / 1_000_000),
+            "concurrencyLimit": String(request.configuration.maxConcurrentTranslationRequests)
+        ]
+        if let boundaryStrength = turn.boundaryStrength {
+            metadata["boundaryStrength"] = String(describing: boundaryStrength)
+        }
+        if let boundaryReason = turn.boundaryReason {
+            metadata["boundaryReason"] = boundaryReason.rawValue
+        }
+        return metadata
+    }
 }
 
 enum CaptionTranslationUpdateResult: Equatable {

--- a/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
@@ -220,6 +220,31 @@ final class CaptionTranslationSchedulerTests: XCTestCase {
         XCTAssertTrue(events.contains { $0.event == "caption_translation_started" && $0.metadata["translationKind"] == "final" })
     }
 
+    func testStaleDraftCompletionLogsStaleWithoutAttachedEvent() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("caption-translation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let eventsURL = root.appendingPathComponent("performance-events.jsonl")
+        var originalStore = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        originalStore.upsert(draftTurn(text: "old draft", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        var currentStore = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        currentStore.upsert(draftTurn(text: "new draft", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        let provider = RecordingTextTranslationProvider(translations: ["segment-1": "旧草稿"])
+        let scheduler = CaptionTranslationScheduler(
+            provider: provider,
+            performanceEventLogger: PerformanceEventLogger(url: eventsURL),
+            configuration: CaptionTranslationSchedulerConfiguration(draftDebounceNanoseconds: 0, maxConcurrentTranslationRequests: 2)
+        )
+
+        let updates = await scheduler.liveTranslationUpdates(for: originalStore)
+        let update = try XCTUnwrap(updates.first)
+        scheduler.apply(update, to: &currentStore)
+
+        let events = try readEvents(from: eventsURL)
+        XCTAssertTrue(events.contains { $0.event == "caption_translation_stale" })
+        XCTAssertFalse(events.contains { $0.event == "caption_translation_attached" })
+        XCTAssertNil(currentStore.turns.first?.translatedText)
+    }
+
     func testTranslationRequestsRespectGlobalConcurrencyLimit() async {
         var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
         store.upsert(hardSealedTurn(id: "segment-1", text: "first", sourceLocale: "en-US", targetLocale: "zh-CN"))

--- a/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
@@ -142,13 +142,110 @@ final class CaptionTranslationSchedulerTests: XCTestCase {
         XCTAssertEqual(store.turns.first?.translationState, .pendingFinal)
     }
 
+    func testDraftTranslationTelemetryUsesDraftFinalFlagAndBudgetMetadata() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("caption-translation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let eventsURL = root.appendingPathComponent("performance-events.jsonl")
+        var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        store.upsert(draftTurn(text: "draft text", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        let provider = RecordingTextTranslationProvider(translations: ["segment-1": "草稿"])
+        let scheduler = CaptionTranslationScheduler(
+            provider: provider,
+            performanceEventLogger: PerformanceEventLogger(url: eventsURL),
+            configuration: CaptionTranslationSchedulerConfiguration(draftDebounceNanoseconds: 0, maxConcurrentTranslationRequests: 2)
+        )
+
+        for update in await scheduler.liveTranslationUpdates(for: store) {
+            scheduler.apply(update, to: &store)
+        }
+
+        let events = try readEvents(from: eventsURL)
+        let started = try XCTUnwrap(events.first { $0.event == "caption_translation_started" })
+        XCTAssertEqual(started.isFinal, false)
+        XCTAssertEqual(started.metadata["translationKind"], "draft")
+        XCTAssertEqual(started.metadata["sourceTextLength"], "10")
+        XCTAssertNotNil(started.metadata["sourceTextHash"])
+        XCTAssertEqual(started.metadata["requestOrdinalForTurn"], "1")
+        XCTAssertEqual(started.metadata["inFlightCount"], "1")
+        XCTAssertEqual(started.metadata["concurrencyLimit"], "2")
+    }
+
+    func testDraftTranslationDebounceKeepsLatestPendingDraftForTurn() async {
+        var firstStore = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        firstStore.upsert(draftTurn(text: "old draft", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        var secondStore = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        secondStore.upsert(draftTurn(text: "new draft", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        let firstStoreSnapshot = firstStore
+        let provider = RecordingTextTranslationProvider(translations: ["segment-1": "新草稿"])
+        let scheduler = CaptionTranslationScheduler(
+            provider: provider,
+            performanceEventLogger: nil,
+            configuration: CaptionTranslationSchedulerConfiguration(draftDebounceNanoseconds: 30_000_000, maxConcurrentTranslationRequests: 2)
+        )
+
+        async let firstUpdates = scheduler.liveTranslationUpdates(for: firstStoreSnapshot)
+        try? await Task.sleep(nanoseconds: 5_000_000)
+        let secondUpdates = await scheduler.liveTranslationUpdates(for: secondStore)
+        let resolvedFirstUpdates = await firstUpdates
+
+        XCTAssertTrue(resolvedFirstUpdates.isEmpty)
+        XCTAssertEqual(secondUpdates.count, 1)
+        XCTAssertEqual(provider.requests.map(\.sourceText), ["new draft"])
+    }
+
+    func testFinalTranslationBypassesDraftDebounceAndRunsWhenDraftTextMatches() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("caption-translation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let eventsURL = root.appendingPathComponent("performance-events.jsonl")
+        var draftStore = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        draftStore.upsert(draftTurn(text: "same text", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        var finalStore = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        finalStore.upsert(hardSealedTurn(text: "same text", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        let draftStoreSnapshot = draftStore
+        let provider = RecordingTextTranslationProvider(translations: ["segment-1": "最终"])
+        let scheduler = CaptionTranslationScheduler(
+            provider: provider,
+            performanceEventLogger: PerformanceEventLogger(url: eventsURL),
+            configuration: CaptionTranslationSchedulerConfiguration(draftDebounceNanoseconds: 30_000_000, maxConcurrentTranslationRequests: 2)
+        )
+
+        async let draftUpdates = scheduler.liveTranslationUpdates(for: draftStoreSnapshot)
+        try? await Task.sleep(nanoseconds: 5_000_000)
+        let finalUpdates = await scheduler.translationUpdates(for: finalStore)
+        _ = await draftUpdates
+
+        let events = try readEvents(from: eventsURL)
+        XCTAssertEqual(finalUpdates.count, 1)
+        XCTAssertEqual(provider.requests.map(\.sourceText), ["same text"])
+        XCTAssertTrue(events.contains { $0.event == "caption_translation_started" && $0.metadata["translationKind"] == "final" })
+    }
+
+    func testTranslationRequestsRespectGlobalConcurrencyLimit() async {
+        var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        store.upsert(hardSealedTurn(id: "segment-1", text: "first", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        store.upsert(hardSealedTurn(id: "segment-2", text: "second", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        store.upsert(hardSealedTurn(id: "segment-3", text: "third", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        let provider = DelayedRecordingTextTranslationProvider(delayNanoseconds: 20_000_000)
+        let scheduler = CaptionTranslationScheduler(
+            provider: provider,
+            performanceEventLogger: nil,
+            configuration: CaptionTranslationSchedulerConfiguration(draftDebounceNanoseconds: 0, maxConcurrentTranslationRequests: 2)
+        )
+
+        let updates = await scheduler.translationUpdates(for: store)
+
+        XCTAssertEqual(updates.count, 3)
+        XCTAssertEqual(provider.maximumConcurrentRequests, 2)
+    }
+
     private func hardSealedTurn(
+        id: String = "segment-1",
         text: String = "hello",
         sourceLocale: String,
         targetLocale: String
     ) -> LiveCaptionTurn {
         LiveCaptionTurn(
-            sourceSegmentID: "segment-1",
+            sourceSegmentID: id,
             originalText: text,
             sourceLocale: sourceLocale,
             targetLocale: targetLocale,
@@ -159,6 +256,32 @@ final class CaptionTranslationSchedulerTests: XCTestCase {
             boundaryReason: .speechFinal,
             boundaryStrength: .hard
         )
+    }
+
+    private func draftTurn(
+        id: String = "segment-1",
+        text: String,
+        sourceLocale: String,
+        targetLocale: String
+    ) -> LiveCaptionTurn {
+        LiveCaptionTurn(
+            sourceSegmentID: id,
+            originalText: text,
+            sourceLocale: sourceLocale,
+            targetLocale: targetLocale,
+            isFinal: false,
+            translationHealth: .pending,
+            displayState: .draft,
+            translationState: .draft
+        )
+    }
+
+    private func readEvents(from url: URL) throws -> [PerformanceEvent] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try String(contentsOf: url, encoding: .utf8)
+            .split(whereSeparator: \.isNewline)
+            .map { try decoder.decode(PerformanceEvent.self, from: Data($0.utf8)) }
     }
 }
 
@@ -216,5 +339,69 @@ private final class RecordingTextTranslationProvider: TextTranslationProvider {
             },
             provenance: PipelineProvenance(profileID: "recording")
         )
+    }
+}
+
+private final class DelayedRecordingTextTranslationProvider: TextTranslationProvider {
+    let delayNanoseconds: UInt64
+    private let lock = NSLock()
+    private var activeRequestCount = 0
+    private var maximumConcurrentRequestCount = 0
+
+    var maximumConcurrentRequests: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return maximumConcurrentRequestCount
+    }
+
+    init(delayNanoseconds: UInt64) {
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    var descriptor: ProviderDescriptor {
+        ProviderDescriptor(
+            id: "delayed-recording-translation",
+            displayName: "Delayed Recording Translation",
+            capability: .textTranslation,
+            executionMode: .local,
+            supportedSourceLocales: ["*"],
+            supportedTargetLocales: ["*"],
+            requiresNetwork: false,
+            requiresAPIKey: false
+        )
+    }
+
+    func translate(transcript: TranscriptDocument, options: TranslationOptions) async throws -> TranslatedTranscript {
+        beginRequest()
+        try? await Task.sleep(nanoseconds: delayNanoseconds)
+        endRequest()
+        return TranslatedTranscript(
+            sourceLocale: options.sourceLocale,
+            targetLocale: options.targetLocale,
+            segments: transcript.segments.map { segment in
+                BilingualSubtitleSegment(
+                    id: segment.id,
+                    speaker: segment.speaker,
+                    sourceText: segment.text,
+                    targetText: "translated \(segment.text)",
+                    status: .complete,
+                    providerChain: [descriptor.id]
+                )
+            },
+            provenance: PipelineProvenance(profileID: "recording")
+        )
+    }
+
+    private func beginRequest() {
+        lock.lock()
+        activeRequestCount += 1
+        maximumConcurrentRequestCount = max(maximumConcurrentRequestCount, activeRequestCount)
+        lock.unlock()
+    }
+
+    private func endRequest() {
+        lock.lock()
+        activeRequestCount -= 1
+        lock.unlock()
     }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -619,7 +619,8 @@ final class MeetingAgentViewModelTests: XCTestCase {
                 speaker: TranscriptSpeaker(identifier: "speaker-1", label: "Alex"),
                 text: "Alex is the launch owner.",
                 language: "en-US",
-                isFinal: true
+                isFinal: true,
+                speechFinal: true
             )
         ])
 
@@ -1643,7 +1644,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
         }
     }
 
-    func testDifferentSpeakerDraftTranslationsAreQueuedOneAtATime() async throws {
+    func testDifferentSpeakerDraftTranslationsRespectGlobalConcurrencyBudget() async throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }
         let store = MeetingStore(baseDirectory: root)
@@ -1665,8 +1666,8 @@ final class MeetingAgentViewModelTests: XCTestCase {
         viewModel.drainRecordingFrames()
         try await waitFor { provider.pendingRequestCount >= 1 }
 
-        XCTAssertEqual(provider.pendingRequestCount, 1)
-        XCTAssertEqual(provider.pendingRequestTexts, [["second speaker draft"]])
+        XCTAssertEqual(provider.pendingRequestCount, 2)
+        XCTAssertEqual(provider.pendingRequestTexts, [["second speaker draft"], ["first speaker draft"]])
 
         viewModel.selectMeeting(nil)
     }

--- a/docs/mistakes/2026-04-30T11-52-05Z.md
+++ b/docs/mistakes/2026-04-30T11-52-05Z.md
@@ -1,0 +1,13 @@
+# [118] Log performance events after the state they claim
+
+**Date**: 2026-04-30
+**Category**: logic-error
+
+### What went wrong
+The first scheduler review found `caption_translation_attached` was logged when the provider returned, before the translated text was actually applied to the live caption store. A stale completion could therefore emit both `attached` and `stale`, which would corrupt real-meeting latency and redundancy analysis.
+
+### Correct approach
+Log outcome events only after the state transition they describe has succeeded. Provider completion should log `finished`; store mutation should log `attached`; rejected results should log `stale` without an `attached` event.
+
+### How to avoid
+For performance telemetry, place each event at the exact state boundary it names, then add a stale-result regression that checks misleading success events are absent.

--- a/docs/superpowers/plans/2026-04-30-caption-translation-budget.md
+++ b/docs/superpowers/plans/2026-04-30-caption-translation-budget.md
@@ -1,0 +1,141 @@
+# Caption Translation Budget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add bounded draft caption translation scheduling and analysis-grade performance telemetry for live meetings.
+
+**Architecture:** Keep the policy inside `CaptionTranslationScheduler`, where draft/final ownership already lives. Add a small scheduler configuration, draft debounce state, request queue state, and richer telemetry metadata while preserving the existing `LiveCaptionPipeline` API.
+
+**Tech Stack:** Swift 5.9, Swift concurrency, XCTest, existing `PerformanceEventLogger` JSONL sink.
+
+---
+
+### Task 1: Add Scheduler Budget Configuration And Telemetry Fields
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/CaptionTranslationScheduler.swift`
+- Test: `Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift`
+
+- [ ] **Step 1: Write failing telemetry tests**
+
+Add tests that schedule one draft translation and assert `caption_translation_started` has `isFinal == false`, `translationKind == "draft"`, `sourceTextHash`, `sourceTextLength`, `requestOrdinalForTurn`, `inFlightCount`, and `concurrencyLimit`.
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: FAIL because current telemetry lacks budget metadata and draft started events are marked final.
+
+- [ ] **Step 3: Add config and metadata**
+
+Add a `CaptionTranslationSchedulerConfiguration` with defaults: draft debounce 0.2 seconds and max concurrent requests 2. Extend `ActiveCaptionTranslationRequest` with request ordinal, source text, scheduled reason, and budget metadata. Fix started/finished/attached top-level `isFinal` to use `!request.isDraft`.
+
+- [ ] **Step 4: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: PASS for the new telemetry test or fail only for later missing behavior.
+
+### Task 2: Add Draft Debounce And Latest-Wins Pending Drafts
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/CaptionTranslationScheduler.swift`
+- Test: `Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift`
+
+- [ ] **Step 1: Write failing debounce tests**
+
+Add tests for rapid same-turn draft updates. The first draft should log `caption_translation_debounce_scheduled`, the second should log `caption_translation_debounce_replaced`, and only the latest text should reach the provider after debounce fires.
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: FAIL because drafts currently call the provider immediately.
+
+- [ ] **Step 3: Implement debounce**
+
+Track pending draft requests by turn ID. Delay draft execution by the configured debounce interval. Replacing a pending draft cancels the older pending item and logs `caption_translation_debounce_replaced`. Final requests bypass this path.
+
+- [ ] **Step 4: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: PASS for debounce tests.
+
+### Task 3: Add Global Concurrency Budget With Final Priority
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/CaptionTranslationScheduler.swift`
+- Test: `Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift`
+
+- [ ] **Step 1: Write failing concurrency tests**
+
+Add a delayed provider test with max concurrency 1. Schedule two draft requests and one final request. Assert no more than one provider call is in flight, the final request starts before waiting draft work, and no final request is dropped.
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: FAIL because the current scheduler awaits each provider call directly and has no queue telemetry.
+
+- [ ] **Step 3: Implement queue policy**
+
+Maintain final and draft queues. Start work while `inFlightCount < maxConcurrentTranslationRequests`. Final queue drains before draft queue. Draft queue uses latest-wins semantics and can log `caption_translation_dropped` when superseded. Final queue is durable.
+
+- [ ] **Step 4: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: PASS for concurrency tests.
+
+### Task 4: Preserve Stale Completion Safety
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/CaptionTranslationScheduler.swift`
+- Test: `Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift`
+
+- [ ] **Step 1: Write failing stale tests**
+
+Add a delayed draft provider test where a draft request completes after a newer draft or hard-final turn is current. Assert the stale completion logs `caption_translation_stale` and does not overwrite the current translated text or final state.
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: FAIL if stale draft application is not guarded by the current key and request kind.
+
+- [ ] **Step 3: Keep apply guard strict**
+
+Reuse `translationKey` checks and request kind checks in `apply(_:,to:)`. Ensure cancellation and stale logging include `reason` and budget metadata.
+
+- [ ] **Step 4: Run focused test**
+
+Run: `swift test --filter CaptionTranslationSchedulerTests`
+
+Expected: PASS for stale tests.
+
+### Task 5: Verify Pipeline Integration And Full Test Suite
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` if existing performance event expectations need stricter metadata.
+
+- [ ] **Step 1: Run focused integration tests**
+
+Run: `swift test --filter MeetingAgentViewModelTests/testCaptionTranslationPerformanceEventsShareRequestID`
+
+Expected: PASS with updated metadata.
+
+- [ ] **Step 2: Run package tests**
+
+Run: `make test`
+
+Expected: PASS, including coverage gate.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/CaptionTranslationScheduler.swift Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+git commit -m "feat: budget caption translation requests (#118)"
+```

--- a/docs/superpowers/specs/2026-04-30-caption-translation-budget-design.md
+++ b/docs/superpowers/specs/2026-04-30-caption-translation-budget-design.md
@@ -1,0 +1,89 @@
+# Caption Translation Budget Design
+
+## Context
+
+Issue #118 extends the live caption translation work from PR #117. Draft caption translation improves responsiveness, but high-frequency interim transcript updates can produce too many translation requests during real meetings. The app also needs enough performance telemetry to diagnose subtitle latency, redundant translation requests, stale completions, queue pressure, and user-visible translation delays after real meeting runs.
+
+## Goals
+
+- Bound draft translation network load during rapid interim updates.
+- Keep final translation durable and prompt, even when draft text matches the final text.
+- Make stale draft completions harmless.
+- Limit global caption translation concurrency.
+- Emit performance events that support real meeting analysis of latency, request redundancy, debounce effectiveness, and concurrency pressure.
+
+## Non-Goals
+
+- No UI dashboard for aggregate performance metrics in this issue.
+- No provider-specific retry policy changes.
+- No changes to transcript persistence format.
+
+## Selected Approach
+
+Implement throttling and concurrency budgeting inside `CaptionTranslationScheduler`. This keeps translation request policy close to the existing draft/final ownership logic and avoids pushing request semantics into `LiveCaptionPipeline` or the provider layer.
+
+Draft requests use a short debounce window. A newer pending draft for the same turn replaces the older pending draft, and only the latest pending draft can fire. Final requests bypass debounce, are never dropped for capacity, and are scheduled before draft work. The scheduler enforces a small global concurrency limit while preserving final priority. Draft work is droppable when superseded by newer draft text or hard-final caption state.
+
+## Performance Telemetry
+
+The existing JSONL `PerformanceEventLogger` remains the sink. Caption translation events must consistently carry:
+
+- `translationKind`: `draft` or `final`
+- `translationRequestID`
+- `turnID`
+- `sourceSegmentID`
+- `sourceSegmentIDs`
+- `sourceLocale`
+- `targetLocale`
+- `translationRevision`
+- `translationKeyHash`
+- `sourceTextHash`
+- `sourceTextLength`
+- `requestOrdinalForTurn`
+
+Budget-related events also carry `queueDepth`, `inFlightCount`, `concurrencyLimit`, `debounceMilliseconds`, and a reason field where applicable.
+
+Required event families:
+
+- `caption_translation_debounce_scheduled`
+- `caption_translation_debounce_replaced`
+- `caption_translation_debounce_fired`
+- `caption_translation_enqueued`
+- `caption_translation_started`
+- `caption_translation_finished`
+- `caption_translation_attached`
+- `caption_translation_dropped`
+- `caption_translation_cancelled`
+- `caption_translation_stale`
+- `caption_translation_skipped`
+
+The existing `caption_translation_started`, `finished`, and `attached` events must set top-level `isFinal` from the actual translation kind. Draft events must not be marked final.
+
+## Analysis Supported
+
+After a real meeting, the JSONL stream should support these calculations:
+
+- Subtitle latency: audio time to caption ingestion and transcript write events.
+- Translation end-to-end latency: scheduled or enqueued to attached.
+- Queue wait: enqueued to started.
+- Provider latency: started to finished.
+- Attach latency: finished to attached.
+- Redundant request rate: requests per `turnID + translationKind`, stale completions, cancellations, and drops.
+- Debounce effectiveness: replaced vs fired draft debounce counts.
+- Final reliability: final dropped count must be zero; final stale/cancelled events require explicit reasons.
+
+## Testing
+
+Unit tests focus on `CaptionTranslationScheduler` because it owns the new policy. Tests must cover:
+
+- Rapid draft updates for the same turn debounce into one provider request.
+- A newer draft replaces an older pending draft.
+- Final requests bypass draft debounce.
+- Final requests still run when draft text equals final text.
+- Global concurrency caps simultaneous provider calls.
+- Final requests are not dropped under concurrency pressure.
+- Stale draft completions cannot overwrite newer draft or final translation.
+- Draft events are not top-level `isFinal == true`.
+- Budget telemetry includes queue, debounce, request ordinal, and source text hash fields.
+
+Full verification remains `make test`.


### PR DESCRIPTION
## Summary

Fixes #118

- Adds draft debounce/latest-wins behavior and a global caption translation concurrency budget.
- Keeps final translation durable and prompt while cancelling superseded draft work.
- Expands performance events with request kind, source hashes, request ordinals, queue depth, in-flight counts, debounce metadata, and post-apply attached semantics.

## Changes

- `Sources/MeetingAgentCore/CaptionTranslationScheduler.swift` - adds scheduler configuration, draft debounce, bounded concurrent execution, final-priority cancellation, and analysis-grade telemetry.
- `Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift` - covers draft telemetry, latest-wins debounce, final bypass, concurrency limit, and stale completion logging.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - updates integration expectations for hard-final translation and the new concurrency budget.
- `docs/superpowers/specs/2026-04-30-caption-translation-budget-design.md` - records the approved design.
- `docs/superpowers/plans/2026-04-30-caption-translation-budget.md` - records the implementation plan.
- `docs/mistakes/2026-04-30T11-52-05Z.md` - records the telemetry placement lesson.

## Test plan

- [x] Build/lint: Swift package build covered by `make test` - passed
- [x] Unit tests: `swift test --filter CaptionTranslationSchedulerTests` - passed
- [x] Integration: `swift test --filter MeetingAgentViewModelTests/testCaptionTranslationPerformanceEventsShareRequestID` - passed
- [x] Full verification: `make test` - passed, 568 tests, coverage gate passed (line 97.12%, method 95.57%)
- [x] Code review: PASS, review fix committed for post-apply attached logging
- [ ] Manual verification: not applicable for core scheduler behavior