### PR TITLE
feat: improve interim caption stability

### DIFF
--- a/Sources/MeetingAgentCore/CaptionTurnAssembler.swift
+++ b/Sources/MeetingAgentCore/CaptionTurnAssembler.swift
@@ -102,6 +102,8 @@ public struct CaptionTurnAssembler: Equatable {
         var translationRevision = 1
         var translatedText: String?
         var translationHealth: LivePipelineHealth = .pending
+        var stableOriginalTextPrefix: String?
+        var unstableOriginalTextTail: String?
         if let previous {
             translationRevision = previous.translationRevision
             if previous.originalText != segment.text {
@@ -111,6 +113,9 @@ public struct CaptionTurnAssembler: Equatable {
             if previous.originalText == segment.text {
                 translationHealth = previous.translationHealth
             }
+            let stability = stableDisplayText(previous: previous, segment: segment)
+            stableOriginalTextPrefix = stability.prefix
+            unstableOriginalTextTail = stability.tail
         }
         return LiveCaptionTurn(
             id: previous?.id ?? segment.id,
@@ -118,6 +123,8 @@ public struct CaptionTurnAssembler: Equatable {
             sourceSegmentIDs: [segment.id],
             speaker: segment.speaker,
             originalText: segment.text,
+            stableOriginalTextPrefix: stableOriginalTextPrefix,
+            unstableOriginalTextTail: unstableOriginalTextTail,
             translatedText: translatedText,
             sourceLocale: segment.language ?? sourceLocale,
             targetLocale: targetLocale,
@@ -133,5 +140,43 @@ public struct CaptionTurnAssembler: Equatable {
             boundaryReason: nil,
             boundaryStrength: nil
         )
+    }
+
+    private func stableDisplayText(
+        previous: LiveCaptionTurn,
+        segment: TranscriptSegment
+    ) -> (prefix: String, tail: String) {
+        guard previous.speaker == segment.speaker else {
+            return ("", segment.text)
+        }
+        let prefix = stablePrefix(previous.originalText, segment.text)
+        let tail = String(segment.text.dropFirst(prefix.count))
+        return (prefix, tail)
+    }
+
+    private func stablePrefix(_ previous: String, _ current: String) -> String {
+        guard !previous.isEmpty, !current.isEmpty else { return "" }
+        let previousCharacters = Array(previous)
+        let currentCharacters = Array(current)
+        var index = 0
+        while index < previousCharacters.count,
+              index < currentCharacters.count,
+              previousCharacters[index] == currentCharacters[index] {
+            index += 1
+        }
+        let rawPrefix = String(currentCharacters.prefix(index))
+        if index == currentCharacters.count || index == previousCharacters.count {
+            return rawPrefix
+        }
+        return rawPrefix.trimmingToLastWordBoundary()
+    }
+}
+
+private extension String {
+    func trimmingToLastWordBoundary() -> String {
+        guard let boundary = lastIndex(where: { $0.isWhitespace || $0.isPunctuation }) else {
+            return ""
+        }
+        return String(self[...boundary])
     }
 }

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -145,6 +145,8 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
     public var sourceSegmentIDs: [String]
     public var speaker: TranscriptSpeaker
     public var originalText: String
+    public var stableOriginalTextPrefix: String
+    public var unstableOriginalTextTail: String
     public var translatedText: String?
     public var sourceLocale: String
     public var targetLocale: String
@@ -166,6 +168,8 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
         sourceSegmentIDs: [String]? = nil,
         speaker: TranscriptSpeaker = .default,
         originalText: String,
+        stableOriginalTextPrefix: String? = nil,
+        unstableOriginalTextTail: String? = nil,
         translatedText: String? = nil,
         sourceLocale: String = "en-US",
         targetLocale: String = "zh-CN",
@@ -189,6 +193,14 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
         self.sourceSegmentIDs = sourceSegmentIDs ?? [sourceSegmentID]
         self.speaker = speaker
         self.originalText = originalText
+        let resolvedStablePrefix = stableOriginalTextPrefix ?? (isFinal ? originalText : "")
+        self.stableOriginalTextPrefix = resolvedStablePrefix
+        self.unstableOriginalTextTail = unstableOriginalTextTail ?? {
+            if isFinal {
+                return ""
+            }
+            return String(originalText.dropFirst(resolvedStablePrefix.count))
+        }()
         self.translatedText = translatedText
         self.sourceLocale = sourceLocale
         self.targetLocale = targetLocale
@@ -216,6 +228,8 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
         case sourceSegmentIDs
         case speaker
         case originalText
+        case stableOriginalTextPrefix
+        case unstableOriginalTextTail
         case translatedText
         case sourceLocale
         case targetLocale
@@ -239,10 +253,20 @@ public struct LiveCaptionTurn: Codable, Equatable, Identifiable {
         sourceSegmentIDs = try container.decodeIfPresent([String].self, forKey: .sourceSegmentIDs) ?? [sourceSegmentID]
         speaker = try container.decode(TranscriptSpeaker.self, forKey: .speaker)
         originalText = try container.decode(String.self, forKey: .originalText)
+        isFinal = try container.decode(Bool.self, forKey: .isFinal)
+        let decodedStablePrefix = try container.decodeIfPresent(String.self, forKey: .stableOriginalTextPrefix)
+        let resolvedStablePrefix = decodedStablePrefix ?? (isFinal ? originalText : "")
+        stableOriginalTextPrefix = resolvedStablePrefix
+        if let decodedUnstableTail = try container.decodeIfPresent(String.self, forKey: .unstableOriginalTextTail) {
+            unstableOriginalTextTail = decodedUnstableTail
+        } else if isFinal {
+            unstableOriginalTextTail = ""
+        } else {
+            unstableOriginalTextTail = String(originalText.dropFirst(resolvedStablePrefix.count))
+        }
         translatedText = try container.decodeIfPresent(String.self, forKey: .translatedText)
         sourceLocale = try container.decode(String.self, forKey: .sourceLocale)
         targetLocale = try container.decode(String.self, forKey: .targetLocale)
-        isFinal = try container.decode(Bool.self, forKey: .isFinal)
         captionHealth = try container.decode(LivePipelineHealth.self, forKey: .captionHealth)
         translationHealth = try container.decode(LivePipelineHealth.self, forKey: .translationHealth)
         createdAt = try container.decode(Date.self, forKey: .createdAt)
@@ -492,6 +516,7 @@ public struct LiveCaptionStore: Equatable {
             previous: previousSegment.text,
             replacement: segment.text
         )
+        updated.resetStableDisplayMetadata()
         updated.sourceLocale = turn.sourceLocale
         updated.targetLocale = turn.targetLocale
         updated.isFinal = turn.isFinal
@@ -541,6 +566,7 @@ public struct LiveCaptionStore: Equatable {
         merged.sourceLocale = turn.sourceLocale
         merged.targetLocale = turn.targetLocale
         merged.isFinal = turn.isFinal
+        merged.resetStableDisplayMetadata()
         merged.captionHealth = turn.captionHealth
         merged.translationHealth = .pending
         merged.displayState = turn.displayState
@@ -557,6 +583,7 @@ public struct LiveCaptionStore: Equatable {
         merged.sourceLocale = turn.sourceLocale
         merged.targetLocale = turn.targetLocale
         merged.isFinal = false
+        merged.resetStableDisplayMetadata()
         merged.captionHealth = turn.captionHealth
         merged.translationHealth = .pending
         merged.chunkState = .draft
@@ -765,6 +792,18 @@ public struct LiveCaptionStore: Equatable {
         self.sourceLocale = sourceLocale
         self.targetLocale = targetLocale
         turns.removeAll()
+    }
+}
+
+private extension LiveCaptionTurn {
+    mutating func resetStableDisplayMetadata() {
+        if isFinal {
+            stableOriginalTextPrefix = originalText
+            unstableOriginalTextTail = ""
+        } else {
+            stableOriginalTextPrefix = ""
+            unstableOriginalTextTail = originalText
+        }
     }
 }
 

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -516,10 +516,10 @@ public struct LiveCaptionStore: Equatable {
             previous: previousSegment.text,
             replacement: segment.text
         )
-        updated.resetStableDisplayMetadata()
         updated.sourceLocale = turn.sourceLocale
         updated.targetLocale = turn.targetLocale
         updated.isFinal = turn.isFinal
+        updated.resetStableDisplayMetadata()
         updated.captionHealth = turn.captionHealth
         updated.translationHealth = turn.translationHealth
         updated.chunkState = turn.chunkState

--- a/Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift
@@ -98,6 +98,116 @@ final class CaptionTurnAssemblerTests: XCTestCase {
         XCTAssertEqual(draft.displayState, .draft)
     }
 
+    func testInterimGrowthPreservesSharedStablePrefix() {
+        var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+        let id = "deepgram-transcribe-stream-0.0"
+        _ = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-0",
+            text: "We should",
+            isFinal: false,
+            speechFinal: false
+        ))
+
+        let events = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-0",
+            text: "We should decide",
+            isFinal: false,
+            speechFinal: false
+        ))
+
+        guard case .draftUpdated(let draft) = events.single else {
+            XCTFail("Expected same-ID interim to update draft")
+            return
+        }
+        XCTAssertEqual(draft.originalText, "We should decide")
+        XCTAssertEqual(draft.stableOriginalTextPrefix, "We should")
+        XCTAssertEqual(draft.unstableOriginalTextTail, " decide")
+    }
+
+    func testInterimCorrectionKeepsOnlyPrefixBeforeChangedWordStable() {
+        var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+        let id = "deepgram-transcribe-stream-0.0"
+        _ = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-0",
+            text: "We should decide",
+            isFinal: false,
+            speechFinal: false
+        ))
+
+        let events = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-0",
+            text: "We might decide",
+            isFinal: false,
+            speechFinal: false
+        ))
+
+        guard case .draftUpdated(let draft) = events.single else {
+            XCTFail("Expected same-ID interim to update draft")
+            return
+        }
+        XCTAssertEqual(draft.stableOriginalTextPrefix, "We ")
+        XCTAssertEqual(draft.unstableOriginalTextTail, "might decide")
+    }
+
+    func testFinalPromotionClearsMutableStableTail() {
+        var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+        let id = "deepgram-transcribe-stream-0.0"
+        _ = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-0",
+            text: "We should decide",
+            isFinal: false,
+            speechFinal: false
+        ))
+
+        let events = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-0",
+            text: "We should decide today.",
+            isFinal: true,
+            speechFinal: true
+        ))
+
+        guard case .sealed(let sealed) = events.last else {
+            XCTFail("Expected final segment to seal matching interim draft")
+            return
+        }
+        XCTAssertEqual(sealed.originalText, "We should decide today.")
+        XCTAssertEqual(sealed.stableOriginalTextPrefix, "We should decide today.")
+        XCTAssertEqual(sealed.unstableOriginalTextTail, "")
+    }
+
+    func testSpeakerChangeResetsStablePrefixForSameSegmentID() {
+        var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+        let id = "deepgram-transcribe-stream-0.0"
+        _ = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-0",
+            text: "We should decide",
+            isFinal: false,
+            speechFinal: false
+        ))
+
+        let events = assembler.apply(segment(
+            id: id,
+            speaker: "deepgram-speaker-1",
+            text: "We should decide now",
+            isFinal: false,
+            speechFinal: false
+        ))
+
+        guard case .draftUpdated(let draft) = events.single else {
+            XCTFail("Expected same-ID interim to update draft")
+            return
+        }
+        XCTAssertEqual(draft.stableOriginalTextPrefix, "")
+        XCTAssertEqual(draft.unstableOriginalTextTail, "We should decide now")
+    }
+
     func testFinalSegmentReplacesMatchingInterimDraft() {
         var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
         let id = "deepgram-transcribe-stream-0.0"

--- a/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
@@ -733,5 +733,7 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(updated.sourceSegmentIDs, ["final-1", "interim-1"])
         XCTAssertEqual(updated.displayState, .sealed)
         XCTAssertEqual(updated.boundaryStrength, .hard)
+        XCTAssertEqual(updated.stableOriginalTextPrefix, "select German and hear the customer")
+        XCTAssertEqual(updated.unstableOriginalTextTail, "")
     }
 }

