### PR TITLE
feat: debounce live caption snapshot publication

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -43,6 +43,10 @@ public final class MeetingAgentViewModel: ObservableObject {
     private var activeCaptionApplyTask: Task<Void, Never>?
     private var liveCaptionReplayTask: Task<Void, Never>?
     private var liveCaptionReplaySequence = 0
+    private let liveCaptionSnapshotDebounceNanoseconds: UInt64
+    private var pendingLiveCaptionSnapshot: LiveCaptionPipelineSnapshot?
+    private var pendingLiveCaptionSnapshotTask: Task<Void, Never>?
+    private var pendingLiveCaptionSnapshotGeneration = 0
     @Published public private(set) var meetingGoal: MeetingGoal?
     public var recommendedQuestions: [FollowUpQuestionSuggestion] {
         Array((meetingProgressState?.suggestedQuestions ?? []).prefix(2))
@@ -70,6 +74,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         exportService: MeetingExportService = MeetingExportService(),
         captionTranslationProviderFactory: @escaping (SpeechTranscriptionConfiguration) -> TextTranslationProvider? = MeetingAgentViewModel.openRouterCaptionTranslationProvider,
         summaryProviderFactory: ((SpeechTranscriptionConfiguration) -> MeetingSummaryProvider)? = nil,
+        liveCaptionSnapshotDebounceNanoseconds: UInt64 = 75_000_000,
         processTargetsProvider: @escaping () -> [AudioCaptureTarget] = RunningProcessDiscovery.currentTargets
     ) {
         self.store = store
@@ -80,6 +85,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         self.summaryProviderFactory = summaryProviderFactory ?? { configuration in
             Self.summaryProvider(for: configuration)
         }
+        self.liveCaptionSnapshotDebounceNanoseconds = liveCaptionSnapshotDebounceNanoseconds
         self.processTargetsProvider = processTargetsProvider
         let resolvedSpeechConfiguration: SpeechTranscriptionConfiguration
         if let speechConfiguration {
@@ -895,7 +901,7 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     private func resetLiveCaptionStore() {
         resetLiveCaptionPipeline()
-        liveCaptionTurns = []
+        clearLiveCaptionTurns()
         meetingProgressHealth.caption = .idle
         meetingProgressHealth.translation = .idle
         resetMeetingProgressState()
@@ -906,7 +912,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         liveCaptionReplayTask?.cancel()
         liveCaptionReplayTask = nil
         liveCaptionReplaySequence += 1
-        liveCaptionTurns = []
+        clearLiveCaptionTurns()
         liveCaptionPipeline = makeLiveCaptionPipeline()
         liveCaptionPipelineUsesCaptionTranslationProvider = false
         liveCaptionPipelineHasTranslationProvider = false
@@ -958,7 +964,7 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     private func refreshLiveCaptionTurnsFromSelectedMeeting() {
         guard let document = selectedTranscriptDocument(), !document.segments.isEmpty else {
-            liveCaptionTurns = []
+            clearLiveCaptionTurns()
             meetingProgressHealth.caption = .idle
             return
         }
@@ -973,7 +979,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     private func refreshLiveCaptionTurnsFromSelectedMeetingSynchronously() {
         guard let document = selectedTranscriptDocument() else {
             liveCaptionReplayTask = nil
-            liveCaptionTurns = []
+            clearLiveCaptionTurns()
             meetingProgressHealth.caption = .idle
             return
         }
@@ -1035,7 +1041,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     ) async {
         guard !Task.isCancelled else { return }
         guard let document = providedDocument ?? selectedTranscriptDocument() else {
-            liveCaptionTurns = []
+            clearLiveCaptionTurns()
             meetingProgressHealth.caption = .idle
             return
         }
@@ -1127,7 +1133,91 @@ public final class MeetingAgentViewModel: ObservableObject {
             && context.selectedMeetingID == selectedMeetingID
     }
 
+    private func clearLiveCaptionTurns() {
+        cancelPendingLiveCaptionSnapshotPublication()
+        liveCaptionTurns = []
+    }
+
+    private func cancelPendingLiveCaptionSnapshotPublication() {
+        pendingLiveCaptionSnapshotGeneration += 1
+        pendingLiveCaptionSnapshotTask?.cancel()
+        pendingLiveCaptionSnapshotTask = nil
+        pendingLiveCaptionSnapshot = nil
+    }
+
     private func publishLiveCaptionPipelineSnapshot(_ snapshot: LiveCaptionPipelineSnapshot) {
+        guard shouldDebounceLiveCaptionSnapshot(snapshot) else {
+            cancelPendingLiveCaptionSnapshotPublication()
+            publishLiveCaptionPipelineSnapshotImmediately(snapshot)
+            return
+        }
+
+        if let pendingLiveCaptionSnapshot {
+            currentPerformanceEventLogger()?.log(
+                "caption_snapshot_publication_coalesced",
+                metadata: [
+                    "pendingTurnCount": String(pendingLiveCaptionSnapshot.turns.count),
+                    "replacementTurnCount": String(snapshot.turns.count),
+                    "debounceMilliseconds": String(liveCaptionSnapshotDebounceNanoseconds / 1_000_000)
+                ]
+            )
+        }
+        pendingLiveCaptionSnapshot = snapshot
+        pendingLiveCaptionSnapshotGeneration += 1
+        let generation = pendingLiveCaptionSnapshotGeneration
+        let delay = liveCaptionSnapshotDebounceNanoseconds
+        pendingLiveCaptionSnapshotTask?.cancel()
+        pendingLiveCaptionSnapshotTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: delay)
+            guard !Task.isCancelled else { return }
+            self?.publishPendingLiveCaptionSnapshot(generation: generation)
+        }
+    }
+
+    private func shouldDebounceLiveCaptionSnapshot(_ snapshot: LiveCaptionPipelineSnapshot) -> Bool {
+        guard liveCaptionSnapshotDebounceNanoseconds > 0 else { return false }
+        guard !snapshot.turns.isEmpty else { return false }
+        guard snapshot.captionHealth == .live else { return false }
+        switch snapshot.translationHealth {
+        case .failed, .degraded:
+            return false
+        case .idle, .pending, .live:
+            break
+        }
+        let previousTurns = pendingLiveCaptionSnapshot?.turns ?? liveCaptionTurns
+        guard !previousTurns.isEmpty else {
+            return snapshot.turns.allSatisfy(isDelayableDraftCaptionTurn)
+        }
+        let previousTurnsByID = Dictionary(uniqueKeysWithValues: previousTurns.map { ($0.id, $0) })
+        let snapshotTurnsByID = Dictionary(uniqueKeysWithValues: snapshot.turns.map { ($0.id, $0) })
+        let changedSnapshotTurns = snapshot.turns.filter { previousTurnsByID[$0.id] != $0 }
+        let removedPreviousTurns = previousTurns.filter { snapshotTurnsByID[$0.id] == nil }
+        guard !changedSnapshotTurns.isEmpty || !removedPreviousTurns.isEmpty else {
+            return false
+        }
+        return changedSnapshotTurns.allSatisfy(isDelayableDraftCaptionTurn)
+            && removedPreviousTurns.allSatisfy(isDelayableDraftCaptionTurn)
+    }
+
+    private func isDelayableDraftCaptionTurn(_ turn: LiveCaptionTurn) -> Bool {
+        turn.displayState == .draft
+            && !turn.isFinal
+            && turn.boundaryStrength != .hard
+            && turn.captionHealth == .live
+    }
+
+    private func publishPendingLiveCaptionSnapshot(generation: Int) {
+        guard generation == pendingLiveCaptionSnapshotGeneration,
+              let snapshot = pendingLiveCaptionSnapshot
+        else {
+            return
+        }
+        pendingLiveCaptionSnapshotTask = nil
+        pendingLiveCaptionSnapshot = nil
+        publishLiveCaptionPipelineSnapshotImmediately(snapshot)
+    }
+
+    private func publishLiveCaptionPipelineSnapshotImmediately(_ snapshot: LiveCaptionPipelineSnapshot) {
         liveCaptionTurns = snapshot.turns
         meetingProgressHealth.caption = snapshot.captionHealth
         meetingProgressHealth.translation = snapshot.translationHealth

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -529,6 +529,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
         let viewModel = MeetingAgentViewModel(
             store: fixture.store,
             recorder: fixture.recorder,
+            liveCaptionSnapshotDebounceNanoseconds: 0,
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
@@ -548,12 +549,185 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.meetingProgressHealth.caption, .live)
     }
 
+    func testDraftCaptionSnapshotsAreDebouncedBeforePublication() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            liveCaptionSnapshotDebounceNanoseconds: 100_000_000,
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        var accumulator = TranscriptSegmentAccumulator()
+
+        let first = accumulator.apply(.upsert(TranscriptSegment(
+            id: "draft-1",
+            text: "first draft",
+            language: "en-US",
+            isFinal: false
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([first])
+        XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+        let second = accumulator.apply(.upsert(TranscriptSegment(
+            id: "draft-1",
+            text: "second draft",
+            language: "en-US",
+            isFinal: false
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([second])
+        XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.originalText == "second draft"
+        }
+        XCTAssertEqual(viewModel.liveCaptionTurns.count, 1)
+    }
+
+    func testFinalCaptionSnapshotPublishesImmediatelyAndCancelsPendingDraft() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            liveCaptionSnapshotDebounceNanoseconds: 1_000_000_000,
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        var accumulator = TranscriptSegmentAccumulator()
+
+        let draft = accumulator.apply(.upsert(TranscriptSegment(
+            id: "caption-1",
+            text: "draft text",
+            language: "en-US",
+            isFinal: false
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([draft])
+        XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+        let final = accumulator.apply(.upsert(TranscriptSegment(
+            id: "caption-1",
+            text: "final text",
+            language: "en-US",
+            isFinal: true,
+            speechFinal: true
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([final])
+
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "final text")
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.isFinal, true)
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "final text")
+    }
+
+    func testDraftSnapshotAfterVisibleFinalCaptionIsDebounced() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            liveCaptionSnapshotDebounceNanoseconds: 100_000_000,
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        var accumulator = TranscriptSegmentAccumulator()
+
+        let final = accumulator.apply(.upsert(TranscriptSegment(
+            id: "final-1",
+            text: "final text",
+            language: "en-US",
+            isFinal: true,
+            speechFinal: true
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([final])
+        XCTAssertEqual(viewModel.liveCaptionTurns.map(\.sourceSegmentID), ["final-1"])
+
+        let draft = accumulator.apply(.upsert(TranscriptSegment(
+            id: "draft-2",
+            text: "draft after final",
+            language: "en-US",
+            isFinal: false
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([draft])
+        XCTAssertEqual(viewModel.liveCaptionTurns.map(\.sourceSegmentID), ["final-1"])
+
+        try await waitFor {
+            viewModel.liveCaptionTurns.map(\.sourceSegmentID) == ["final-1", "draft-2"]
+        }
+    }
+
+    func testSelectingAnotherMeetingCancelsPendingDraftCaptionSnapshot() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            liveCaptionSnapshotDebounceNanoseconds: 1_000_000_000,
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        let firstMeetingID = try XCTUnwrap(viewModel.selectedMeetingID)
+        let secondMeeting = try fixture.store.createMeeting(name: "Second", startedAt: Date()).record
+        viewModel.selectMeeting(firstMeetingID)
+        var accumulator = TranscriptSegmentAccumulator()
+
+        let draft = accumulator.apply(.upsert(TranscriptSegment(
+            id: "stale-draft",
+            text: "stale draft",
+            language: "en-US",
+            isFinal: false
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([draft])
+        XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+        viewModel.selectMeeting(secondMeeting.id)
+        try await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+    }
+
+    func testCoalescedDraftCaptionSnapshotsLogPerformanceEvent() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            liveCaptionSnapshotDebounceNanoseconds: 100_000_000,
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+        let record = try XCTUnwrap(viewModel.selectedMeeting)
+        var accumulator = TranscriptSegmentAccumulator()
+
+        let first = accumulator.apply(.upsert(TranscriptSegment(
+            id: "metric-draft",
+            text: "first",
+            language: "en-US",
+            isFinal: false
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([first])
+        let second = accumulator.apply(.upsert(TranscriptSegment(
+            id: "metric-draft",
+            text: "second",
+            language: "en-US",
+            isFinal: false
+        )))
+        await viewModel.applyTranscriptAccumulationResultsForTesting([second])
+
+        try await waitFor {
+            ((try? readPerformanceEvents(from: XCTUnwrap(record.performanceEventsURL))) ?? [])
+                .contains(where: { $0.event == "caption_snapshot_publication_coalesced" })
+        }
+    }
+
     func testStaleActiveTranscriptApplyDoesNotOverwriteNewerCaption() async throws {
         let fixture = try ViewModelRecorderFixture()
         let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
         let viewModel = MeetingAgentViewModel(
             store: fixture.store,
             recorder: fixture.recorder,
+            liveCaptionSnapshotDebounceNanoseconds: 0,
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
@@ -1462,6 +1636,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
         let viewModel = MeetingAgentViewModel(
             store: store,
             captionTranslationProviderFactory: { _ in provider },
+            liveCaptionSnapshotDebounceNanoseconds: 0,
             processTargetsProvider: { [] }
         )
         try viewModel.loadMeetings()

--- a/docs/mistakes/2026-04-30T13-06-38Z.md
+++ b/docs/mistakes/2026-04-30T13-06-38Z.md
@@ -1,0 +1,13 @@
+# [119] Compare Changed Snapshot Turns For Display Debounce
+
+**Date**: 2026-04-30
+**Category**: logic-error
+
+### What went wrong
+The first display snapshot debounce predicate required every visible caption turn in the snapshot to be draft, which missed the common case where existing final captions remain visible and only a new draft turn changes.
+
+### Correct approach
+Compare the pending snapshot against the currently visible or pending snapshot, then debounce only when the changed or removed turns are draft-only.
+
+### How to avoid
+For UI snapshot throttling, classify the delta between snapshots, not the entire snapshot.

--- a/docs/superpowers/plans/2026-04-30-live-caption-snapshot-debounce.md
+++ b/docs/superpowers/plans/2026-04-30-live-caption-snapshot-debounce.md
@@ -1,0 +1,406 @@
+# Live Caption Snapshot Debounce Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Debounce draft-only live caption UI snapshot publication while keeping pipeline ingestion and final caption publication immediate.
+
+**Architecture:** `MeetingAgentViewModel` remains the presentation boundary for `@Published liveCaptionTurns`. It stores one pending delayable `LiveCaptionPipelineSnapshot`, schedules a short main-actor task, and cancels that task whenever an immediate snapshot, reset, or selection change happens. The caption pipeline and transcript persistence remain unchanged.
+
+**Tech Stack:** Swift 5.9, Swift concurrency on `@MainActor`, XCTest, existing `PerformanceEventLogger`.
+
+---
+
+### Task 1: Add Focused Failing Tests
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Add draft debounce and immediate final tests**
+
+Add tests near the existing active live caption tests:
+
+```swift
+func testDraftCaptionSnapshotsAreDebouncedBeforePublication() async throws {
+    let fixture = try ViewModelRecorderFixture()
+    let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+    let viewModel = MeetingAgentViewModel(
+        store: fixture.store,
+        recorder: fixture.recorder,
+        liveCaptionSnapshotDebounceNanoseconds: 100_000_000,
+        processTargetsProvider: { [target] }
+    )
+    try await viewModel.startRecording(for: target)
+    var accumulator = TranscriptSegmentAccumulator()
+
+    let first = accumulator.apply(.upsert(TranscriptSegment(
+        id: "draft-1",
+        text: "first draft",
+        language: "en-US",
+        isFinal: false
+    )))
+    await viewModel.applyTranscriptAccumulationResultsForTesting([first])
+    XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+    let second = accumulator.apply(.upsert(TranscriptSegment(
+        id: "draft-1",
+        text: "second draft",
+        language: "en-US",
+        isFinal: false
+    )))
+    await viewModel.applyTranscriptAccumulationResultsForTesting([second])
+    XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+    try await waitFor {
+        viewModel.liveCaptionTurns.first?.originalText == "second draft"
+    }
+    XCTAssertEqual(viewModel.liveCaptionTurns.count, 1)
+}
+
+func testFinalCaptionSnapshotPublishesImmediatelyAndCancelsPendingDraft() async throws {
+    let fixture = try ViewModelRecorderFixture()
+    let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+    let viewModel = MeetingAgentViewModel(
+        store: fixture.store,
+        recorder: fixture.recorder,
+        liveCaptionSnapshotDebounceNanoseconds: 1_000_000_000,
+        processTargetsProvider: { [target] }
+    )
+    try await viewModel.startRecording(for: target)
+    var accumulator = TranscriptSegmentAccumulator()
+
+    let draft = accumulator.apply(.upsert(TranscriptSegment(
+        id: "caption-1",
+        text: "draft text",
+        language: "en-US",
+        isFinal: false
+    )))
+    await viewModel.applyTranscriptAccumulationResultsForTesting([draft])
+    XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+    let final = accumulator.apply(.upsert(TranscriptSegment(
+        id: "caption-1",
+        text: "final text",
+        language: "en-US",
+        isFinal: true,
+        speechFinal: true
+    )))
+    await viewModel.applyTranscriptAccumulationResultsForTesting([final])
+
+    XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "final text")
+    XCTAssertEqual(viewModel.liveCaptionTurns.first?.isFinal, true)
+
+    try await Task.sleep(nanoseconds: 150_000_000)
+    XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "final text")
+}
+```
+
+- [ ] **Step 2: Add reset cancellation and coalesced metric tests**
+
+Add tests near the same section:
+
+```swift
+func testSelectingAnotherMeetingCancelsPendingDraftCaptionSnapshot() async throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = MeetingStore(baseDirectory: root)
+    let firstRecord = try store.createMeeting(name: "First", startedAt: Date()).record
+    let secondRecord = try store.createMeeting(name: "Second", startedAt: Date()).record
+    let viewModel = MeetingAgentViewModel(
+        store: store,
+        liveCaptionSnapshotDebounceNanoseconds: 1_000_000_000,
+        processTargetsProvider: { [] }
+    )
+    try viewModel.loadMeetings()
+    viewModel.selectMeeting(firstRecord.id)
+    viewModel.setActiveMeetingForTesting(firstRecord.id)
+    var accumulator = TranscriptSegmentAccumulator()
+
+    let draft = accumulator.apply(.upsert(TranscriptSegment(
+        id: "stale-draft",
+        text: "stale draft",
+        language: "en-US",
+        isFinal: false
+    )))
+    await viewModel.applyTranscriptAccumulationResultsForTesting([draft])
+    XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+
+    viewModel.selectMeeting(secondRecord.id)
+    try await Task.sleep(nanoseconds: 150_000_000)
+    XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+}
+
+func testCoalescedDraftCaptionSnapshotsLogPerformanceEvent() async throws {
+    let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+    defer { try? FileManager.default.removeItem(at: root) }
+    let store = MeetingStore(baseDirectory: root)
+    let record = try store.createMeeting(name: "Meet", startedAt: Date()).record
+    let viewModel = MeetingAgentViewModel(
+        store: store,
+        liveCaptionSnapshotDebounceNanoseconds: 100_000_000,
+        processTargetsProvider: { [] }
+    )
+    try viewModel.loadMeetings()
+    viewModel.selectMeeting(record.id)
+    viewModel.setActiveMeetingForTesting(record.id)
+    var accumulator = TranscriptSegmentAccumulator()
+
+    let first = accumulator.apply(.upsert(TranscriptSegment(
+        id: "metric-draft",
+        text: "first",
+        language: "en-US",
+        isFinal: false
+    )))
+    await viewModel.applyTranscriptAccumulationResultsForTesting([first])
+    let second = accumulator.apply(.upsert(TranscriptSegment(
+        id: "metric-draft",
+        text: "second",
+        language: "en-US",
+        isFinal: false
+    )))
+    await viewModel.applyTranscriptAccumulationResultsForTesting([second])
+
+    try await waitFor {
+        ((try? readPerformanceEvents(from: XCTUnwrap(record.performanceEventsURL))) ?? [])
+            .contains(where: { $0.event == "caption_snapshot_publication_coalesced" })
+    }
+}
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests/testDraftCaptionSnapshotsAreDebouncedBeforePublication
+```
+
+Expected: compile failure because `liveCaptionSnapshotDebounceNanoseconds` and `setActiveMeetingForTesting` are not yet implemented, or assertion failure because draft snapshots publish immediately.
+
+### Task 2: Add ViewModel Debounce State and Injection
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+
+- [ ] **Step 1: Add stored properties**
+
+Add private state beside existing caption task state:
+
+```swift
+private let liveCaptionSnapshotDebounceNanoseconds: UInt64
+private var pendingLiveCaptionSnapshot: LiveCaptionPipelineSnapshot?
+private var pendingLiveCaptionSnapshotTask: Task<Void, Never>?
+private var pendingLiveCaptionSnapshotGeneration = 0
+```
+
+- [ ] **Step 2: Add initializer parameter**
+
+Add this parameter before `processTargetsProvider`:
+
+```swift
+liveCaptionSnapshotDebounceNanoseconds: UInt64 = 75_000_000,
+```
+
+Assign it in `init`:
+
+```swift
+self.liveCaptionSnapshotDebounceNanoseconds = liveCaptionSnapshotDebounceNanoseconds
+```
+
+- [ ] **Step 3: Run compile check**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests/testDraftCaptionSnapshotsAreDebouncedBeforePublication
+```
+
+Expected: tests still fail until publication logic exists.
+
+### Task 3: Implement Immediate vs Delayable Publication
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+
+- [ ] **Step 1: Add cancellation helper**
+
+Add helper methods near `publishLiveCaptionPipelineSnapshot`:
+
+```swift
+private func cancelPendingLiveCaptionSnapshotPublication() {
+    pendingLiveCaptionSnapshotGeneration += 1
+    pendingLiveCaptionSnapshotTask?.cancel()
+    pendingLiveCaptionSnapshotTask = nil
+    pendingLiveCaptionSnapshot = nil
+}
+
+private func publishLiveCaptionPipelineSnapshotImmediately(_ snapshot: LiveCaptionPipelineSnapshot) {
+    liveCaptionTurns = snapshot.turns
+    meetingProgressHealth.caption = snapshot.captionHealth
+    meetingProgressHealth.translation = snapshot.translationHealth
+}
+```
+
+- [ ] **Step 2: Add delayability predicate**
+
+Add:
+
+```swift
+private func shouldDebounceLiveCaptionSnapshot(_ snapshot: LiveCaptionPipelineSnapshot) -> Bool {
+    guard liveCaptionSnapshotDebounceNanoseconds > 0 else { return false }
+    guard snapshot.captionHealth == .live, snapshot.translationHealth != .failed else { return false }
+    guard !snapshot.turns.isEmpty else { return false }
+    let previousTurns = pendingLiveCaptionSnapshot?.turns ?? liveCaptionTurns
+    guard !previousTurns.isEmpty else {
+        return snapshot.turns.allSatisfy(isDelayableDraftCaptionTurn)
+    }
+    let previousTurnsByID = Dictionary(uniqueKeysWithValues: previousTurns.map { ($0.id, $0) })
+    let snapshotTurnsByID = Dictionary(uniqueKeysWithValues: snapshot.turns.map { ($0.id, $0) })
+    let changedSnapshotTurns = snapshot.turns.filter { previousTurnsByID[$0.id] != $0 }
+    let removedPreviousTurns = previousTurns.filter { snapshotTurnsByID[$0.id] == nil }
+    guard !changedSnapshotTurns.isEmpty || !removedPreviousTurns.isEmpty else {
+        return false
+    }
+    return changedSnapshotTurns.allSatisfy(isDelayableDraftCaptionTurn)
+        && removedPreviousTurns.allSatisfy(isDelayableDraftCaptionTurn)
+}
+
+private func isDelayableDraftCaptionTurn(_ turn: LiveCaptionTurn) -> Bool {
+    turn.displayState == .draft && !turn.isFinal && turn.boundaryStrength != .hard
+}
+```
+
+If `translationHealth` is not Equatable-friendly for `.failed`, use a `switch` over `snapshot.translationHealth`.
+
+- [ ] **Step 3: Replace publication method**
+
+Replace `publishLiveCaptionPipelineSnapshot` with:
+
+```swift
+private func publishLiveCaptionPipelineSnapshot(_ snapshot: LiveCaptionPipelineSnapshot) {
+    guard shouldDebounceLiveCaptionSnapshot(snapshot) else {
+        cancelPendingLiveCaptionSnapshotPublication()
+        publishLiveCaptionPipelineSnapshotImmediately(snapshot)
+        return
+    }
+
+    if let pendingLiveCaptionSnapshot {
+        currentPerformanceEventLogger()?.log(
+            "caption_snapshot_publication_coalesced",
+            metadata: [
+                "pendingTurnCount": String(pendingLiveCaptionSnapshot.turns.count),
+                "replacementTurnCount": String(snapshot.turns.count),
+                "debounceMilliseconds": String(liveCaptionSnapshotDebounceNanoseconds / 1_000_000)
+            ]
+        )
+    }
+    pendingLiveCaptionSnapshot = snapshot
+    pendingLiveCaptionSnapshotGeneration += 1
+    let generation = pendingLiveCaptionSnapshotGeneration
+    pendingLiveCaptionSnapshotTask?.cancel()
+    pendingLiveCaptionSnapshotTask = Task { [weak self] in
+        try? await Task.sleep(nanoseconds: self?.liveCaptionSnapshotDebounceNanoseconds ?? 0)
+        await self?.publishPendingLiveCaptionSnapshot(generation: generation)
+    }
+}
+
+private func publishPendingLiveCaptionSnapshot(generation: Int) {
+    guard generation == pendingLiveCaptionSnapshotGeneration,
+          let snapshot = pendingLiveCaptionSnapshot
+    else {
+        return
+    }
+    pendingLiveCaptionSnapshotTask = nil
+    pendingLiveCaptionSnapshot = nil
+    publishLiveCaptionPipelineSnapshotImmediately(snapshot)
+}
+```
+
+- [ ] **Step 4: Cancel pending snapshots on resets**
+
+Call `cancelPendingLiveCaptionSnapshotPublication()` before direct `liveCaptionTurns = []` assignments in reset and no-document paths.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests/testDraftCaptionSnapshotsAreDebouncedBeforePublication
+swift test --filter MeetingAgentViewModelTests/testFinalCaptionSnapshotPublishesImmediatelyAndCancelsPendingDraft
+swift test --filter MeetingAgentViewModelTests/testSelectingAnotherMeetingCancelsPendingDraftCaptionSnapshot
+swift test --filter MeetingAgentViewModelTests/testCoalescedDraftCaptionSnapshotsLogPerformanceEvent
+```
+
+Expected: all pass.
+
+### Task 4: Preserve Stop Flush and Existing Behaviors
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` if focused tests reveal an issue
+
+- [ ] **Step 1: Run existing stop flush test**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests/testStopRecordingPublishesDelayedFlushedFinalTranslation
+```
+
+Expected: PASS because `flushLiveCaptionPipeline` produces frozen/final snapshots that bypass debounce.
+
+- [ ] **Step 2: Run existing active caption tests**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests/testActiveRecordingCaptionDoesNotRequireTranscriptFileReload
+swift test --filter MeetingAgentViewModelTests/testActiveTranscriptUpdatesAreAppliedThroughPipeline
+swift test --filter MeetingAgentViewModelTests/testStaleActiveTranscriptApplyDoesNotOverwriteNewerCaption
+```
+
+Expected: update tests only if they intentionally asserted immediate draft UI publication; keep data-pipeline behavior unchanged.
+
+### Task 5: Full Verification and Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+- Already added: `docs/superpowers/specs/2026-04-30-live-caption-snapshot-debounce-design.md`
+- Added: `docs/superpowers/plans/2026-04-30-live-caption-snapshot-debounce.md`
+
+- [ ] **Step 1: Run focused suite**
+
+Run:
+
+```bash
+swift test --filter MeetingAgentViewModelTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run required coverage gate**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/MeetingAgentViewModel.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift docs/superpowers/plans/2026-04-30-live-caption-snapshot-debounce.md
+git commit -m "feat: debounce live caption snapshot publication (#119)"
+```
+
+Expected: commit created.
+
+## Self-Review
+
+- Spec coverage: draft coalescing is Task 1 and Task 3; final/hard-boundary immediate publication is Task 1 and Task 3; reset cancellation is Task 1 and Task 3; stop flush is Task 4; metrics are Task 1 and Task 3.
+- Placeholder scan: no placeholder steps remain.
+- Type consistency: all new APIs are owned by `MeetingAgentViewModel`; tests use existing transcript accumulator and fixture patterns.

--- a/docs/superpowers/specs/2026-04-30-live-caption-snapshot-debounce-design.md
+++ b/docs/superpowers/specs/2026-04-30-live-caption-snapshot-debounce-design.md
@@ -1,0 +1,57 @@
+# Live Caption Snapshot Debounce Design
+
+## Context
+
+Issue #119 asks for display-level throttling for live caption snapshots. The caption pipeline can ingest Deepgram interim updates and draft translation refreshes at provider speed, but SwiftUI does not need every draft-only intermediate state to be published through `@Published liveCaptionTurns`.
+
+## Goals
+
+- Coalesce draft-only live caption snapshot publication before assigning `liveCaptionTurns`.
+- Publish final captions, hard boundaries, manual stop flushes, resets, and error-state changes immediately.
+- Keep pipeline ingestion, transcript persistence, translation scheduling, summaries, and meeting progress logic on the current immediate data path.
+- Record coalesced display updates through the existing performance event stream when a meeting performance log is available.
+- Cover draft coalescing, immediate final publication, stop flush publication, and cancellation/reset behavior in tests.
+
+## Non-Goals
+
+- Do not debounce `LiveCaptionPipeline` ingestion or structured transcript writes.
+- Do not delay summary, progress, or translation scheduler inputs.
+- Do not add user-facing settings for the debounce interval.
+- Do not change SwiftUI layout or caption rendering behavior.
+
+## Selected Approach
+
+Add a small presentation-layer coalescer inside `MeetingAgentViewModel`. Existing callers continue to produce `LiveCaptionPipelineSnapshot` immediately. `MeetingAgentViewModel` decides whether that snapshot can be delayed before publishing to `liveCaptionTurns`.
+
+A snapshot is delayable only when all changed visible caption turns are draft display state and no health/error transition requires immediate visibility. The view model stores the latest delayable snapshot and schedules one main-actor task for a short interval, using a default of 75ms. New delayable snapshots replace the pending one. Non-delayable snapshots cancel the pending task and publish immediately.
+
+This keeps the data pipeline immediate and isolates SwiftUI redraw throttling at the boundary where `@Published liveCaptionTurns` changes.
+
+## Publication Rules
+
+- Draft-only updates: debounce and publish only the latest pending snapshot after the interval.
+- Final captions and hard boundaries: publish immediately.
+- Manual stop flushes: publish immediately for the flush snapshot and for the final translation snapshot that follows.
+- Reset/cancel paths: cancel pending display snapshots and clear `liveCaptionTurns` immediately.
+- Health changes involving failure, idle, or recovery: publish immediately so visible status does not lag.
+
+## Metrics
+
+When a draft snapshot replaces another pending draft snapshot, log `caption_snapshot_publication_coalesced` through `PerformanceEventLogger` if the selected meeting has a performance event URL. Metadata includes:
+
+- `pendingTurnCount`
+- `replacementTurnCount`
+- `debounceMilliseconds`
+
+The event does not include raw transcript or translation text.
+
+## Tests
+
+Add focused `MeetingAgentViewModelTests` coverage:
+
+- Draft-only active transcript updates are coalesced before `liveCaptionTurns` changes.
+- A final or hard-boundary snapshot cancels pending draft publication and appears immediately.
+- `stopRecording()` still flushes and publishes final captions reliably.
+- Reset or meeting selection changes cancel pending draft snapshots so stale captions cannot appear later.
+
+Run focused tests with `swift test --filter MeetingAgentViewModelTests`, then run `make test` for the coverage gate.


### PR DESCRIPTION
## Summary

Fixes #119

- Debounces draft-only live caption UI snapshot publication in MeetingAgentViewModel.
- Publishes final, hard-boundary, reset, and stop-flush snapshots immediately.
- Logs coalesced draft UI publication events without transcript text.

## Changes

- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - adds pending snapshot debounce state and delta-based draft-only publication rules.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - covers draft coalescing, final immediate publish, final+draft delta coalescing, reset cancellation, and metrics.
- `docs/superpowers/specs/2026-04-30-live-caption-snapshot-debounce-design.md` - records the approved design.
- `docs/superpowers/plans/2026-04-30-live-caption-snapshot-debounce.md` - records the implementation plan.
- `docs/mistakes/2026-04-30T13-06-38Z.md` - records the review lesson.

## Test plan

- [x] Build/lint: `make test` passed
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests` passed
- [x] E2E/integration: skipped; behavior is covered at view-model/unit integration level and repo has no matching E2E convention for this macOS state path
- [x] Code review: PASS, with review fix committed
- [x] Manual verification: not applicable
