### PR TITLE
feat: add transcript display modes

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -810,6 +810,7 @@ private struct TranscriptPaneView: View {
     @State private var speakerEditTarget: LiveCaptionTurn?
     @State private var speakerLabelDraft = ""
     @State private var autoFollowsLatest = true
+    @State private var transcriptDisplayMode: LiveCaptionDisplayMode = .both
 
     var body: some View {
         VStack(spacing: 0) {
@@ -819,12 +820,14 @@ private struct TranscriptPaneView: View {
                     VStack(alignment: .leading, spacing: 22) {
                         metadata
                         failureReason
+                        transcriptDisplayModePicker
                         UnifiedTranscriptView(
                             turns: liveCaptionTurns,
                             transcriptText: transcriptText,
                             isRecording: isRecording,
                             sourceLocale: sourceLocale,
                             targetLocale: targetLocale,
+                            displayMode: transcriptDisplayMode,
                             autoFollowsLatest: autoFollowsLatest,
                             returnToLatest: {
                                 returnToLatest(proxy: proxy)
@@ -872,6 +875,16 @@ private struct TranscriptPaneView: View {
         withAnimation(.easeOut(duration: 0.2)) {
             proxy.scrollTo(latestID, anchor: .bottom)
         }
+    }
+
+    private var transcriptDisplayModePicker: some View {
+        Picker("Transcript display", selection: $transcriptDisplayMode) {
+            Text("Both").tag(LiveCaptionDisplayMode.both)
+            Text("Original").tag(LiveCaptionDisplayMode.originalOnly)
+            Text("Translation").tag(LiveCaptionDisplayMode.translationOnly)
+        }
+        .pickerStyle(.segmented)
+        .frame(width: 260)
     }
 
     private var header: some View {
@@ -1221,6 +1234,7 @@ private struct UnifiedTranscriptView: View {
     let isRecording: Bool
     let sourceLocale: String
     let targetLocale: String
+    let displayMode: LiveCaptionDisplayMode
     let autoFollowsLatest: Bool
     let returnToLatest: () -> Void
     let pauseFollowing: () -> Void
@@ -1249,6 +1263,7 @@ private struct UnifiedTranscriptView: View {
                             group: group,
                             sourceLocale: sourceLocale,
                             targetLocale: targetLocale,
+                            displayMode: displayMode,
                             editSpeaker: group.speaker.identifier == nil ? nil : {
                                 if let firstTurn = group.turns.first {
                                     editSpeaker(firstTurn)
@@ -1292,6 +1307,7 @@ private struct BilingualTranscriptGroup: View {
     let group: LiveCaptionSpeakerGroup
     let sourceLocale: String
     let targetLocale: String
+    let displayMode: LiveCaptionDisplayMode
     var editSpeaker: (() -> Void)? = nil
 
     var body: some View {
@@ -1300,7 +1316,8 @@ private struct BilingualTranscriptGroup: View {
             ForEach(group.turns) { turn in
                 BilingualTranscriptBlock(
                     turn: turn,
-                    secondLanguageEnabled: secondLanguageEnabled(for: turn)
+                    secondLanguageEnabled: secondLanguageEnabled(for: turn),
+                    displayMode: displayMode
                 )
                 .id(turn.id)
             }
@@ -1363,6 +1380,7 @@ private struct BilingualTranscriptGroup: View {
 private struct BilingualTranscriptBlock: View {
     let turn: LiveCaptionTurn
     let secondLanguageEnabled: Bool
+    let displayMode: LiveCaptionDisplayMode
 
     var body: some View {
         transcriptText
@@ -1372,7 +1390,7 @@ private struct BilingualTranscriptBlock: View {
     @ViewBuilder
     private var transcriptText: some View {
         VStack(alignment: .leading, spacing: 7) {
-            switch LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: secondLanguageEnabled) {
+            switch LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: secondLanguageEnabled, displayMode: displayMode) {
             case .translated(let primaryText, let sourceText):
                 Text(sourceText)
                     .font(CommandCenterTypography.transcript)

--- a/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
+++ b/Sources/MeetingAgentCore/LiveMeetingCockpit.swift
@@ -318,6 +318,14 @@ public struct LiveCaptionSpeakerGroup: Equatable, Identifiable {
     }
 }
 
+public enum LiveCaptionDisplayMode: String, Codable, CaseIterable, Equatable, Identifiable {
+    case both
+    case originalOnly
+    case translationOnly
+
+    public var id: String { rawValue }
+}
+
 public enum LiveCaptionDisplayState: Equatable {
     case originalOnly(String)
     case translated(primaryText: String, sourceText: String)
@@ -325,23 +333,49 @@ public enum LiveCaptionDisplayState: Equatable {
     case failed(sourceText: String, message: String)
 
     public init(turn: LiveCaptionTurn, secondLanguageEnabled: Bool) {
+        self.init(turn: turn, secondLanguageEnabled: secondLanguageEnabled, displayMode: .both)
+    }
+
+    public init(
+        turn: LiveCaptionTurn,
+        secondLanguageEnabled: Bool,
+        displayMode: LiveCaptionDisplayMode
+    ) {
         let originalText = turn.originalText.trimmingCharacters(in: .whitespacesAndNewlines)
         let translatedText = turn.translatedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard secondLanguageEnabled else {
+        switch displayMode {
+        case .originalOnly:
             self = .originalOnly(originalText)
-            return
+        case .translationOnly:
+            if translatedText.isEmpty {
+                self = Self.translationFallbackState(originalText: originalText, health: turn.translationHealth)
+            } else {
+                self = .originalOnly(translatedText)
+            }
+        case .both:
+            guard secondLanguageEnabled else {
+                self = .originalOnly(originalText)
+                return
+            }
+            if !translatedText.isEmpty {
+                self = .translated(primaryText: translatedText, sourceText: originalText)
+                return
+            }
+            self = Self.translationFallbackState(originalText: originalText, health: turn.translationHealth)
         }
-        if !translatedText.isEmpty {
-            self = .translated(primaryText: translatedText, sourceText: originalText)
-            return
-        }
-        switch turn.translationHealth {
+    }
+
+    private static func translationFallbackState(
+        originalText: String,
+        health: LivePipelineHealth
+    ) -> LiveCaptionDisplayState {
+        switch health {
         case .failed(let message), .degraded(let message):
-            self = .failed(sourceText: originalText, message: message)
+            return .failed(sourceText: originalText, message: message)
         case .pending:
-            self = .pending(sourceText: originalText)
+            return .pending(sourceText: originalText)
         case .idle, .live:
-            self = .originalOnly(originalText)
+            return .originalOnly(originalText)
         }
     }
 

--- a/Tests/MeetingAgentCoreTests/LiveCaptionDisplayStateTests.swift
+++ b/Tests/MeetingAgentCoreTests/LiveCaptionDisplayStateTests.swift
@@ -18,6 +18,69 @@ final class LiveCaptionDisplayStateTests: XCTestCase {
         XCTAssertEqual(state, .translated(primaryText: "我们需要一位上线负责人。", sourceText: "We need a launch owner."))
     }
 
+    func testBothDisplayModeKeepsTranslatedState() {
+        let turn = LiveCaptionTurn(
+            sourceSegmentID: "segment-1",
+            originalText: "We need a launch owner.",
+            translatedText: "我们需要一位上线负责人。",
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            isFinal: true,
+            translationHealth: .live
+        )
+
+        let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .both)
+
+        XCTAssertEqual(state, .translated(primaryText: "我们需要一位上线负责人。", sourceText: "We need a launch owner."))
+    }
+
+    func testOriginalOnlyDisplayModeHidesTranslation() {
+        let turn = LiveCaptionTurn(
+            sourceSegmentID: "segment-1",
+            originalText: "We need a launch owner.",
+            translatedText: "我们需要一位上线负责人。",
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            isFinal: true,
+            translationHealth: .live
+        )
+
+        let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .originalOnly)
+
+        XCTAssertEqual(state, .originalOnly("We need a launch owner."))
+    }
+
+    func testTranslationOnlyDisplayModeUsesTranslatedTextAsSingleBlock() {
+        let turn = LiveCaptionTurn(
+            sourceSegmentID: "segment-1",
+            originalText: "We need a launch owner.",
+            translatedText: "我们需要一位上线负责人。",
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            isFinal: true,
+            translationHealth: .live
+        )
+
+        let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .translationOnly)
+
+        XCTAssertEqual(state, .originalOnly("我们需要一位上线负责人。"))
+    }
+
+    func testTranslationOnlyDisplayModeShowsPendingWhenTranslationIsMissing() {
+        let turn = LiveCaptionTurn(
+            sourceSegmentID: "segment-1",
+            originalText: "We need a launch owner.",
+            sourceLocale: "en-US",
+            targetLocale: "zh-CN",
+            isFinal: true,
+            translationHealth: .pending
+        )
+
+        let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .translationOnly)
+
+        XCTAssertEqual(state, .pending(sourceText: "We need a launch owner."))
+    }
+
     func testOriginalOnlyWhenSecondLanguageIsDisabled() {
         let turn = LiveCaptionTurn(
             sourceSegmentID: "segment-1",

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -598,6 +598,20 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(source.contains("Text(speakerStartTimeText)"))
     }
 
+    func testTranscriptPaneDefinesDisplayModePicker() throws {
+        let source = try appSource(named: "MainWindowView.swift")
+
+        XCTAssertTrue(source.contains("@State private var transcriptDisplayMode: LiveCaptionDisplayMode = .both"))
+        XCTAssertTrue(source.contains("Picker(\"Transcript display\", selection: $transcriptDisplayMode)"))
+        XCTAssertTrue(source.contains("Text(\"Both\").tag(LiveCaptionDisplayMode.both)"))
+        XCTAssertTrue(source.contains("Text(\"Original\").tag(LiveCaptionDisplayMode.originalOnly)"))
+        XCTAssertTrue(source.contains("Text(\"Translation\").tag(LiveCaptionDisplayMode.translationOnly)"))
+        XCTAssertTrue(source.contains(".pickerStyle(.segmented)"))
+        XCTAssertTrue(source.contains("displayMode: transcriptDisplayMode"))
+        XCTAssertTrue(source.contains("displayMode: displayMode"))
+        XCTAssertTrue(source.contains("LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: secondLanguageEnabled, displayMode: displayMode)"))
+    }
+
     func testMainWindowRemovesUnimplementedMeetingGoalComposer() throws {
         let sourceURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
             .appendingPathComponent("Sources/MeetingAgentApp/MainWindowView.swift")

--- a/docs/superpowers/plans/2026-05-01-transcript-display-mode.md
+++ b/docs/superpowers/plans/2026-05-01-transcript-display-mode.md
@@ -1,0 +1,269 @@
+# Transcript Display Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a workspace transcript display mode for Both, Original, and Translation, defaulting to Both.
+
+**Architecture:** Model the mode in core so display-state behavior is unit-testable, then thread it through the existing SwiftUI transcript view hierarchy. The option is local UI state in `TranscriptPaneView`; it does not affect transcription, translation scheduling, persistence, or exports.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest, Swift Package Manager, project `make test` coverage command.
+
+---
+
+### Task 1: Core Display State
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Test: `Tests/MeetingAgentCoreTests/LiveCaptionDisplayStateTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for the new display mode behavior:
+
+```swift
+func testBothDisplayModeKeepsTranslatedState() {
+    let turn = LiveCaptionTurn(
+        sourceSegmentID: "segment-1",
+        originalText: "We need a launch owner.",
+        translatedText: "我们需要一位上线负责人。",
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        isFinal: true,
+        translationHealth: .live
+    )
+
+    let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .both)
+
+    XCTAssertEqual(state, .translated(primaryText: "我们需要一位上线负责人。", sourceText: "We need a launch owner."))
+}
+
+func testOriginalOnlyDisplayModeHidesTranslation() {
+    let turn = LiveCaptionTurn(
+        sourceSegmentID: "segment-1",
+        originalText: "We need a launch owner.",
+        translatedText: "我们需要一位上线负责人。",
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        isFinal: true,
+        translationHealth: .live
+    )
+
+    let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .originalOnly)
+
+    XCTAssertEqual(state, .originalOnly("We need a launch owner."))
+}
+
+func testTranslationOnlyDisplayModeUsesTranslatedTextAsSingleBlock() {
+    let turn = LiveCaptionTurn(
+        sourceSegmentID: "segment-1",
+        originalText: "We need a launch owner.",
+        translatedText: "我们需要一位上线负责人。",
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        isFinal: true,
+        translationHealth: .live
+    )
+
+    let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .translationOnly)
+
+    XCTAssertEqual(state, .originalOnly("我们需要一位上线负责人。"))
+}
+
+func testTranslationOnlyDisplayModeShowsPendingWhenTranslationIsMissing() {
+    let turn = LiveCaptionTurn(
+        sourceSegmentID: "segment-1",
+        originalText: "We need a launch owner.",
+        sourceLocale: "en-US",
+        targetLocale: "zh-CN",
+        isFinal: true,
+        translationHealth: .pending
+    )
+
+    let state = LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: true, displayMode: .translationOnly)
+
+    XCTAssertEqual(state, .pending(sourceText: "We need a launch owner."))
+}
+```
+
+- [ ] **Step 2: Run focused test to verify failure**
+
+Run: `swift test --filter LiveCaptionDisplayStateTests`
+Expected: fail because `LiveCaptionDisplayMode` and the new initializer argument do not exist.
+
+- [ ] **Step 3: Implement core mode**
+
+Add this enum before `LiveCaptionDisplayState`:
+
+```swift
+public enum LiveCaptionDisplayMode: String, Codable, CaseIterable, Equatable, Identifiable {
+    case both
+    case originalOnly
+    case translationOnly
+
+    public var id: String { rawValue }
+}
+```
+
+Change `LiveCaptionDisplayState` to add a mode-aware initializer while keeping the existing initializer:
+
+```swift
+public init(turn: LiveCaptionTurn, secondLanguageEnabled: Bool) {
+    self.init(turn: turn, secondLanguageEnabled: secondLanguageEnabled, displayMode: .both)
+}
+
+public init(turn: LiveCaptionTurn, secondLanguageEnabled: Bool, displayMode: LiveCaptionDisplayMode) {
+    let originalText = turn.originalText.trimmingCharacters(in: .whitespacesAndNewlines)
+    let translatedText = turn.translatedText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    switch displayMode {
+    case .originalOnly:
+        self = .originalOnly(originalText)
+    case .translationOnly:
+        if !translatedText.isEmpty {
+            self = .originalOnly(translatedText)
+        } else {
+            self = Self.translationFallbackState(originalText: originalText, health: turn.translationHealth)
+        }
+    case .both:
+        guard secondLanguageEnabled else {
+            self = .originalOnly(originalText)
+            return
+        }
+        if !translatedText.isEmpty {
+            self = .translated(primaryText: translatedText, sourceText: originalText)
+            return
+        }
+        self = Self.translationFallbackState(originalText: originalText, health: turn.translationHealth)
+    }
+}
+```
+
+Add the helper:
+
+```swift
+private static func translationFallbackState(originalText: String, health: LivePipelineHealth) -> LiveCaptionDisplayState {
+    switch health {
+    case .failed(let message), .degraded(let message):
+        return .failed(sourceText: originalText, message: message)
+    case .pending:
+        return .pending(sourceText: originalText)
+    case .idle, .live:
+        return .originalOnly(originalText)
+    }
+}
+```
+
+- [ ] **Step 4: Run focused test to verify pass**
+
+Run: `swift test --filter LiveCaptionDisplayStateTests`
+Expected: pass.
+
+### Task 2: Workspace UI Control
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write source-layout test**
+
+Add a layout guard that checks the mode state, picker labels, and prop threading:
+
+```swift
+func testTranscriptPaneDefinesDisplayModePicker() throws {
+    let source = try appSource(named: "MainWindowView.swift")
+
+    XCTAssertTrue(source.contains("@State private var transcriptDisplayMode: LiveCaptionDisplayMode = .both"))
+    XCTAssertTrue(source.contains("Picker(\"Transcript display\", selection: $transcriptDisplayMode)"))
+    XCTAssertTrue(source.contains("Text(\"Both\").tag(LiveCaptionDisplayMode.both)"))
+    XCTAssertTrue(source.contains("Text(\"Original\").tag(LiveCaptionDisplayMode.originalOnly)"))
+    XCTAssertTrue(source.contains("Text(\"Translation\").tag(LiveCaptionDisplayMode.translationOnly)"))
+    XCTAssertTrue(source.contains(".pickerStyle(.segmented)"))
+    XCTAssertTrue(source.contains("displayMode: transcriptDisplayMode"))
+    XCTAssertTrue(source.contains("displayMode: displayMode"))
+    XCTAssertTrue(source.contains("LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: secondLanguageEnabled, displayMode: displayMode)"))
+}
+```
+
+- [ ] **Step 2: Run focused test to verify failure**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testTranscriptPaneDefinesDisplayModePicker`
+Expected: fail because the picker and display-mode props do not exist.
+
+- [ ] **Step 3: Add transcript pane state and picker**
+
+In `TranscriptPaneView`, add:
+
+```swift
+@State private var transcriptDisplayMode: LiveCaptionDisplayMode = .both
+```
+
+Pass `displayMode: transcriptDisplayMode` into `UnifiedTranscriptView`.
+
+In `UnifiedTranscriptView`, add `let displayMode: LiveCaptionDisplayMode`. Replace the header `HStack` with one that includes:
+
+```swift
+Picker("Transcript display", selection: $transcriptDisplayMode) {
+    Text("Both").tag(LiveCaptionDisplayMode.both)
+    Text("Original").tag(LiveCaptionDisplayMode.originalOnly)
+    Text("Translation").tag(LiveCaptionDisplayMode.translationOnly)
+}
+.pickerStyle(.segmented)
+.frame(width: 260)
+```
+
+The picker belongs in `TranscriptPaneView` because the state is owned there; pass the current value into `UnifiedTranscriptView`.
+
+- [ ] **Step 4: Thread mode into transcript blocks**
+
+Add `displayMode` properties to `UnifiedTranscriptView`, `BilingualTranscriptGroup`, and `BilingualTranscriptBlock`. Pass it through every initializer and update `BilingualTranscriptBlock` to call:
+
+```swift
+LiveCaptionDisplayState(turn: turn, secondLanguageEnabled: secondLanguageEnabled, displayMode: displayMode)
+```
+
+- [ ] **Step 5: Run focused layout test**
+
+Run: `swift test --filter MainWindowViewLayoutTests/testTranscriptPaneDefinesDisplayModePicker`
+Expected: pass.
+
+### Task 3: Verification and Commit
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/LiveMeetingCockpit.swift`
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/LiveCaptionDisplayStateTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+- Create: `docs/superpowers/specs/2026-05-01-transcript-display-mode-design.md`
+- Create: `docs/superpowers/plans/2026-05-01-transcript-display-mode.md`
+
+- [ ] **Step 1: Run focused tests**
+
+Run these serially:
+
+```bash
+swift test --filter LiveCaptionDisplayStateTests
+swift test --filter MainWindowViewLayoutTests/testTranscriptPaneDefinesDisplayModePicker
+```
+
+Expected: both pass.
+
+- [ ] **Step 2: Run required verification**
+
+Run: `make test`
+Expected: pass with coverage gate satisfied.
+
+- [ ] **Step 3: Commit implementation**
+
+Run:
+
+```bash
+git add Sources/MeetingAgentCore/LiveMeetingCockpit.swift Sources/MeetingAgentApp/MainWindowView.swift Tests/MeetingAgentCoreTests/LiveCaptionDisplayStateTests.swift Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift docs/superpowers/specs/2026-05-01-transcript-display-mode-design.md docs/superpowers/plans/2026-05-01-transcript-display-mode.md
+git commit -m "feat: add transcript display modes (#126)"
+```
+
+Expected: commit succeeds.
+
+## Self-Review
+
+- Spec coverage: The plan adds all three display modes, defaults to both, keeps behavior display-only, and adds tests.
+- Placeholder scan: No placeholder instructions remain.
+- Type consistency: `LiveCaptionDisplayMode`, `displayMode`, and `LiveCaptionDisplayState` initializer names are consistent across tasks.

--- a/docs/superpowers/specs/2026-05-01-transcript-display-mode-design.md
+++ b/docs/superpowers/specs/2026-05-01-transcript-display-mode-design.md
@@ -1,0 +1,51 @@
+# Transcript Display Mode Design
+
+## Context
+
+Issue #126 asks the transcript module to support original-language only, translation only, and both-language display modes, with both as the default. The current meeting workspace always renders live caption turns as source text plus translated text when a second language is available, and falls back to original text when no translation is available.
+
+## Goals
+
+- Add a transcript display control in the meeting workspace.
+- Support three modes: both languages, original only, and translation only.
+- Keep the default behavior as both languages.
+- Limit the change to display behavior. Transcription, translation scheduling, persistence, and exports stay unchanged.
+
+## Non-Goals
+
+- Do not add a global persisted setting.
+- Do not change the bilingual transcript file format.
+- Do not stop translation requests when the user temporarily hides translation text.
+- Do not change transcript export output.
+
+## Selected Approach
+
+Add a local transcript display mode state to the workspace transcript pane and pass it through the existing transcript view hierarchy. A small segmented picker in the Transcript header lets the user switch between Both, Original, and Translation. This keeps the option close to the affected content and avoids expanding application settings for a view-only preference.
+
+## Alternatives Considered
+
+### Settings-Level Preference
+
+Persisting the mode in settings would make the preference survive app relaunches, but it broadens the issue into configuration persistence and migration. The issue is about transcript module display, so this is unnecessary for the first version.
+
+### Reusing Second-Language Enablement
+
+The existing `secondLanguageEnabled` logic only decides whether translation should appear based on locale and translation availability. Overloading it for explicit user modes would make "translation only" hard to model and would blur automatic locale behavior with user intent.
+
+## Architecture
+
+- Add `LiveCaptionDisplayMode` in core as a small public enum with `.both`, `.originalOnly`, and `.translationOnly`.
+- Extend `LiveCaptionDisplayState` to accept a display mode while preserving the existing initializer for current tests and callers.
+- Keep fallback behavior explicit: translation-only mode shows translated text when available; otherwise it shows translation pending or unavailable states instead of silently rendering original text as the primary content.
+- Store `@State private var transcriptDisplayMode: LiveCaptionDisplayMode = .both` inside `TranscriptPaneView`.
+- Add a segmented picker beside the Transcript header and pass the selected mode into each transcript block.
+
+## Testing
+
+- Unit test `LiveCaptionDisplayState` for all three display modes, including translation-only pending and failed states.
+- Source-layout test that `MainWindowView` defines the display mode state, segmented picker labels, and passes the mode to transcript blocks.
+- Run the required `make test` verification.
+
+## User Approval
+
+The design was presented in conversation and approved with "OK" before implementation.


### PR DESCRIPTION
## Summary

Fixes #126

- Adds a transcript display mode for Both, Original, and Translation in the meeting workspace.
- Keeps Both as the default and limits the change to display rendering.

## Changes

- `Sources/MeetingAgentCore/LiveMeetingCockpit.swift` - adds `LiveCaptionDisplayMode` and mode-aware display-state resolution.
- `Sources/MeetingAgentApp/MainWindowView.swift` - adds the segmented display picker and threads the selected mode through transcript views.
- `Tests/MeetingAgentCoreTests/LiveCaptionDisplayStateTests.swift` - covers the three display modes and translation-only pending behavior.
- `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift` - guards the picker and display-mode prop threading.
- `docs/superpowers/specs/2026-05-01-transcript-display-mode-design.md` and `docs/superpowers/plans/2026-05-01-transcript-display-mode.md` - record design and implementation plan.

## Test plan

- [x] Build/lint: `make test` passed
- [x] Unit tests: `swift test --filter LiveCaptionDisplayStateTests` passed; `swift test --filter MainWindowViewLayoutTests/testTranscriptPaneDefinesDisplayModePicker` passed
- [x] E2E/integration: skipped, no E2E convention for this local SwiftUI display mode
- [x] Code review: PASS manual Swift review; plovr code-review skill is TypeScript/Java-specific
- [x] Manual verification: display behavior covered by focused unit/layout tests
