### PR TITLE
feat: add live caption latency metrics

### DIFF
--- a/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
+++ b/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
@@ -376,6 +376,13 @@ public final class CaptionTranslationScheduler {
                 textLength: request.turn.originalText.count,
                 metadata: failureMetadata
             )
+            logger?.log(
+                "caption_translation_failed_count",
+                segmentID: request.turn.id,
+                isFinal: !request.isDraft,
+                textLength: request.turn.originalText.count,
+                metadata: failureMetadata
+            )
             return CaptionTranslationUpdate(
                 turnID: request.turn.id,
                 key: request.key,

--- a/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
+++ b/Sources/MeetingAgentCore/CaptionTranslationScheduler.swift
@@ -86,9 +86,10 @@ public final class CaptionTranslationScheduler {
         return await execute(executions)
     }
 
-    func apply(_ update: CaptionTranslationUpdate, to store: inout LiveCaptionStore) {
+    @discardableResult
+    func apply(_ update: CaptionTranslationUpdate, to store: inout LiveCaptionStore) -> Bool {
         guard let current = store.turns.first(where: { $0.id == update.turnID }) else {
-            return
+            return false
         }
         let currentIsFinalTranslation = update.request.map { !$0.isDraft }
             ?? (current.displayState == .sealed && current.boundaryStrength == .hard)
@@ -99,18 +100,20 @@ public final class CaptionTranslationScheduler {
             if let request = update.request {
                 logStale(update: update, request: request, current: current)
             }
-            return
+            return false
         }
 
         switch update.result {
         case .completeWithoutText:
             store.markTranslationCompleteWithoutText(forTurnID: update.turnID)
+            return false
         case .draftText(let text):
             store.attachTranslation(text, toTurnID: update.turnID)
             if let request = update.request {
                 logAttached(request: request, textLength: text.count)
             }
             persistTranslation?(current, text, false)
+            return true
         case .finalText(let text):
             store.attachTranslation(text, toTurnID: update.turnID)
             store.markTranslationFinal(forTurnID: update.turnID)
@@ -118,8 +121,10 @@ public final class CaptionTranslationScheduler {
                 logAttached(request: request, textLength: text.count)
             }
             persistTranslation?(current, text, true)
+            return true
         case .failed(let message):
             store.markTranslationFailed(forTurnID: update.turnID, message: message)
+            return false
         }
     }
 
@@ -198,6 +203,7 @@ public final class CaptionTranslationScheduler {
             revision: turn.translationRevision,
             requestOrdinalForTurn: requestOrdinal,
             sourceText: sourceText,
+            providerID: provider.descriptor.id,
             configuration: configuration
         )
         activeRequestsByKey[key] = request
@@ -235,6 +241,7 @@ public final class CaptionTranslationScheduler {
             textLength: turn.originalText.count,
             metadata: metadata
         )
+        logCount("caption_translation_scheduled_count", request: request)
 
         let segment = TranscriptSegment(
             id: turn.sourceSegmentID,
@@ -324,6 +331,7 @@ public final class CaptionTranslationScheduler {
         }
         let metadata = execution.metadata(queueDepth: queueDepth, inFlightCount: inFlightCount)
         do {
+            let startedAt = Date()
             logger?.log(
                 "caption_translation_started",
                 segmentID: request.turn.id,
@@ -335,13 +343,15 @@ public final class CaptionTranslationScheduler {
                 transcript: TranscriptDocument(segments: [segment]),
                 options: execution.options
             )
+            var finishedMetadata = metadata
+            finishedMetadata.merge(PerformanceEventLogger.durationMetadata(from: startedAt)) { _, new in new }
             let translatedText = translated.segments.first { $0.id == request.turn.sourceSegmentID }?.targetText ?? ""
             logger?.log(
                 "caption_translation_finished",
                 segmentID: request.turn.id,
                 isFinal: !request.isDraft,
                 textLength: translatedText.count,
-                metadata: metadata
+                metadata: finishedMetadata
             )
             var completedRequest = request
             completedRequest.queueDepth = queueDepth
@@ -350,15 +360,28 @@ public final class CaptionTranslationScheduler {
                 turnID: request.turn.id,
                 key: request.key,
                 result: request.isDraft ? .draftText(translatedText) : .finalText(translatedText),
-                request: completedRequest
+                request: completedRequest,
+                resultReceivedAt: Date()
             )
         } catch {
             let nsError = error as NSError
+            var failureMetadata = metadata
+            failureMetadata["failureReason"] = "\(nsError.domain) error \(nsError.code)"
+            failureMetadata["retryCount"] = "0"
+            failureMetadata["count"] = "1"
+            logger?.log(
+                "caption_translation_provider_error",
+                segmentID: request.turn.id,
+                isFinal: !request.isDraft,
+                textLength: request.turn.originalText.count,
+                metadata: failureMetadata
+            )
             return CaptionTranslationUpdate(
                 turnID: request.turn.id,
                 key: request.key,
                 result: .failed("\(nsError.domain) error \(nsError.code)"),
-                request: request
+                request: request,
+                resultReceivedAt: Date()
             )
         }
     }
@@ -405,6 +428,7 @@ public final class CaptionTranslationScheduler {
             textLength: request.turn.originalText.count,
             metadata: translationMetadata(for: request, extra: ["reason": reason])
         )
+        logCount("caption_translation_cancelled_count", request: request, extra: ["reason": reason])
     }
 
     private func logStale(
@@ -427,6 +451,7 @@ public final class CaptionTranslationScheduler {
             textLength: request.turn.originalText.count,
             metadata: translationMetadata(for: request, extra: ["reason": reason])
         )
+        logCount("caption_translation_stale_count", request: request, extra: ["reason": reason])
     }
 
     private func logAttached(request: ActiveCaptionTranslationRequest, textLength: Int) {
@@ -437,6 +462,7 @@ public final class CaptionTranslationScheduler {
             textLength: textLength,
             metadata: translationMetadata(for: request)
         )
+        logCount("caption_translation_completed_count", request: request)
     }
 
     private func translationMetadata(
@@ -452,6 +478,7 @@ public final class CaptionTranslationScheduler {
             "targetLocale": turn.targetLocale,
             "translationKind": request.isDraft ? "draft" : "final",
             "translationRequestID": request.id,
+            "providerID": request.providerID,
             "translationRevision": String(request.revision),
             "translationKeyHash": stableHash(request.key),
             "sourceTextHash": stableHash(request.sourceText),
@@ -501,6 +528,21 @@ public final class CaptionTranslationScheduler {
             textLength: turn.originalText.count,
             metadata: translationMetadata(for: request, extra: ["skipReason": reason])
         )
+        logCount("caption_translation_skipped_count", request: request, extra: ["skipReason": reason])
+    }
+
+    private func logCount(
+        _ event: String,
+        request: ActiveCaptionTranslationRequest,
+        extra: [String: String] = [:]
+    ) {
+        performanceEventLogger?.log(
+            event,
+            segmentID: request.turn.id,
+            isFinal: !request.isDraft,
+            textLength: request.turn.originalText.count,
+            metadata: translationMetadata(for: request, extra: extra.merging(["count": "1"]) { current, _ in current })
+        )
     }
 
     private func nextRequestOrdinal(forTurnID turnID: String) -> Int {
@@ -527,6 +569,7 @@ struct ActiveCaptionTranslationRequest: Equatable {
     var revision: Int
     var requestOrdinalForTurn: Int = 1
     var sourceText: String = ""
+    var providerID: String = ""
     var configuration: CaptionTranslationSchedulerConfiguration = CaptionTranslationSchedulerConfiguration()
     var queueDepth: Int?
     var inFlightCount: Int?
@@ -548,7 +591,7 @@ private struct CaptionTranslationExecution {
     }
 }
 
-private enum CaptionTranslationExecutionMetadata {
+enum CaptionTranslationExecutionMetadata {
     static func metadata(for request: ActiveCaptionTranslationRequest) -> [String: String] {
         let turn = request.turn
         var metadata: [String: String] = [
@@ -559,6 +602,7 @@ private enum CaptionTranslationExecutionMetadata {
             "targetLocale": turn.targetLocale,
             "translationKind": request.isDraft ? "draft" : "final",
             "translationRequestID": request.id,
+            "providerID": request.providerID,
             "translationRevision": String(request.revision),
             "translationKeyHash": stableHash(request.key),
             "sourceTextHash": stableHash(request.sourceText),
@@ -595,4 +639,25 @@ struct CaptionTranslationUpdate: Equatable {
     var key: String
     var result: CaptionTranslationUpdateResult
     var request: ActiveCaptionTranslationRequest?
+    var resultReceivedAt: Date? = nil
+}
+
+extension CaptionTranslationUpdate {
+    var attachesVisibleText: Bool {
+        switch result {
+        case .draftText, .finalText:
+            return true
+        case .completeWithoutText, .failed:
+            return false
+        }
+    }
+
+    var visibleTextLength: Int? {
+        switch result {
+        case .draftText(let text), .finalText(let text):
+            return text.count
+        case .completeWithoutText, .failed:
+            return nil
+        }
+    }
 }

--- a/Sources/MeetingAgentCore/LiveCaptionPipeline.swift
+++ b/Sources/MeetingAgentCore/LiveCaptionPipeline.swift
@@ -69,8 +69,9 @@ public final class LiveCaptionPipeline {
 
         let changedSegmentIDs = Set(result.changedSegmentIDs)
         for segment in result.document.segments where changedSegmentIDs.contains(segment.id) {
+            let receivedAt = Date()
             logSegmentIngestedIfNeeded(segment, path: segment.isFinal ? "final" : "interim")
-            applyEvents(turnAssembler.apply(segment), sourceSegment: segment)
+            applyEvents(turnAssembler.apply(segment), sourceSegment: segment, segmentReceivedAt: receivedAt)
         }
         await scheduleLiveTranslations()
 
@@ -143,6 +144,7 @@ public final class LiveCaptionPipeline {
     private func applyEvents(
         _ events: [CaptionTurnEvent],
         sourceSegment: TranscriptSegment? = nil,
+        segmentReceivedAt: Date? = nil,
         currentSegments: [TranscriptSegment] = []
     ) {
         for event in events {
@@ -156,12 +158,14 @@ public final class LiveCaptionPipeline {
                         applying: turn
                     )
                     hydrateCachedTranslation(from: sourceSegment, toTurnID: updated.id)
+                    logCaptionTurnVisible(updated, sourceSegment: sourceSegment, receivedAt: segmentReceivedAt)
                     interimSegmentsByID[sourceSegment.id] = sourceSegment
                     continue
                 }
-                store.upsert(turn)
+                let updated = store.upsert(turn)
                 if let sourceSegment {
-                    hydrateCachedTranslation(from: sourceSegment, toTurnID: turn.id)
+                    hydrateCachedTranslation(from: sourceSegment, toTurnID: updated.id)
+                    logCaptionTurnVisible(updated, sourceSegment: sourceSegment, receivedAt: segmentReceivedAt)
                 }
             case .sealed(let turn):
                 if let sourceSegment,
@@ -172,14 +176,16 @@ public final class LiveCaptionPipeline {
                         applying: turn
                     )
                     hydrateCachedTranslation(from: sourceSegment, toTurnID: updated.id)
+                    logCaptionTurnVisible(updated, sourceSegment: sourceSegment, receivedAt: segmentReceivedAt)
                     if sourceSegment.isFinal {
                         interimSegmentsByID[sourceSegment.id] = nil
                     }
                     continue
                 }
-                store.upsert(turn)
+                let updated = store.upsert(turn)
                 if let sourceSegment {
-                    hydrateCachedTranslation(from: sourceSegment, toTurnID: turn.id)
+                    hydrateCachedTranslation(from: sourceSegment, toTurnID: updated.id)
+                    logCaptionTurnVisible(updated, sourceSegment: sourceSegment, receivedAt: segmentReceivedAt)
                     if sourceSegment.isFinal {
                         interimSegmentsByID[sourceSegment.id] = nil
                     }
@@ -187,6 +193,7 @@ public final class LiveCaptionPipeline {
             case .interimUpdated(let segment):
                 let turn = store.append(segment)
                 hydrateCachedTranslation(from: segment, toTurnID: turn.id)
+                logCaptionTurnVisible(turn, sourceSegment: segment, receivedAt: segmentReceivedAt)
                 interimSegmentsByID[segment.id] = segment
             case .removed(let turnID):
                 let updatedTurn = store.removeSourceSegment(turnID, remainingSegments: currentSegments)
@@ -199,6 +206,47 @@ public final class LiveCaptionPipeline {
                 }
             }
         }
+    }
+
+    private func logCaptionTurnVisible(
+        _ turn: LiveCaptionTurn,
+        sourceSegment: TranscriptSegment,
+        receivedAt: Date?
+    ) {
+        var metadata = captionMetadata(for: turn, sourceSegment: sourceSegment)
+        if let receivedAt {
+            metadata.merge(PerformanceEventLogger.durationMetadata(from: receivedAt)) { _, new in new }
+        }
+        performanceEventLogger?.log(
+            "caption_turn_visible",
+            audioTimeSeconds: sourceSegment.endTimeSeconds,
+            segmentID: sourceSegment.id,
+            isFinal: sourceSegment.isFinal,
+            textLength: sourceSegment.text.count,
+            metadata: metadata
+        )
+    }
+
+    private func captionMetadata(for turn: LiveCaptionTurn, sourceSegment: TranscriptSegment) -> [String: String] {
+        var metadata: [String: String] = [
+            "turnID": turn.id,
+            "sourceSegmentID": sourceSegment.id,
+            "sourceSegmentIDs": turn.sourceSegmentIDs.joined(separator: ","),
+            "sourceLocale": turn.sourceLocale,
+            "targetLocale": turn.targetLocale,
+            "captionState": String(describing: turn.displayState)
+        ]
+        let providerID = sourceSegment.sourceProvider.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !providerID.isEmpty {
+            metadata["providerID"] = providerID
+        }
+        if let boundaryStrength = turn.boundaryStrength {
+            metadata["boundaryStrength"] = String(describing: boundaryStrength)
+        }
+        if let boundaryReason = turn.boundaryReason {
+            metadata["boundaryReason"] = boundaryReason.rawValue
+        }
+        return metadata
     }
 
     private func replayCaptions(_ document: TranscriptDocument) {
@@ -294,8 +342,30 @@ public final class LiveCaptionPipeline {
             return
         }
         for update in updates {
-            translationScheduler.apply(update, to: &store)
+            let attachedVisibleText = translationScheduler.apply(update, to: &store)
+            if attachedVisibleText {
+                logCaptionSnapshotPublished(for: update, publishedAt: Date())
+            }
         }
+    }
+
+    private func logCaptionSnapshotPublished(for update: CaptionTranslationUpdate, publishedAt: Date) {
+        guard let request = update.request,
+              update.attachesVisibleText
+        else {
+            return
+        }
+        var metadata = CaptionTranslationExecutionMetadata.metadata(for: request)
+        if let resultReceivedAt = update.resultReceivedAt {
+            metadata.merge(PerformanceEventLogger.durationMetadata(from: resultReceivedAt, to: publishedAt)) { _, new in new }
+        }
+        performanceEventLogger?.log(
+            "caption_snapshot_published",
+            segmentID: update.turnID,
+            isFinal: !request.isDraft,
+            textLength: update.visibleTextLength,
+            metadata: metadata
+        )
     }
 
     private func currentTranslationHealth() -> LivePipelineHealth {

--- a/Sources/MeetingAgentCore/PerformanceEventLogger.swift
+++ b/Sources/MeetingAgentCore/PerformanceEventLogger.swift
@@ -96,3 +96,10 @@ public extension PerformanceEventLogger {
         )
     }
 }
+
+extension PerformanceEventLogger {
+    static func durationMetadata(from start: Date, to end: Date = Date()) -> [String: String] {
+        let milliseconds = max(0, Int((end.timeIntervalSince(start) * 1_000).rounded()))
+        return ["durationMilliseconds": String(milliseconds)]
+    }
+}

--- a/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
@@ -168,6 +168,16 @@ final class CaptionTranslationSchedulerTests: XCTestCase {
         XCTAssertEqual(started.metadata["requestOrdinalForTurn"], "1")
         XCTAssertEqual(started.metadata["inFlightCount"], "1")
         XCTAssertEqual(started.metadata["concurrencyLimit"], "2")
+        XCTAssertEqual(started.metadata["providerID"], "recording-translation")
+        XCTAssertNil(started.metadata["sourceText"])
+        let finished = try XCTUnwrap(events.first { $0.event == "caption_translation_finished" })
+        XCTAssertNotNil(finished.metadata["durationMilliseconds"])
+        let scheduledCount = try XCTUnwrap(events.first { $0.event == "caption_translation_scheduled_count" })
+        XCTAssertEqual(scheduledCount.metadata["count"], "1")
+        XCTAssertEqual(scheduledCount.metadata["translationKind"], "draft")
+        let completedCount = try XCTUnwrap(events.first { $0.event == "caption_translation_completed_count" })
+        XCTAssertEqual(completedCount.metadata["count"], "1")
+        XCTAssertEqual(completedCount.metadata["translationKind"], "draft")
     }
 
     func testDraftTranslationDebounceKeepsLatestPendingDraftForTurn() async {
@@ -218,6 +228,12 @@ final class CaptionTranslationSchedulerTests: XCTestCase {
         XCTAssertEqual(finalUpdates.count, 1)
         XCTAssertEqual(provider.requests.map(\.sourceText), ["same text"])
         XCTAssertTrue(events.contains { $0.event == "caption_translation_started" && $0.metadata["translationKind"] == "final" })
+        XCTAssertTrue(events.contains {
+            $0.event == "caption_translation_scheduled_count"
+                && $0.metadata["translationKind"] == "final"
+                && $0.metadata["count"] == "1"
+                && $0.metadata["providerID"] == "recording-translation"
+        })
     }
 
     func testStaleDraftCompletionLogsStaleWithoutAttachedEvent() async throws {
@@ -240,9 +256,41 @@ final class CaptionTranslationSchedulerTests: XCTestCase {
         scheduler.apply(update, to: &currentStore)
 
         let events = try readEvents(from: eventsURL)
-        XCTAssertTrue(events.contains { $0.event == "caption_translation_stale" })
+        let stale = try XCTUnwrap(events.first { $0.event == "caption_translation_stale" })
+        XCTAssertEqual(stale.metadata["translationKind"], "draft")
+        XCTAssertEqual(stale.metadata["reason"], "draft_no_longer_current")
+        XCTAssertTrue(events.contains {
+            $0.event == "caption_translation_stale_count"
+                && $0.metadata["count"] == "1"
+                && $0.metadata["translationKind"] == "draft"
+        })
         XCTAssertFalse(events.contains { $0.event == "caption_translation_attached" })
         XCTAssertNil(currentStore.turns.first?.translatedText)
+    }
+
+    func testProviderFailureLogsSanitizedErrorCount() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("caption-translation-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let eventsURL = root.appendingPathComponent("performance-events.jsonl")
+        var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+        store.upsert(hardSealedTurn(text: "private words", sourceLocale: "en-US", targetLocale: "zh-CN"))
+        let provider = RecordingTextTranslationProvider(error: NSError(domain: "translation", code: 2))
+        let scheduler = CaptionTranslationScheduler(
+            provider: provider,
+            performanceEventLogger: PerformanceEventLogger(url: eventsURL),
+            configuration: CaptionTranslationSchedulerConfiguration(draftDebounceNanoseconds: 0, maxConcurrentTranslationRequests: 2)
+        )
+
+        await scheduler.scheduleTranslations(in: &store)
+
+        let events = try readEvents(from: eventsURL)
+        let providerError = try XCTUnwrap(events.first { $0.event == "caption_translation_provider_error" })
+        XCTAssertEqual(providerError.metadata["failureReason"], "translation error 2")
+        XCTAssertEqual(providerError.metadata["retryCount"], "0")
+        XCTAssertEqual(providerError.metadata["count"], "1")
+        XCTAssertEqual(providerError.metadata["translationKind"], "final")
+        XCTAssertEqual(providerError.metadata["providerID"], "recording-translation")
+        XCTAssertFalse(providerError.metadata.values.contains("private words"))
     }
 
     func testTranslationRequestsRespectGlobalConcurrencyLimit() async {

--- a/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift
@@ -291,6 +291,12 @@ final class CaptionTranslationSchedulerTests: XCTestCase {
         XCTAssertEqual(providerError.metadata["translationKind"], "final")
         XCTAssertEqual(providerError.metadata["providerID"], "recording-translation")
         XCTAssertFalse(providerError.metadata.values.contains("private words"))
+        XCTAssertTrue(events.contains {
+            $0.event == "caption_translation_failed_count"
+                && $0.metadata["count"] == "1"
+                && $0.metadata["translationKind"] == "final"
+                && $0.metadata["failureReason"] == "translation error 2"
+        })
     }
 
     func testTranslationRequestsRespectGlobalConcurrencyLimit() async {

--- a/Tests/MeetingAgentCoreTests/LiveCaptionPipelineTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionPipelineTests.swift
@@ -89,6 +89,49 @@ final class LiveCaptionPipelineTests: XCTestCase {
         XCTAssertEqual(snapshot.turns.first?.displayState, .draft)
     }
 
+    func testApplyLogsCaptionTurnVisibleWithoutRawText() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("live-caption-pipeline-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let eventsURL = root.appendingPathComponent("performance-events.jsonl")
+        let pipeline = LiveCaptionPipeline(
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            translationProvider: nil,
+            performanceEventLogger: PerformanceEventLogger(url: eventsURL)
+        )
+        let result = TranscriptSegmentAccumulationResult(
+            document: TranscriptDocument(segments: [
+                TranscriptSegment(
+                    id: "deepgram-transcribe-stream-0.0",
+                    speaker: TranscriptSpeaker(identifier: "deepgram-speaker-0"),
+                    text: "Sensitive customer launch detail",
+                    language: "en-US",
+                    sourceProvider: "deepgram-transcribe",
+                    isFinal: false,
+                    speechFinal: false
+                )
+            ]),
+            changedSegmentIDs: ["deepgram-transcribe-stream-0.0"],
+            plainTextReplacement: nil
+        )
+
+        _ = await pipeline.apply(result)
+
+        let events = try readPipelineEvents(from: eventsURL)
+        let visible = try XCTUnwrap(events.first { $0.event == "caption_turn_visible" })
+        XCTAssertEqual(visible.segmentID, "deepgram-transcribe-stream-0.0")
+        XCTAssertEqual(visible.isFinal, false)
+        XCTAssertEqual(visible.textLength, "Sensitive customer launch detail".count)
+        XCTAssertEqual(visible.metadata["turnID"], "deepgram-transcribe-stream-0.0")
+        XCTAssertEqual(visible.metadata["sourceSegmentID"], "deepgram-transcribe-stream-0.0")
+        XCTAssertEqual(visible.metadata["sourceLocale"], "en-US")
+        XCTAssertEqual(visible.metadata["targetLocale"], "zh-CN")
+        XCTAssertEqual(visible.metadata["providerID"], "deepgram-transcribe")
+        XCTAssertNotNil(visible.metadata["durationMilliseconds"])
+        XCTAssertNil(visible.metadata["text"])
+        XCTAssertFalse(visible.metadata.values.contains("Sensitive customer launch detail"))
+    }
+
     func testApplySameIDInterimUpdatePreservesMergedTurn() async {
         let pipeline = LiveCaptionPipeline(
             sourceLocale: "en-US",
@@ -539,6 +582,45 @@ final class LiveCaptionPipelineTests: XCTestCase {
         XCTAssertEqual(translatedSnapshot.translationHealth, .live)
     }
 
+    func testScheduleLivePendingTranslationsLogsSnapshotPublished() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("live-caption-pipeline-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let eventsURL = root.appendingPathComponent("performance-events.jsonl")
+        let provider = PipelineRecordingTranslationProvider(translations: ["segment-1": "草稿"])
+        let pipeline = LiveCaptionPipeline(
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            translationProvider: provider,
+            performanceEventLogger: PerformanceEventLogger(url: eventsURL)
+        )
+        let document = TranscriptDocument(segments: [
+            TranscriptSegment(
+                id: "segment-1",
+                text: "draft text",
+                language: "en-US",
+                isFinal: false,
+                speechFinal: false
+            )
+        ])
+
+        _ = pipeline.replayCaptionsOnly(document)
+        _ = await pipeline.scheduleLivePendingTranslations()
+
+        let events = try readPipelineEvents(from: eventsURL)
+        let published = try XCTUnwrap(events.first { $0.event == "caption_snapshot_published" })
+        XCTAssertEqual(published.segmentID, "segment-1")
+        XCTAssertEqual(published.isFinal, false)
+        XCTAssertEqual(published.textLength, "草稿".count)
+        XCTAssertEqual(published.metadata["turnID"], "segment-1")
+        XCTAssertEqual(published.metadata["sourceSegmentID"], "segment-1")
+        XCTAssertEqual(published.metadata["sourceLocale"], "en-US")
+        XCTAssertEqual(published.metadata["targetLocale"], "zh-CN")
+        XCTAssertEqual(published.metadata["translationKind"], "draft")
+        XCTAssertEqual(published.metadata["providerID"], "pipeline-recording-translation")
+        XCTAssertNotNil(published.metadata["translationRequestID"])
+        XCTAssertNotNil(published.metadata["durationMilliseconds"])
+    }
+
     func testStaleTranslationCompletionDoesNotOverwriteNewerReplayState() async throws {
         let provider = SuspendedPipelineTranslationProvider()
         let pipeline = LiveCaptionPipeline(
@@ -724,6 +806,14 @@ private func waitForPipelineCondition(
         }
         try await Task.sleep(nanoseconds: 1_000_000)
     }
+}
+
+private func readPipelineEvents(from url: URL) throws -> [PerformanceEvent] {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try String(contentsOf: url, encoding: .utf8)
+        .split(whereSeparator: \.isNewline)
+        .map { try decoder.decode(PerformanceEvent.self, from: Data($0.utf8)) }
 }
 
 private final class SuspendedPipelineTranslationProvider: TextTranslationProvider {

--- a/Tests/MeetingAgentCoreTests/PerformanceEventLoggerTests.swift
+++ b/Tests/MeetingAgentCoreTests/PerformanceEventLoggerTests.swift
@@ -35,4 +35,13 @@ final class PerformanceEventLoggerTests: XCTestCase {
         XCTAssertEqual(first.metadata["provider"], "deepgram-transcribe")
         XCTAssertEqual(second.event, "recording_stopped")
     }
+
+    func testDurationMetadataRoundsElapsedMilliseconds() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        let end = Date(timeIntervalSince1970: 1_000.124)
+
+        let metadata = PerformanceEventLogger.durationMetadata(from: start, to: end)
+
+        XCTAssertEqual(metadata["durationMilliseconds"], "124")
+    }
 }

--- a/docs/mistakes/2026-04-30T12-15-46Z.md
+++ b/docs/mistakes/2026-04-30T12-15-46Z.md
@@ -1,0 +1,13 @@
+# [120] Keep distinct metrics for adjacent failure concepts
+
+**Date**: 2026-04-30
+**Category**: logic-error
+
+### What went wrong
+The first live caption metrics implementation logged provider errors with `count=1`, but review found it did not also emit a distinct failed translation request count.
+
+### Correct approach
+When an issue asks for multiple related metrics, log each requested concept explicitly even when two events currently happen on the same code path.
+
+### How to avoid
+Map every requested metric name to a concrete event before treating adjacent telemetry as sufficient.

--- a/docs/superpowers/plans/2026-04-30-live-caption-latency-metrics.md
+++ b/docs/superpowers/plans/2026-04-30-live-caption-latency-metrics.md
@@ -1,0 +1,66 @@
+# Live Caption Latency Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add non-sensitive latency and lifecycle metrics for realtime captions and caption translation.
+
+**Architecture:** Keep the existing JSONL `PerformanceEventLogger` as the only sink. `LiveCaptionPipeline` owns STT-to-visible and snapshot-published checkpoints; `CaptionTranslationScheduler` owns translation request counts, provider timing, stale discard, and failure payloads.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, macOS 14.2 target.
+
+---
+
+### Task 1: Logger Duration Metadata
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/PerformanceEventLogger.swift`
+- Test: `Tests/MeetingAgentCoreTests/PerformanceEventLoggerTests.swift`
+
+- [ ] Add an internal helper that returns metadata with `durationMilliseconds` from two `Date` values.
+- [ ] Add a logger test that confirms duration metadata remains encoded through JSONL.
+- [ ] Run: `swift test --filter PerformanceEventLoggerTests`.
+
+### Task 2: Pipeline Caption Latency Events
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveCaptionPipeline.swift`
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionPipelineTests.swift`
+
+- [ ] Track receive time for each changed segment in `apply(_:)`.
+- [ ] Log `caption_turn_visible` after upsert, append, or replace paths mutate the store.
+- [ ] Include segment ID, turn ID, locale pair, final state, boundary metadata, and `durationMilliseconds`.
+- [ ] Add a focused test proving raw transcript text is absent from event metadata.
+- [ ] Run: `swift test --filter LiveCaptionPipelineTests`.
+
+### Task 3: Translation Scheduler Metrics
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/CaptionTranslationScheduler.swift`
+- Test: `Tests/MeetingAgentCoreTests/CaptionTranslationSchedulerTests.swift`
+
+- [ ] Add `providerID` to provider-backed request metadata.
+- [ ] Emit count events for draft/final scheduled, completed, stale, cancelled, skipped, and failed paths using `count=1`.
+- [ ] Add `durationMilliseconds` to `caption_translation_finished`.
+- [ ] Log provider failure events with sanitized error metadata.
+- [ ] Add focused tests for draft, final, stale, and failure payload shape.
+- [ ] Run: `swift test --filter CaptionTranslationSchedulerTests`.
+
+### Task 4: Snapshot Publish Metrics
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveCaptionPipeline.swift`
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionPipelineTests.swift`
+
+- [ ] Return enough scheduler update context for pipeline snapshot logging without exposing public API.
+- [ ] Log `caption_snapshot_published` after successful translation attachment.
+- [ ] Include translation request ID, turn ID, source/target locale, draft/final state, and duration from result receipt to snapshot publish.
+- [ ] Run: `swift test --filter LiveCaptionPipelineTests`.
+
+### Task 5: Full Verification And Commit
+
+**Files:**
+- All modified source and test files.
+
+- [ ] Run: `swift build --product MeetingAgentApp`.
+- [ ] Run: `make test`.
+- [ ] Commit implementation with `feat: add live caption latency metrics (#120)`.

--- a/docs/superpowers/specs/2026-04-30-live-caption-latency-metrics-design.md
+++ b/docs/superpowers/specs/2026-04-30-live-caption-latency-metrics-design.md
@@ -1,0 +1,53 @@
+# Live Caption Latency Metrics Design
+
+## Context
+
+Issue #120 asks for explicit realtime caption metrics after the caption lifecycle moved into `LiveCaptionPipeline`, `CaptionTurnAssembler`, and `CaptionTranslationScheduler`. The existing `PerformanceEventLogger` already writes JSONL events and the caption scheduler already logs request lifecycle events, but the pipeline does not yet expose all latency checkpoints or count/failure payloads needed to compare scheduler and provider changes.
+
+## Goals
+
+- Emit STT segment to caption visible latency without logging raw transcript text.
+- Emit caption translation lifecycle metrics for scheduled, started, finished, attached, stale, cancelled, skipped, and failed paths.
+- Include enough non-sensitive context to debug latency: turn IDs, source segment IDs, provider ID, locale pair, draft/final state, boundary metadata, request ordinal, queue depth, in-flight count, and duration in milliseconds where the code can measure it directly.
+- Cover representative draft, final, stale, and failure payloads in tests.
+
+## Non-Goals
+
+- Do not add a second metrics sink or aggregated metrics database.
+- Do not log raw transcript or translated text.
+- Do not change user-visible caption or translation behavior.
+
+## Selected Approach
+
+Extend the existing `PerformanceEventLogger` JSONL event stream. `LiveCaptionPipeline` records when a changed transcript segment is received, then logs `caption_turn_visible` when the corresponding live caption turn is inserted or updated. `CaptionTranslationScheduler` continues to own translation lifecycle events and adds duration/count/error fields to the existing request events.
+
+This keeps metrics co-located with the code that knows the timing boundary, avoids duplicate persistence, and lets tests assert event payload shape with the current JSONL decoder helpers.
+
+## Event Shape
+
+All new metadata values are strings to preserve the existing `PerformanceEvent.metadata` contract.
+
+- `durationMilliseconds`: integer elapsed wall-clock milliseconds for a directly measured interval.
+- `providerID`: translation provider identifier when a provider-backed request runs.
+- `turnID`, `sourceSegmentID`, `sourceSegmentIDs`: caption identity without text.
+- `sourceLocale`, `targetLocale`: language pair.
+- `translationKind`: `draft` or `final`.
+- `boundaryStrength`, `boundaryReason`: included when known.
+- `requestOrdinalForTurn`, `queueDepth`, `inFlightCount`, `concurrencyLimit`: scheduler context.
+- `failureReason`: sanitized provider error category for failure events.
+- `count`: `1` on count events so downstream tooling can aggregate draft/final schedules, completions, stale discards, provider errors, and retries.
+
+## Implementation Plan
+
+1. Add duration helper support to `PerformanceEventLogger` without changing the encoded model.
+2. Track segment receive times inside `LiveCaptionPipeline` and log `caption_turn_visible` when turns are upserted, appended, or replaced.
+3. Log `caption_snapshot_published` after translation updates are applied, keyed to the translation request that attached text to a turn.
+4. Extend scheduler metadata with provider ID and count events.
+5. Add provider failure logging in `performTranslation`.
+6. Add focused tests for pipeline event shape and scheduler draft/final/stale/failure payloads.
+
+## Test Plan
+
+- Run focused `swift test --filter LiveCaptionPipelineTests`.
+- Run focused `swift test --filter CaptionTranslationSchedulerTests`.
+- Run `make test` for the project coverage gate.


### PR DESCRIPTION
## Summary

Fixes #120

- Adds non-sensitive live caption latency events for segment-to-visible and snapshot publication timing.
- Extends caption translation scheduler telemetry with provider ID, duration, draft/final count, stale, failed, and provider error events.
- Records design/implementation notes and a reusable metrics lesson.

## Changes

- `Sources/MeetingAgentCore/LiveCaptionPipeline.swift` - logs caption visibility and snapshot publication events.
- `Sources/MeetingAgentCore/CaptionTranslationScheduler.swift` - enriches translation lifecycle telemetry and count events.
- `Sources/MeetingAgentCore/PerformanceEventLogger.swift` - adds duration metadata helper.
- `Tests/MeetingAgentCoreTests/*` - covers payload shape for draft, final, stale, failure, caption visible, and snapshot publication paths.
- `docs/superpowers/*` and `docs/mistakes/*` - captures design, plan, and lessons.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter PerformanceEventLoggerTests`, `swift test --filter CaptionTranslationSchedulerTests`, `swift test --filter LiveCaptionPipelineTests` passed
- [x] Full verification: `make test` passed with coverage gate
- [x] Code review: PASS after one metrics completeness fix
- [x] E2E/integration: skipped; no E2E convention for this internal metrics path