--- a/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
@@ -179,6 +179,44 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(turn.chunkState, .frozen)
     }
 
+    func testLiveCaptionTurnDefaultsStableDisplayMetadata() {
+        let turn = LiveCaptionTurn(
+            sourceSegmentID: "segment-1",
+            originalText: "We should decide",
+            isFinal: false
+        )
+
+        XCTAssertEqual(turn.stableOriginalTextPrefix, "")
+        XCTAssertEqual(turn.unstableOriginalTextTail, "We should decide")
+    }
+
+    func testLiveCaptionTurnDecodesLegacyStableDisplayMetadataDefaults() throws {
+        let data = Data("""
+        {
+          "id": "segment-1",
+          "sourceSegmentID": "segment-1",
+          "sourceSegmentIDs": ["segment-1"],
+          "speaker": {},
+          "originalText": "Legacy draft",
+          "sourceLocale": "en-US",
+          "targetLocale": "zh-CN",
+          "isFinal": false,
+          "captionHealth": { "state": "live" },
+          "translationHealth": { "state": "pending" },
+          "createdAt": "2026-04-30T00:00:00Z",
+          "chunkState": "draft",
+          "translationRevision": 1,
+          "displayState": "draft",
+          "translationState": "draft"
+        }
+        """.utf8)
+
+        let turn = try JSONDecoder.meetingAgent.decode(LiveCaptionTurn.self, from: data)
+
+        XCTAssertEqual(turn.stableOriginalTextPrefix, "")
+        XCTAssertEqual(turn.unstableOriginalTextTail, "Legacy draft")
+    }
+
     func testSpeakerGroupsCombineConsecutiveSameSpeakerCaptionBlocks() {
         let speaker = TranscriptSpeaker(identifier: "speaker-1", label: "User A")
         let groups = LiveCaptionSpeakerGroup.groups(from: [
@@ -317,6 +355,8 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertTrue(merged.isFinal)
         XCTAssertEqual(merged.translationHealth, .pending)
         XCTAssertEqual(merged.createdAt, Date(timeIntervalSince1970: 100))
+        XCTAssertEqual(merged.stableOriginalTextPrefix, "我们先看一下 这个季度的目标")
+        XCTAssertEqual(merged.unstableOriginalTextTail, "")
     }
 
     func testAppendingFinalSegmentFromDifferentSpeakerCreatesNewTurn() {
@@ -367,6 +407,8 @@ final class LiveCaptionStoreTests: XCTestCase {
         XCTAssertEqual(updated.originalText, "So I just No. It works. It works very well.")
         XCTAssertFalse(updated.isFinal)
         XCTAssertEqual(updated.chunkState, .draft)
+        XCTAssertEqual(updated.stableOriginalTextPrefix, "")
+        XCTAssertEqual(updated.unstableOriginalTextTail, "So I just No. It works. It works very well.")
     }
 
     func testAppendingInterimContainingLatestTurnKeepsSingleCompleteText() {

--- a/docs/mistakes/2026-04-30T15-12-59Z.md
+++ b/docs/mistakes/2026-04-30T15-12-59Z.md
@@ -1,0 +1,13 @@
+# [121] Reset derived display metadata after state transitions
+
+**Date**: 2026-04-30
+**Category**: logic-error
+
+### What went wrong
+The first stable caption metadata implementation reset derived display fields before applying the incoming final/draft state in `replaceRepresentedSegment`, so a final replacement could keep draft-style stable metadata.
+
+### Correct approach
+When derived fields depend on multiple mutable properties, update all source properties first and then recompute the derived fields.
+
+### How to avoid
+For state-derived metadata, place reset/recompute calls after every source-of-truth state assignment they depend on.

--- a/docs/superpowers/plans/2026-04-30-stable-prefix-caption-rendering.md
+++ b/docs/superpowers/plans/2026-04-30-stable-prefix-caption-rendering.md
@@ -1,0 +1,436 @@
+# Stable Prefix Caption Rendering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add display-only stable-prefix metadata to live caption turns so repeated interim ASR revisions keep stable text anchored while preserving final provider text.
+
+**Architecture:** `LiveCaptionTurn` carries optional display metadata beside `originalText`. `CaptionTurnAssembler` computes that metadata only for repeated interim updates to the same open draft, and final or reset paths clear it. Persistence remains source-segment driven and does not use this display-only state.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, macOS 14.2+.
+
+---
+
+## File Structure
+
+- Modify `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`: add optional stable-prefix fields to `LiveCaptionTurn`, encode/decode them with legacy-safe defaults, and preserve/reset them in store update paths.
+- Modify `Sources/MeetingAgentCore/CaptionTurnAssembler.swift`: compute same-turn stable prefix/tail for draft updates and reset it on speaker changes or final/hard boundaries.
+- Modify `Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift`: add regression coverage for interim growth, interim correction, final promotion, and speaker reset.
+- Optionally modify `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`: add focused coverage only if store paths drop the new metadata unexpectedly.
+
+### Task 1: Add LiveCaptionTurn Display Metadata
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+
+- [ ] **Step 1: Write the failing legacy decode and initializer tests**
+
+Add these tests near existing `LiveCaptionTurn` Codable/default tests in `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`:
+
+```swift
+func testLiveCaptionTurnDefaultsStableDisplayMetadata() {
+    let turn = LiveCaptionTurn(
+        sourceSegmentID: "segment-1",
+        originalText: "We should decide",
+        isFinal: false
+    )
+
+    XCTAssertEqual(turn.stableOriginalTextPrefix, "")
+    XCTAssertEqual(turn.unstableOriginalTextTail, "We should decide")
+}
+
+func testLiveCaptionTurnDecodesLegacyStableDisplayMetadataDefaults() throws {
+    let data = Data("""
+    {
+      "id": "segment-1",
+      "sourceSegmentID": "segment-1",
+      "sourceSegmentIDs": ["segment-1"],
+      "speaker": {},
+      "originalText": "Legacy draft",
+      "sourceLocale": "en-US",
+      "targetLocale": "zh-CN",
+      "isFinal": false,
+      "captionHealth": { "state": "live" },
+      "translationHealth": { "state": "pending" },
+      "createdAt": "2026-04-30T00:00:00Z",
+      "chunkState": "draft",
+      "translationRevision": 1,
+      "displayState": "draft",
+      "translationState": "draft"
+    }
+    """.utf8)
+
+    let turn = try JSONDecoder.meetingAgent.decode(LiveCaptionTurn.self, from: data)
+
+    XCTAssertEqual(turn.stableOriginalTextPrefix, "")
+    XCTAssertEqual(turn.unstableOriginalTextTail, "Legacy draft")
+}
+```
+
+- [ ] **Step 2: Run focused tests to verify failure**
+
+Run:
+
+```bash
+swift test --filter LiveCaptionStoreTests/testLiveCaptionTurnDefaultsStableDisplayMetadata
+```
+
+Expected: compile failure because `stableOriginalTextPrefix` and `unstableOriginalTextTail` do not exist.
+
+- [ ] **Step 3: Implement metadata fields on LiveCaptionTurn**
+
+In `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`, add stored properties after `originalText`:
+
+```swift
+public var stableOriginalTextPrefix: String
+public var unstableOriginalTextTail: String
+```
+
+Update the initializer signature after `originalText`:
+
+```swift
+stableOriginalTextPrefix: String? = nil,
+unstableOriginalTextTail: String? = nil,
+```
+
+Inside the initializer after `self.originalText = originalText`, add:
+
+```swift
+let resolvedStablePrefix = stableOriginalTextPrefix ?? (isFinal ? originalText : "")
+self.stableOriginalTextPrefix = resolvedStablePrefix
+self.unstableOriginalTextTail = unstableOriginalTextTail ?? {
+    if isFinal {
+        return ""
+    }
+    return String(originalText.dropFirst(resolvedStablePrefix.count))
+}()
+```
+
+Update `CodingKeys`:
+
+```swift
+case stableOriginalTextPrefix
+case unstableOriginalTextTail
+```
+
+Update `init(from:)` after decoding `originalText`:
+
+```swift
+let decodedStablePrefix = try container.decodeIfPresent(String.self, forKey: .stableOriginalTextPrefix)
+stableOriginalTextPrefix = decodedStablePrefix ?? (isFinal ? originalText : "")
+unstableOriginalTextTail = try container.decodeIfPresent(String.self, forKey: .unstableOriginalTextTail) ?? {
+    if isFinal {
+        return ""
+    }
+    return String(originalText.dropFirst(stableOriginalTextPrefix.count))
+}()
+```
+
+If Swift complains that `isFinal` is used before initialization, decode `isFinal` before this block and keep field assignments ordered so every property is initialized once.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+swift test --filter LiveCaptionStoreTests/testLiveCaptionTurnDefaultsStableDisplayMetadata
+swift test --filter LiveCaptionStoreTests/testLiveCaptionTurnDecodesLegacyStableDisplayMetadataDefaults
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Commit Task 1**
+
+```bash
+git add Sources/MeetingAgentCore/LiveMeetingCockpit.swift Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+git commit -m "feat: add live caption stable display metadata"
+```
+
+### Task 2: Compute Stable Prefixes in CaptionTurnAssembler
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/CaptionTurnAssembler.swift`
+- Test: `Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift`
+
+- [ ] **Step 1: Write failing assembler tests**
+
+Add these tests after `testInterimUpdatesReplaceDraftForSameSegmentID`:
+
+```swift
+func testInterimGrowthPreservesSharedStablePrefix() {
+    var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+    let id = "deepgram-transcribe-stream-0.0"
+    _ = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-0",
+        text: "We should",
+        isFinal: false,
+        speechFinal: false
+    ))
+
+    let events = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-0",
+        text: "We should decide",
+        isFinal: false,
+        speechFinal: false
+    ))
+
+    guard case .draftUpdated(let draft) = events.single else {
+        XCTFail("Expected same-ID interim to update draft")
+        return
+    }
+    XCTAssertEqual(draft.originalText, "We should decide")
+    XCTAssertEqual(draft.stableOriginalTextPrefix, "We should")
+    XCTAssertEqual(draft.unstableOriginalTextTail, " decide")
+}
+
+func testInterimCorrectionKeepsOnlyPrefixBeforeChangedWordStable() {
+    var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+    let id = "deepgram-transcribe-stream-0.0"
+    _ = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-0",
+        text: "We should decide",
+        isFinal: false,
+        speechFinal: false
+    ))
+
+    let events = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-0",
+        text: "We might decide",
+        isFinal: false,
+        speechFinal: false
+    ))
+
+    guard case .draftUpdated(let draft) = events.single else {
+        XCTFail("Expected same-ID interim to update draft")
+        return
+    }
+    XCTAssertEqual(draft.stableOriginalTextPrefix, "We ")
+    XCTAssertEqual(draft.unstableOriginalTextTail, "might decide")
+}
+
+func testFinalPromotionClearsMutableStableTail() {
+    var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+    let id = "deepgram-transcribe-stream-0.0"
+    _ = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-0",
+        text: "We should decide",
+        isFinal: false,
+        speechFinal: false
+    ))
+
+    let events = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-0",
+        text: "We should decide today.",
+        isFinal: true,
+        speechFinal: true
+    ))
+
+    guard case .sealed(let sealed) = events.last else {
+        XCTFail("Expected final segment to seal matching interim draft")
+        return
+    }
+    XCTAssertEqual(sealed.originalText, "We should decide today.")
+    XCTAssertEqual(sealed.stableOriginalTextPrefix, "We should decide today.")
+    XCTAssertEqual(sealed.unstableOriginalTextTail, "")
+}
+
+func testSpeakerChangeResetsStablePrefixForSameSegmentID() {
+    var assembler = CaptionTurnAssembler(sourceLocale: "en-US", targetLocale: "zh-CN")
+    let id = "deepgram-transcribe-stream-0.0"
+    _ = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-0",
+        text: "We should decide",
+        isFinal: false,
+        speechFinal: false
+    ))
+
+    let events = assembler.apply(segment(
+        id: id,
+        speaker: "deepgram-speaker-1",
+        text: "We should decide now",
+        isFinal: false,
+        speechFinal: false
+    ))
+
+    guard case .draftUpdated(let draft) = events.single else {
+        XCTFail("Expected same-ID interim to update draft")
+        return
+    }
+    XCTAssertEqual(draft.stableOriginalTextPrefix, "")
+    XCTAssertEqual(draft.unstableOriginalTextTail, "We should decide now")
+}
+```
+
+- [ ] **Step 2: Run focused assembler tests to verify failure**
+
+Run:
+
+```bash
+swift test --filter CaptionTurnAssemblerTests/testInterimGrowthPreservesSharedStablePrefix
+```
+
+Expected: failure because the assembler still defaults updated draft stable metadata incorrectly.
+
+- [ ] **Step 3: Implement assembler stability calculation**
+
+In `Sources/MeetingAgentCore/CaptionTurnAssembler.swift`, update `draftTurn(for:)` so it computes display metadata before constructing `LiveCaptionTurn`:
+
+```swift
+var stableOriginalTextPrefix: String?
+var unstableOriginalTextTail: String?
+if let previous {
+    let stability = stableDisplayText(previous: previous, segment: segment)
+    stableOriginalTextPrefix = stability.prefix
+    unstableOriginalTextTail = stability.tail
+}
+```
+
+Pass the values into `LiveCaptionTurn` after `originalText: segment.text`:
+
+```swift
+stableOriginalTextPrefix: stableOriginalTextPrefix,
+unstableOriginalTextTail: unstableOriginalTextTail,
+```
+
+Add private helpers in `CaptionTurnAssembler`:
+
+```swift
+private func stableDisplayText(
+    previous: LiveCaptionTurn,
+    segment: TranscriptSegment
+) -> (prefix: String, tail: String) {
+    guard previous.speaker == segment.speaker else {
+        return ("", segment.text)
+    }
+    let prefix = stablePrefix(previous.originalText, segment.text)
+    let tail = String(segment.text.dropFirst(prefix.count))
+    return (prefix, tail)
+}
+
+private func stablePrefix(_ previous: String, _ current: String) -> String {
+    guard !previous.isEmpty, !current.isEmpty else { return "" }
+    let previousCharacters = Array(previous)
+    let currentCharacters = Array(current)
+    var index = 0
+    while index < previousCharacters.count,
+          index < currentCharacters.count,
+          previousCharacters[index] == currentCharacters[index] {
+        index += 1
+    }
+    let rawPrefix = String(currentCharacters.prefix(index))
+    if index == currentCharacters.count {
+        return rawPrefix
+    }
+    if index == previousCharacters.count {
+        return rawPrefix
+    }
+    return rawPrefix.trimmingToLastWordBoundary()
+}
+```
+
+Add a private `String` extension at the bottom of the file:
+
+```swift
+private extension String {
+    func trimmingToLastWordBoundary() -> String {
+        guard let boundary = lastIndex(where: { $0.isWhitespace || $0.isPunctuation }) else {
+            return ""
+        }
+        return String(self[...boundary])
+    }
+}
+```
+
+- [ ] **Step 4: Run focused assembler tests**
+
+Run:
+
+```bash
+swift test --filter CaptionTurnAssemblerTests
+```
+
+Expected: all `CaptionTurnAssemblerTests` pass.
+
+- [ ] **Step 5: Commit Task 2**
+
+```bash
+git add Sources/MeetingAgentCore/CaptionTurnAssembler.swift Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift
+git commit -m "feat: compute stable prefixes for interim captions"
+```
+
+### Task 3: Verify Store Preservation and Full Suite
+
+**Files:**
+- Modify if needed: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Modify if needed: `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift`
+
+- [ ] **Step 1: Search store update paths for metadata loss**
+
+Run:
+
+```bash
+rg -n "LiveCaptionTurn\\(|originalText =|turns\\[index\\] =|merged" Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+```
+
+Expected: identify every path that creates or rewrites a `LiveCaptionTurn`.
+
+- [ ] **Step 2: Add preservation tests only if a path drops metadata**
+
+If `upsert(_:)`, `replaceRepresentedSegment`, `mergedProvisionalTurn`, or `rebuiltTurn` loses display metadata for a same-turn update, add a focused test like:
+
+```swift
+func testUpsertPreservesStableDisplayMetadataFromTurn() {
+    var store = LiveCaptionStore(sourceLocale: "en-US", targetLocale: "zh-CN")
+    let draft = LiveCaptionTurn(
+        sourceSegmentID: "segment-1",
+        originalText: "We should decide",
+        stableOriginalTextPrefix: "We should",
+        unstableOriginalTextTail: " decide",
+        isFinal: false
+    )
+
+    let updated = store.upsert(draft)
+
+    XCTAssertEqual(updated.stableOriginalTextPrefix, "We should")
+    XCTAssertEqual(updated.unstableOriginalTextTail, " decide")
+    XCTAssertEqual(store.turns.first?.stableOriginalTextPrefix, "We should")
+}
+```
+
+- [ ] **Step 3: Run build**
+
+Run:
+
+```bash
+swift build --product MeetingAgentApp
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Run required test and coverage gate**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: all unit tests pass and coverage gate remains passing.
+
+- [ ] **Step 5: Commit verification fixes if any**
+
+If Step 2 required code or tests:
+
+```bash
+git add Sources/MeetingAgentCore/LiveMeetingCockpit.swift Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift
+git commit -m "test: cover stable caption metadata preservation"
+```
+
+If no changes were required, do not create an empty commit.

