### PR TITLE
feat: tune readable caption boundaries

### DIFF
--- a/Sources/MeetingAgentCore/LiveCaptionChunker.swift
+++ b/Sources/MeetingAgentCore/LiveCaptionChunker.swift
@@ -4,15 +4,27 @@ public struct LiveCaptionChunkingPolicy: Equatable {
     public var maxCharacters: Int
     public var maxDurationSeconds: Double
     public var minPunctuationCharacters: Int
+    public var readableCharacterLimit: Int
+    public var shortFragmentCharacters: Int
+    public var maxMergeGapSeconds: Double
+    public var minSentenceBoundaryCharacters: Int
 
     public init(
         maxCharacters: Int = 240,
         maxDurationSeconds: Double = 10,
-        minPunctuationCharacters: Int = 80
+        minPunctuationCharacters: Int = 80,
+        readableCharacterLimit: Int = 140,
+        shortFragmentCharacters: Int = 24,
+        maxMergeGapSeconds: Double = 1.25,
+        minSentenceBoundaryCharacters: Int = 36
     ) {
         self.maxCharacters = maxCharacters
         self.maxDurationSeconds = maxDurationSeconds
         self.minPunctuationCharacters = minPunctuationCharacters
+        self.readableCharacterLimit = readableCharacterLimit
+        self.shortFragmentCharacters = shortFragmentCharacters
+        self.maxMergeGapSeconds = maxMergeGapSeconds
+        self.minSentenceBoundaryCharacters = minSentenceBoundaryCharacters
     }
 }
 
@@ -117,10 +129,12 @@ public struct LiveCaptionChunker: Equatable {
                 return OpenChunk(
                     turn: draft,
                     startTimeSeconds: startTimeSeconds,
-                    endTimeSeconds: endTimeSeconds
+                    endTimeSeconds: endTimeSeconds,
+                    previousEndTimeSeconds: openChunk.previousEndTimeSeconds
                 )
             }
 