--- a/docs/superpowers/specs/2026-04-30-stable-prefix-caption-rendering-design.md
+++ b/docs/superpowers/specs/2026-04-30-stable-prefix-caption-rendering-design.md
@@ -1,0 +1,72 @@
+# Stable Prefix Caption Rendering Design
+
+## Context
+
+Deepgram interim transcription can revise text repeatedly before a final segment arrives. `CaptionTurnAssembler` already owns the boundary between provider transcript segments and live caption turns, so it is the right place to attach display-only stability metadata without changing persisted transcript source data.
+
+Issue #121 asks for stable-prefix rendering that keeps already-stable caption text visually anchored while allowing the unstable tail to change during interim updates.
+
+## Goals
+
+- Preserve `LiveCaptionTurn.originalText` as the complete provider text for every draft and final caption.
+- Track the stable prefix and unstable tail for repeated interim updates to the same open caption turn.
+- Let the UI render stable and unstable text differently later without changing transcript persistence.
+- Clear or freeze display-only unstable state when a final caption or hard boundary arrives.
+- Cover same-turn interim growth, interim correction, final promotion, and speaker or boundary reset behavior with unit tests.
+
+## Non-Goals
+
+- Do not split one provider interim into multiple persisted transcript segments.
+- Do not change source transcript persistence or exported transcript text.
+- Do not add a new user setting for caption stability in this issue.
+- Do not redesign the transcript UI beyond exposing enough model state for future styling.
+
+## Selected Approach
+
+Add display-only stable-prefix metadata to `LiveCaptionTurn`, then compute that metadata in `CaptionTurnAssembler` when the same open interim segment receives a new draft update.
+
+`originalText` remains the source of truth for the full caption text. New optional fields describe how the full text should be interpreted for display:
+
+- `stableOriginalTextPrefix`: the text prefix that is unchanged across successive interim updates.
+- `unstableOriginalTextTail`: the current remaining text after that stable prefix.
+
+For first-time interim segments, the stable prefix is empty and the unstable tail is the full interim text. For repeated updates to the same segment and speaker, the assembler computes a word-boundary-safe shared prefix between the previous and current interim text. For final captions, both display-only fields are normalized so the final visible caption remains identical to the provider final text and is not treated as a mutable draft tail.
+
+## Alternatives Considered
+
+### UI-only text diffing
+
+This keeps model changes smaller but puts speaker, segment, and boundary semantics in SwiftUI. The view does not have enough context to know when a stable prefix should reset.
+
+### Split stable and unstable text into separate caption turns
+
+This could make styling simple, but it would pollute transcript and translation semantics. It risks changing persistence, exports, same-speaker grouping, and translation scheduling for a display-only concern.
+
+### Assembler-owned display metadata
+
+This keeps provider text intact while making the display stability state testable at the pipeline boundary. It matches the existing `CaptionTurnAssembler` responsibility and the issue proposal.
+
+## Data Flow
+
+1. The ASR provider emits an interim `TranscriptSegment`.
+2. `CaptionTurnAssembler.apply(_:)` creates or updates an open draft turn.
+3. On same-segment draft updates, the assembler compares the previous draft text and current segment text.
+4. The shared word-boundary prefix becomes `stableOriginalTextPrefix`; the remaining current text becomes `unstableOriginalTextTail`.
+5. Final segments clear the matching open draft and flow through `LiveCaptionChunker`, preserving final provider text.
+6. `LiveCaptionStore` stores and updates the display metadata with the turn, but transcript persistence continues to use transcript segments and `originalText`.
+
+## Edge Cases
+
+- If the provider corrects an early word, only the prefix before the correction remains stable.
+- If the speaker changes for the same segment ID, stability resets because the display turn semantics changed.
+- If a final or hard boundary arrives, the final turn is sealed with provider final text and no mutable unstable tail.
+- Legacy decoded caption JSON should continue to work with empty stability metadata.
+- Same-speaker merge paths must not invent stable prefix metadata across separate source segments.
+
+## Test Plan
+
+- Add `CaptionTurnAssemblerTests` coverage for interim growth where `"We should"` becomes `"We should decide"` and the shared prefix remains stable.
+- Add interim correction coverage where `"We should decide"` becomes `"We might decide"` and only `"We "` remains stable.
+- Add final promotion coverage showing final text equals provider final text and unstable tail is cleared.
+- Add speaker reset coverage showing same segment ID with a new speaker does not inherit prior stability.
+- Run focused tests, then `make test` to satisfy the coverage gate.