+            let previousEndTimeSeconds = openChunk.endTimeSeconds
             let draft = LiveCaptionTurn(
                 id: openChunk.turn.id,
                 sourceSegmentID: segment.id,
@@ -145,7 +159,8 @@ public struct LiveCaptionChunker: Equatable {
             return OpenChunk(
                 turn: draft,
                 startTimeSeconds: [openChunk.startTimeSeconds, segment.startTimeSeconds].compactMap { $0 }.min(),
-                endTimeSeconds: [openChunk.endTimeSeconds, segment.endTimeSeconds].compactMap { $0 }.max()
+                endTimeSeconds: [openChunk.endTimeSeconds, segment.endTimeSeconds].compactMap { $0 }.max(),
+                previousEndTimeSeconds: previousEndTimeSeconds
             )
         }
 
@@ -170,7 +185,8 @@ public struct LiveCaptionChunker: Equatable {
         return OpenChunk(
             turn: draft,
             startTimeSeconds: segment.startTimeSeconds,
-            endTimeSeconds: segment.endTimeSeconds
+            endTimeSeconds: segment.endTimeSeconds,
+            previousEndTimeSeconds: nil
         )
     }
 
@@ -178,12 +194,17 @@ public struct LiveCaptionChunker: Equatable {
         if latestSegment.speechFinal { return .speechFinal }
         if chunk.turn.originalText.count >= policy.maxCharacters { return .maxLength }
         if durationSeconds(for: chunk) >= policy.maxDurationSeconds,
-           hasStrongPunctuation(chunk.turn.originalText) {
+           hasSentenceEndingPunctuation(chunk.turn.originalText) {
             return .maxDuration
         }
-        if chunk.turn.originalText.count >= policy.minPunctuationCharacters,
-           hasStrongPunctuation(chunk.turn.originalText) {
+        if chunk.turn.originalText.count >= sentenceBoundaryCharacterLimit(for: chunk.turn.originalText),
+           hasSentenceEndingPunctuation(chunk.turn.originalText),
+           !shouldKeepMergingShortFragment(chunk, latestSegment: latestSegment) {
             return .punctuation
+        }
+        if chunk.turn.originalText.count >= policy.readableCharacterLimit,
+           !shouldKeepMergingShortFragment(chunk, latestSegment: latestSegment) {
+            return .maxLength
         }
         return nil
     }
@@ -195,6 +216,37 @@ public struct LiveCaptionChunker: Equatable {
             return 0
         }
         return max(0, end - start)
+    }
+
+    private func shouldKeepMergingShortFragment(_ chunk: OpenChunk, latestSegment: TranscriptSegment) -> Bool {
+        guard chunk.turn.sourceSegmentIDs.count > 1 else { return false }
+        let latestText = latestSegment.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard latestText.count <= policy.shortFragmentCharacters else {
+            return false
+        }
+        guard let previousEnd = chunk.previousEndTimeSeconds,
+              let latestStart = latestSegment.startTimeSeconds
+        else {
+            return false
+        }
+        return max(0, latestStart - previousEnd) <= policy.maxMergeGapSeconds
+    }
+
+    private func sentenceBoundaryCharacterLimit(for text: String) -> Int {
+        let configuredLimit = min(policy.minPunctuationCharacters, policy.minSentenceBoundaryCharacters)
+        if containsCJKCharacter(text) {
+            return max(12, configuredLimit / 2)
+        }
+        return configuredLimit
+    }
+
+    private func containsCJKCharacter(_ text: String) -> Bool {
+        text.unicodeScalars.contains { scalar in
+            let value = Int(scalar.value)
+            return (0x4E00...0x9FFF).contains(value)
+                || (0x3040...0x30FF).contains(value)
+                || (0xAC00...0xD7AF).contains(value)
+        }
     }
 
     private func frozen(_ turn: LiveCaptionTurn, reason: LiveCaptionFreezeReason) -> LiveCaptionTurn {
@@ -230,7 +282,7 @@ public struct LiveCaptionChunker: Equatable {
         return "\(first) \(second)"
     }
 
-    private func hasStrongPunctuation(_ text: String) -> Bool {
+    private func hasSentenceEndingPunctuation(_ text: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         for marker in [".", "!", "?", "。", "！", "？"] where trimmed.contains(marker) {
             return true
@@ -242,5 +294,6 @@ public struct LiveCaptionChunker: Equatable {
         var turn: LiveCaptionTurn
         var startTimeSeconds: Double?
         var endTimeSeconds: Double?
+        var previousEndTimeSeconds: Double?
     }
 }

--- a/Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift
@@ -49,6 +49,27 @@ final class CaptionTurnAssemblerTests: XCTestCase {
         XCTAssertEqual(sealed.originalText, "First part second part.")
     }
 
+    func testAssemblerUsesReadableChunkingPolicyForSoftSentenceBoundary() {
+        var assembler = CaptionTurnAssembler(
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            policy: LiveCaptionChunkingPolicy(minSentenceBoundaryCharacters: 18)
+        )
+
+        let events = assembler.apply(segment(
+            id: "segment-1",
+            text: "That sounds very good.",
+            speechFinal: false
+        ))
+
+        guard case .sealed(let sealed) = events.last else {
+            XCTFail("Expected readable sentence punctuation to seal a soft boundary")
+            return
+        }
+        XCTAssertEqual(sealed.boundaryReason, .punctuation)
+        XCTAssertEqual(sealed.boundaryStrength, .soft)
+    }
+
     func testInterimSegmentProducesInterimEvent() {
         var assembler = CaptionTurnAssembler(sourceLocale: "ja-JP", targetLocale: "en-US")
 

--- a/Tests/MeetingAgentCoreTests/LiveCaptionChunkerTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionChunkerTests.swift
@@ -29,6 +29,28 @@ final class LiveCaptionChunkerTests: XCTestCase {
         XCTAssertEqual(updates.first?.turn.freezeReason, .speakerChanged)
     }
 
+    func testSameSpeakerShortFragmentsMergeWhenTimingIsClose() {
+        var chunker = LiveCaptionChunker(
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            policy: LiveCaptionChunkingPolicy(
+                readableCharacterLimit: 80,
+                shortFragmentCharacters: 24,
+                maxMergeGapSeconds: 1.25,
+                minSentenceBoundaryCharacters: 30
+            )
+        )
+
+        _ = chunker.append(segment(id: "s1", text: "Let's align", start: 0, end: 0.7))
+        let updates = chunker.append(segment(id: "s2", text: "on the launch owner", start: 0.9, end: 1.8))
+
+        XCTAssertEqual(updates.single?.turn.originalText, "Let's align on the launch owner")
+        XCTAssertEqual(updates.single?.turn.sourceSegmentIDs, ["s1", "s2"])
+        XCTAssertEqual(updates.single?.turn.displayState, .draft)
+        XCTAssertNil(updates.single?.turn.boundaryReason)
+        XCTAssertNil(updates.single?.turn.boundaryStrength)
+    }
+
     func testMaxLengthFreezesLongDraft() {
         var chunker = LiveCaptionChunker(
             sourceLocale: "en-US",
@@ -40,6 +62,27 @@ final class LiveCaptionChunkerTests: XCTestCase {
 
         XCTAssertEqual(updates.last?.turn.chunkState, .frozen)
         XCTAssertEqual(updates.last?.turn.freezeReason, .maxLength)
+    }
+
+    func testReadableCharacterLimitFreezesBeforeHardMaximum() {
+        var chunker = LiveCaptionChunker(
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            policy: LiveCaptionChunkingPolicy(
+                maxCharacters: 120,
+                readableCharacterLimit: 48,
+                minSentenceBoundaryCharacters: 80
+            )
+        )
+
+        let updates = chunker.append(segment(
+            id: "s1",
+            text: "This caption is already long enough to become difficult to scan"
+        ))
+
+        XCTAssertEqual(updates.last?.turn.displayState, .sealed)
+        XCTAssertEqual(updates.last?.turn.boundaryReason, .maxLength)
+        XCTAssertEqual(updates.last?.turn.boundaryStrength, .soft)
     }
 
     func testMaxDurationDoesNotFreezeMidSentenceDraft() {
@@ -67,10 +110,39 @@ final class LiveCaptionChunkerTests: XCTestCase {
             policy: LiveCaptionChunkingPolicy(minPunctuationCharacters: 10)
         )
 
-        let updates = chunker.append(segment(id: "s1", text: "That sounds good."))
+        let updates = chunker.append(segment(id: "s1", text: "That sounds very good."))
 
         XCTAssertEqual(updates.last?.turn.chunkState, .frozen)
         XCTAssertEqual(updates.last?.turn.freezeReason, .punctuation)
+    }
+
+    func testTerminalSentencePunctuationCreatesSoftBoundaryAtReadableLength() {
+        var chunker = LiveCaptionChunker(
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            policy: LiveCaptionChunkingPolicy(minSentenceBoundaryCharacters: 18)
+        )
+
+        let updates = chunker.append(segment(id: "s1", text: "That sounds very good."))
+
+        XCTAssertEqual(updates.last?.turn.displayState, .sealed)
+        XCTAssertEqual(updates.last?.turn.boundaryReason, .punctuation)
+        XCTAssertEqual(updates.last?.turn.boundaryStrength, .soft)
+        XCTAssertEqual(updates.last?.turn.translationState, .draft)
+    }
+
+    func testInlinePunctuationDoesNotCreateSentenceBoundary() {
+        var chunker = LiveCaptionChunker(
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            policy: LiveCaptionChunkingPolicy(minSentenceBoundaryCharacters: 10)
+        )
+
+        let updates = chunker.append(segment(id: "s1", text: "Yes, we can continue with rollout planning"))
+
+        XCTAssertEqual(updates.single?.turn.displayState, .draft)
+        XCTAssertNil(updates.single?.turn.boundaryReason)
+        XCTAssertNil(updates.single?.turn.boundaryStrength)
     }
 
     func testSoftPunctuationBoundarySealsDisplayButKeepsDraftTranslation() {

--- a/docs/mistakes/2026-05-01T02-41-03Z.md
+++ b/docs/mistakes/2026-05-01T02-41-03Z.md
@@ -1,0 +1,13 @@
+# [122] Preserve internal sentence boundaries when tuning caption chunking
+
+**Date**: 2026-05-01
+**Category**: logic-error
+
+### What went wrong
+The first readable-boundary implementation narrowed sentence punctuation detection to only terminal punctuation, which broke existing Deepgram behavior where one provider segment can contain a complete sentence followed by more same-speaker text.
+
+### Correct approach
+Treat sentence-ending punctuation markers inside a sufficiently readable provider chunk as a soft boundary, while still excluding non-sentence inline punctuation such as commas.
+
+### How to avoid
+When tightening punctuation heuristics, check existing provider-shape tests for complete sentences embedded inside one ASR segment.

--- a/docs/superpowers/plans/2026-05-01-readable-caption-boundaries.md
+++ b/docs/superpowers/plans/2026-05-01-readable-caption-boundaries.md
@@ -1,0 +1,306 @@
+# Readable Caption Boundaries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tune live caption boundary heuristics so bilingual subtitle turns merge short same-speaker fragments, split at natural sentence endings, and remain observable through boundary reason and strength.
+
+**Architecture:** Keep the behavior inside `LiveCaptionChunker`, because it already owns open chunk state, speaker changes, timing, and freeze metadata. Extend `LiveCaptionChunkingPolicy` with readable-boundary controls while preserving existing initializer compatibility and public behavior. Cover the behavior through `LiveCaptionChunkerTests` and a focused assembler test.
+
+**Tech Stack:** Swift 5.9, Swift Package Manager, XCTest, existing `MeetingAgentCore` model types.
+
+---
+
+### Task 1: Add Regression Tests For Readable Boundaries
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/LiveCaptionChunkerTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift`
+
+- [ ] **Step 1: Add short-fragment merge and punctuation-boundary tests**
+
+Insert these tests in `LiveCaptionChunkerTests` near the existing punctuation and speaker-change tests:
+
+```swift
+func testSameSpeakerShortFragmentsMergeWhenTimingIsClose() {
+    var chunker = LiveCaptionChunker(
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        policy: LiveCaptionChunkingPolicy(
+            readableCharacterLimit: 80,
+            shortFragmentCharacters: 24,
+            maxMergeGapSeconds: 1.25,
+            minSentenceBoundaryCharacters: 30
+        )
+    )
+
+    _ = chunker.append(segment(id: "s1", text: "Let's align", start: 0, end: 0.7))
+    let updates = chunker.append(segment(id: "s2", text: "on the launch owner", start: 0.9, end: 1.8))
+
+    XCTAssertEqual(updates.single?.turn.originalText, "Let's align on the launch owner")
+    XCTAssertEqual(updates.single?.turn.sourceSegmentIDs, ["s1", "s2"])
+    XCTAssertEqual(updates.single?.turn.displayState, .draft)
+    XCTAssertNil(updates.single?.turn.boundaryReason)
+    XCTAssertNil(updates.single?.turn.boundaryStrength)
+}
+
+func testTerminalSentencePunctuationCreatesSoftBoundaryAtReadableLength() {
+    var chunker = LiveCaptionChunker(
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        policy: LiveCaptionChunkingPolicy(minSentenceBoundaryCharacters: 18)
+    )
+
+    let updates = chunker.append(segment(id: "s1", text: "That sounds good."))
+
+    XCTAssertEqual(updates.last?.turn.displayState, .sealed)
+    XCTAssertEqual(updates.last?.turn.boundaryReason, .punctuation)
+    XCTAssertEqual(updates.last?.turn.boundaryStrength, .soft)
+    XCTAssertEqual(updates.last?.turn.translationState, .draft)
+}
+
+func testInlinePunctuationDoesNotCreateSentenceBoundary() {
+    var chunker = LiveCaptionChunker(
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        policy: LiveCaptionChunkingPolicy(minSentenceBoundaryCharacters: 10)
+    )
+
+    let updates = chunker.append(segment(id: "s1", text: "Yes, we can continue with rollout planning"))
+
+    XCTAssertEqual(updates.single?.turn.displayState, .draft)
+    XCTAssertNil(updates.single?.turn.boundaryReason)
+    XCTAssertNil(updates.single?.turn.boundaryStrength)
+}
+```
+
+- [ ] **Step 2: Add readable limit and assembler tests**
+
+Insert this test in `LiveCaptionChunkerTests` near `testMaxLengthFreezesLongDraft`:
+
+```swift
+func testReadableCharacterLimitFreezesBeforeHardMaximum() {
+    var chunker = LiveCaptionChunker(
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        policy: LiveCaptionChunkingPolicy(
+            maxCharacters: 120,
+            readableCharacterLimit: 48,
+            minSentenceBoundaryCharacters: 80
+        )
+    )
+
+    let updates = chunker.append(segment(
+        id: "s1",
+        text: "This caption is already long enough to become difficult to scan"
+    ))
+
+    XCTAssertEqual(updates.last?.turn.displayState, .sealed)
+    XCTAssertEqual(updates.last?.turn.boundaryReason, .maxLength)
+    XCTAssertEqual(updates.last?.turn.boundaryStrength, .soft)
+}
+```
+
+Insert this test in `CaptionTurnAssemblerTests` near `testSameSpeakerFinalSegmentsMergeUntilHardBoundary`:
+
+```swift
+func testAssemblerUsesReadableChunkingPolicyForSoftSentenceBoundary() {
+    var assembler = CaptionTurnAssembler(
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        policy: LiveCaptionChunkingPolicy(minSentenceBoundaryCharacters: 18)
+    )
+
+    let events = assembler.apply(segment(
+        id: "segment-1",
+        text: "That sounds good.",
+        speechFinal: false
+    ))
+
+    guard case .sealed(let sealed) = events.last else {
+        XCTFail("Expected readable sentence punctuation to seal a soft boundary")
+        return
+    }
+    XCTAssertEqual(sealed.boundaryReason, .punctuation)
+    XCTAssertEqual(sealed.boundaryStrength, .soft)
+}
+```
+
+- [ ] **Step 3: Run focused tests and confirm they fail**
+
+Run:
+
+```bash
+swift test --filter LiveCaptionChunkerTests
+swift test --filter CaptionTurnAssemblerTests
+```
+
+Expected before implementation: failures because `LiveCaptionChunkingPolicy` does not yet accept the new readable-boundary fields and punctuation still uses the old `minPunctuationCharacters` behavior.
+
+### Task 2: Implement Policy Fields And Boundary Heuristics
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveCaptionChunker.swift`
+
+- [ ] **Step 1: Extend `LiveCaptionChunkingPolicy`**
+
+Update the struct to include new stored properties and initializer parameters:
+
+```swift
+public struct LiveCaptionChunkingPolicy: Equatable {
+    public var maxCharacters: Int
+    public var maxDurationSeconds: Double
+    public var minPunctuationCharacters: Int
+    public var readableCharacterLimit: Int
+    public var shortFragmentCharacters: Int
+    public var maxMergeGapSeconds: Double
+    public var minSentenceBoundaryCharacters: Int
+
+    public init(
+        maxCharacters: Int = 240,
+        maxDurationSeconds: Double = 10,
+        minPunctuationCharacters: Int = 80,
+        readableCharacterLimit: Int = 140,
+        shortFragmentCharacters: Int = 24,
+        maxMergeGapSeconds: Double = 1.25,
+        minSentenceBoundaryCharacters: Int = 36
+    ) {
+        self.maxCharacters = maxCharacters
+        self.maxDurationSeconds = maxDurationSeconds
+        self.minPunctuationCharacters = minPunctuationCharacters
+        self.readableCharacterLimit = readableCharacterLimit
+        self.shortFragmentCharacters = shortFragmentCharacters
+        self.maxMergeGapSeconds = maxMergeGapSeconds
+        self.minSentenceBoundaryCharacters = minSentenceBoundaryCharacters
+    }
+}
+```
+
+- [ ] **Step 2: Replace punctuation and length checks**
+
+Update `freezeReason(for:latestSegment:)`:
+
+```swift
+private func freezeReason(for chunk: OpenChunk, latestSegment: TranscriptSegment) -> LiveCaptionFreezeReason? {
+    if latestSegment.speechFinal { return .speechFinal }
+    if chunk.turn.originalText.count >= policy.maxCharacters { return .maxLength }
+    if chunk.turn.originalText.count >= policy.readableCharacterLimit,
+       !shouldKeepMergingShortFragment(chunk, latestSegment: latestSegment) {
+        return .maxLength
+    }
+    if durationSeconds(for: chunk) >= policy.maxDurationSeconds,
+       hasSentenceEndingPunctuation(chunk.turn.originalText) {
+        return .maxDuration
+    }
+    if sentenceBoundaryCharacterLimit(for: chunk.turn.originalText) <= chunk.turn.originalText.count,
+       hasSentenceEndingPunctuation(chunk.turn.originalText),
+       !shouldKeepMergingShortFragment(chunk, latestSegment: latestSegment) {
+        return .punctuation
+    }
+    return nil
+}
+```
+
+- [ ] **Step 3: Add helper methods**
+
+Add helpers below `durationSeconds(for:)`:
+
+```swift
+private func shouldKeepMergingShortFragment(_ chunk: OpenChunk, latestSegment: TranscriptSegment) -> Bool {
+    guard chunk.turn.sourceSegmentIDs.count > 1 else { return false }
+    guard latestSegment.text.trimmingCharacters(in: .whitespacesAndNewlines).count <= policy.shortFragmentCharacters else {
+        return false
+    }
+    guard let previousEnd = chunk.previousEndTimeSeconds,
+          let latestStart = latestSegment.startTimeSeconds
+    else {
+        return true
+    }
+    return max(0, latestStart - previousEnd) <= policy.maxMergeGapSeconds
+}
+
+private func sentenceBoundaryCharacterLimit(for text: String) -> Int {
+    if containsCJKCharacter(text) {
+        return max(12, policy.minSentenceBoundaryCharacters / 2)
+    }
+    return policy.minSentenceBoundaryCharacters
+}
+
+private func containsCJKCharacter(_ text: String) -> Bool {
+    text.unicodeScalars.contains { scalar in
+        (0x4E00...0x9FFF).contains(Int(scalar.value))
+            || (0x3040...0x30FF).contains(Int(scalar.value))
+            || (0xAC00...0xD7AF).contains(Int(scalar.value))
+    }
+}
+
+private func hasSentenceEndingPunctuation(_ text: String) -> Bool {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    for marker in [".", "!", "?", "。", "！", "？"] where trimmed.contains(marker) {
+        return true
+    }
+    return false
+}
+```
+
+- [ ] **Step 4: Track previous end timing**
+
+Extend `OpenChunk`:
+
+```swift
+private struct OpenChunk: Equatable {
+    var turn: LiveCaptionTurn
+    var startTimeSeconds: Double?
+    var endTimeSeconds: Double?
+    var previousEndTimeSeconds: Double?
+}
+```
+
+When returning a merged chunk for a new segment, set `previousEndTimeSeconds: openChunk.endTimeSeconds`. For replacement of the same segment ID and for a brand-new chunk, keep `previousEndTimeSeconds` from the prior chunk or `nil` as appropriate.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+swift test --filter LiveCaptionChunkerTests
+swift test --filter CaptionTurnAssemblerTests
+```
+
+Expected: both pass.
+
+### Task 3: Full Verification And Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveCaptionChunker.swift`
+- Modify: `Tests/MeetingAgentCoreTests/LiveCaptionChunkerTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift`
+
+- [ ] **Step 1: Run required verification**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: all tests pass and coverage gate remains passing.
+
+- [ ] **Step 2: Inspect final diff**
+
+Run:
+
+```bash
+git diff
+git status --short
+```
+
+Expected: only the chunker, chunker tests, assembler tests, spec, and plan files are changed.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/LiveCaptionChunker.swift Tests/MeetingAgentCoreTests/LiveCaptionChunkerTests.swift Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift docs/superpowers/plans/2026-05-01-readable-caption-boundaries.md
+git commit -m "feat: tune readable caption boundaries (#122)"
+```

--- a/docs/superpowers/specs/2026-05-01-readable-caption-boundaries-design.md
+++ b/docs/superpowers/specs/2026-05-01-readable-caption-boundaries-design.md
@@ -1,0 +1,65 @@
+# Readable Caption Boundaries Design
+
+## Context
+
+Issue #122 asks for bilingual subtitle chunks that read naturally instead of mirroring raw ASR segment boundaries. The current caption assembly path already exposes boundary reason and strength through `LiveCaptionTurn`, and the core chunking behavior lives in `LiveCaptionChunker` with `CaptionTurnAssembler` adapting final provider segments into chunk updates.
+
+## Goals
+
+- Merge same-speaker short fragments into a readable caption turn when timing is close.
+- Always start a new turn on speaker change and mark the previous turn as a hard boundary.
+- Treat sentence-ending punctuation as a natural soft boundary once the caption is readable.
+- Freeze very long turns before they become hard to read.
+- Preserve provider speech-final boundaries as hard final boundaries.
+- Keep boundary reason and strength visible in the emitted `LiveCaptionTurn` values and covered by unit tests.
+
+## Non-Goals
+
+- No UI redesign for subtitle rendering.
+- No provider-specific parsing beyond existing `TranscriptSegment` fields.
+- No change to translation scheduling semantics except the boundary metadata already consumed by existing code.
+
+## Selected Approach
+
+Enhance `LiveCaptionChunkingPolicy` and `LiveCaptionChunker` directly. The existing chunker already owns open-caption state, speaker-change detection, timing windows, punctuation checks, and freeze reasons, so the smallest reliable change is to make those heuristics more expressive there.
+
+The chunker will keep hard boundaries for speaker changes and provider `speechFinal` segments. It will treat sentence-ending punctuation as a soft boundary when the caption has reached a readable minimum length. It will continue merging short same-speaker fragments while their timing gap is close and the combined text remains below the readable length limit. Long captions will freeze with `.maxLength`, preserving existing boundary observability.
+
+## Policy Shape
+
+`LiveCaptionChunkingPolicy` will retain existing fields for compatibility and add narrowly scoped controls:
+
+- `readableCharacterLimit`: preferred upper bound for a readable turn before soft length freezing.
+- `shortFragmentCharacters`: threshold under which a same-speaker fragment should prefer merging.
+- `maxMergeGapSeconds`: maximum timing gap for short-fragment merging when both segment timings are available.
+- `minSentenceBoundaryCharacters`: minimum length before terminal punctuation can seal a turn.
+
+The existing `maxCharacters`, `maxDurationSeconds`, and `minPunctuationCharacters` fields remain available. `maxCharacters` stays as the hard safety cap, while readable limits guide softer UX boundaries.
+
+## Boundary Rules
+
+1. If the next final segment has a different speaker, freeze the current open chunk with `.speakerChanged` and `.hard`.
+2. Append or replace the same segment ID as today so interim-to-final replacement remains stable.
+3. If the latest segment is `speechFinal`, freeze the merged turn with `.speechFinal` and `.hard`.
+4. If the merged turn reaches `maxCharacters`, freeze with `.maxLength`.
+5. If the merged turn exceeds the readable character limit, freeze with `.maxLength` after emitting the draft update.
+6. If the merged turn ends with sentence-ending punctuation and meets the sentence-boundary minimum, freeze with `.punctuation` and `.soft`.
+7. If duration exceeds `maxDurationSeconds` and the turn has terminal sentence punctuation, freeze with `.maxDuration`.
+8. Otherwise keep the turn open so nearby same-speaker fragments can merge.
+
+## Testing
+
+Unit tests will cover:
+
+- Same-speaker short fragments merge into one readable turn.
+- Speaker change always seals the previous turn with `.speakerChanged` and `.hard`.
+- Terminal sentence punctuation seals with `.punctuation` and `.soft`.
+- Punctuation inside the middle of text does not prematurely seal.
+- Very long turns freeze with `.maxLength` before becoming unreadable.
+- Provider `speechFinal` stays `.speechFinal` and `.hard`.
+
+Verification commands:
+
+- `swift test --filter LiveCaptionChunkerTests`
+- `swift test --filter CaptionTurnAssemblerTests`
+- `make test`

--- a/docs/superpowers/specs/2026-05-01-readable-caption-boundaries-design.md
+++ b/docs/superpowers/specs/2026-05-01-readable-caption-boundaries-design.md
@@ -23,7 +23,7 @@ Issue #122 asks for bilingual subtitle chunks that read naturally instead of mir
 
 Enhance `LiveCaptionChunkingPolicy` and `LiveCaptionChunker` directly. The existing chunker already owns open-caption state, speaker-change detection, timing windows, punctuation checks, and freeze reasons, so the smallest reliable change is to make those heuristics more expressive there.
 
-The chunker will keep hard boundaries for speaker changes and provider `speechFinal` segments. It will treat sentence-ending punctuation as a soft boundary when the caption has reached a readable minimum length. It will continue merging short same-speaker fragments while their timing gap is close and the combined text remains below the readable length limit. Long captions will freeze with `.maxLength`, preserving existing boundary observability.
+The chunker will keep hard boundaries for speaker changes and provider `speechFinal` segments. It will treat sentence-ending punctuation as a soft boundary when the caption has reached a readable minimum length, including provider chunks that contain a complete sentence followed by more same-speaker text. It will continue merging short same-speaker fragments while their timing gap is close and the combined text remains below the readable length limit. Long captions will freeze with `.maxLength`, preserving existing boundary observability.
 
 ## Policy Shape
 
@@ -43,7 +43,7 @@ The existing `maxCharacters`, `maxDurationSeconds`, and `minPunctuationCharacter
 3. If the latest segment is `speechFinal`, freeze the merged turn with `.speechFinal` and `.hard`.
 4. If the merged turn reaches `maxCharacters`, freeze with `.maxLength`.
 5. If the merged turn exceeds the readable character limit, freeze with `.maxLength` after emitting the draft update.
-6. If the merged turn ends with sentence-ending punctuation and meets the sentence-boundary minimum, freeze with `.punctuation` and `.soft`.
+6. If the merged turn contains sentence-ending punctuation and meets the sentence-boundary minimum, freeze with `.punctuation` and `.soft`.
 7. If duration exceeds `maxDurationSeconds` and the turn has terminal sentence punctuation, freeze with `.maxDuration`.
 8. Otherwise keep the turn open so nearby same-speaker fragments can merge.
 


### PR DESCRIPTION
## Summary

Fixes #122

- Adds readable caption chunking policy controls for sentence boundaries, short-fragment merging, and readable length limits.
- Preserves hard boundaries for speaker changes and provider speech-final segments while keeping boundary reason/strength observable.
- Adds regression coverage for short fragment merging, sentence punctuation, readable length freezing, and assembler policy forwarding.

## Changes

- `Sources/MeetingAgentCore/LiveCaptionChunker.swift` - extends chunking policy and tunes freeze heuristics.
- `Tests/MeetingAgentCoreTests/LiveCaptionChunkerTests.swift` - covers readable boundary behavior and edge cases.
- `Tests/MeetingAgentCoreTests/CaptionTurnAssemblerTests.swift` - verifies assembler uses readable chunking policy.
- `docs/superpowers/specs/2026-05-01-readable-caption-boundaries-design.md` - records design.
- `docs/superpowers/plans/2026-05-01-readable-caption-boundaries.md` - records implementation plan.
- `docs/mistakes/2026-05-01T02-41-03Z.md` - records lesson from the implementation.

## Test plan

- [x] Build/lint: `swift test --filter LiveCaptionChunkerTests` passed
- [x] Unit tests: `swift test --filter CaptionTurnAssemblerTests` passed
- [x] Full verification: `make test` passed, 582 tests, coverage gate passed (line 97.09%, method 95.32%)
- [x] Code review: PASS after manual Swift review; project code-review skill is TypeScript/Java-only
- [x] Manual verification: Not applicable for core chunking heuristic change