### PR DESCRIPTION
## Summary

Fixes #121

- Add display-only stable prefix and unstable tail metadata to live caption turns.
- Compute same-turn interim shared prefixes in CaptionTurnAssembler while preserving provider final text.
- Reset derived display metadata across merge and represented-segment replacement paths.

## Changes

- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift` - adds stable caption display metadata and reset behavior.
- `Sources/MeetingAgentCore/CaptionTurnAssembler.swift` - computes stable prefix/tail for repeated interim updates.
- `Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift` - covers interim growth, correction, final promotion, and speaker reset.
- `Tests/MeetingAgentCoreTests/LiveCaptionStoreTests.swift` - covers metadata defaults and merge/replacement preservation.
- `docs/superpowers/specs/2026-04-30-stable-prefix-caption-rendering-design.md` - design record.
- `docs/superpowers/plans/2026-04-30-stable-prefix-caption-rendering.md` - implementation plan.
- `docs/mistakes/2026-04-30T15-12-59Z.md` - recorded review lesson.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `make test` passed, 583 tests, coverage line 97.21%, method 95.23%
- [x] E2E/integration: skipped; no E2E convention for model-level caption metadata behavior
- [x] Code review: PASS after fixing represented final replacement metadata ordering
- [x] Manual verification: not applicable