### PR TITLE
fix: separate active captions from replay

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -36,6 +36,8 @@ public final class MeetingAgentViewModel: ObservableObject {
     private let speechConfigurationStore: SpeechTranscriptionConfigurationStore
     private let recorder: MeetingRecorder
     private let exportService: MeetingExportService
+    private var realtimeCaptionSession: RealtimeCaptionSession
+    private var realtimeCaptionSessionUsesCaptionTranslationProvider = false
     private var liveCaptionPipeline: LiveCaptionPipeline
     private var liveCaptionPipelineUsesCaptionTranslationProvider = false
     private var liveCaptionPipelineHasTranslationProvider = false
@@ -135,9 +137,16 @@ public final class MeetingAgentViewModel: ObservableObject {
             resolvedSpeechConfiguration = (try? speechConfigurationStore.load()) ?? .default
         }
         self.speechConfiguration = resolvedSpeechConfiguration
-        liveCaptionPipeline = Self.makeLiveCaptionPipeline(
+        let initialLiveCaptionPipeline = Self.makeLiveCaptionPipeline(
             configuration: resolvedSpeechConfiguration,
             translationProvider: nil
+        )
+        liveCaptionPipeline = initialLiveCaptionPipeline
+        realtimeCaptionSession = RealtimeCaptionSession(
+            pipeline: Self.makeLiveCaptionPipeline(
+                configuration: resolvedSpeechConfiguration,
+                translationProvider: nil
+            )
         )
         refreshPrimaryChainPreflightResult()
     }
@@ -381,9 +390,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         updateRecordingStatus()
         let transcriptResults = recorder.drainTranscriptUpdates()
         if transcriptResults.isEmpty {
-            if isRecording || activeMeetingID != nil {
-                refreshActiveLiveCaptionTurnsFromSelectedMeetingIfSafe()
-            } else {
+            if !isRecording && activeMeetingID == nil {
                 refreshLiveCaptionTurnsFromSelectedMeetingSynchronously()
             }
             if meetingProgressCoordinator != nil {
@@ -965,6 +972,8 @@ public final class MeetingAgentViewModel: ObservableObject {
         liveCaptionPipeline = makeLiveCaptionPipeline()
         liveCaptionPipelineUsesCaptionTranslationProvider = false
         liveCaptionPipelineHasTranslationProvider = false
+        realtimeCaptionSession.replacePipeline(makeLiveCaptionPipeline())
+        realtimeCaptionSessionUsesCaptionTranslationProvider = false
         invalidateActiveCaptionApplyTasks()
     }
 
@@ -1118,37 +1127,6 @@ public final class MeetingAgentViewModel: ObservableObject {
         date.addingTimeInterval(selectedMeetingPendingTranslationRetryInterval)
     }
 
-    private func refreshActiveLiveCaptionTurnsFromSelectedMeetingIfSafe() {
-        guard let document = selectedTranscriptDocument(), !document.segments.isEmpty else {
-            return
-        }
-        let documentSignature = Self.captionDocumentSignature(document)
-        guard activeCaptionDocumentSignature != documentSignature else {
-            return
-        }
-        liveCaptionReplayTask?.cancel()
-        liveCaptionReplaySequence += 1
-        let sequence = liveCaptionReplaySequence
-        let translationProvider = liveCaptionPipelineHasTranslationProvider
-            ? nil
-            : captionTranslationProviderForCurrentConfiguration(document: document)
-        if !liveCaptionPipelineUsesCaptionTranslationProvider
-            || (translationProvider != nil && !liveCaptionPipelineHasTranslationProvider) {
-            liveCaptionPipeline = makeLiveCaptionPipeline(translationProvider: translationProvider)
-            liveCaptionPipelineUsesCaptionTranslationProvider = true
-            liveCaptionPipelineHasTranslationProvider = translationProvider != nil
-        }
-        activeCaptionDocumentSignature = documentSignature
-        publishLiveCaptionPipelineSnapshot(liveCaptionPipeline.replayCaptionsOnly(document))
-        liveCaptionReplayTask = Task { [weak self] in
-            guard let self else { return }
-            guard liveCaptionReplaySequence == sequence else { return }
-            let snapshot = await liveCaptionPipeline.scheduleLivePendingTranslations()
-            guard liveCaptionReplaySequence == sequence else { return }
-            publishLiveCaptionPipelineSnapshot(snapshot)
-        }
-    }
-
     func waitForLiveCaptionReplayForTesting() async {
         await liveCaptionReplayTask?.value
     }
@@ -1246,14 +1224,13 @@ public final class MeetingAgentViewModel: ObservableObject {
     ) async {
         guard let latest = results.last else { return }
         guard isCurrentActiveCaptionApply(context) else { return }
-        if !liveCaptionPipelineUsesCaptionTranslationProvider {
+        if !realtimeCaptionSessionUsesCaptionTranslationProvider {
             let translationProvider = captionTranslationProviderForCurrentConfiguration(document: latest.document)
-            liveCaptionPipeline = makeLiveCaptionPipeline(translationProvider: translationProvider)
-            liveCaptionPipelineUsesCaptionTranslationProvider = true
-            liveCaptionPipelineHasTranslationProvider = translationProvider != nil
+            realtimeCaptionSession.replacePipeline(makeLiveCaptionPipeline(translationProvider: translationProvider))
+            realtimeCaptionSessionUsesCaptionTranslationProvider = true
         }
         activeCaptionDocumentSignature = Self.captionDocumentSignature(latest.document)
-        let snapshot = await liveCaptionPipeline.apply(latest)
+        let snapshot = await realtimeCaptionSession.apply(latest)
         guard !Task.isCancelled, isCurrentActiveCaptionApply(context) else { return }
         publishLiveCaptionPipelineSnapshot(snapshot)
     }
@@ -1515,10 +1492,10 @@ public final class MeetingAgentViewModel: ObservableObject {
         cancelPendingDraftCaptionInput(reason: "flush")
         let context = beginActiveCaptionApply()
         activeCaptionApplyTask?.cancel()
-        publishLiveCaptionPipelineSnapshot(liveCaptionPipeline.flushCaptionsOnly(reason: reason))
+        publishLiveCaptionPipelineSnapshot(realtimeCaptionSession.flushCaptionsOnly(reason: reason))
         activeCaptionApplyTask = Task { [weak self] in
             guard let self else { return }
-            let snapshot = await liveCaptionPipeline.schedulePendingTranslations()
+            let snapshot = await realtimeCaptionSession.schedulePendingTranslations()
             guard !Task.isCancelled, isCurrentCaptionFlush(context) else { return }
             publishLiveCaptionPipelineSnapshot(snapshot)
         }

--- a/Sources/MeetingAgentCore/RealtimeCaptionSession.swift
+++ b/Sources/MeetingAgentCore/RealtimeCaptionSession.swift
@@ -1,0 +1,24 @@
+@MainActor
+final class RealtimeCaptionSession {
+    private var pipeline: LiveCaptionPipeline
+
+    init(pipeline: LiveCaptionPipeline) {
+        self.pipeline = pipeline
+    }
+
+    func replacePipeline(_ pipeline: LiveCaptionPipeline) {
+        self.pipeline = pipeline
+    }
+
+    func apply(_ result: TranscriptSegmentAccumulationResult) async -> LiveCaptionPipelineSnapshot {
+        await pipeline.apply(result)
+    }
+
+    func flushCaptionsOnly(reason: LiveCaptionFreezeReason) -> LiveCaptionPipelineSnapshot {
+        pipeline.flushCaptionsOnly(reason: reason)
+    }
+
+    func schedulePendingTranslations() async -> LiveCaptionPipelineSnapshot {
+        await pipeline.schedulePendingTranslations()
+    }
+}

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -84,14 +84,17 @@ final class MeetingAgentViewModelTests: XCTestCase {
         )
 
         try await viewModel.startRecording(for: target)
-        let record = try XCTUnwrap(viewModel.selectedMeeting)
-        let writer = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL), structuredURL: XCTUnwrap(record.transcriptJSONURL))
-        try writer.replace(with: [
-            TranscriptSegment(id: "segment-1", speaker: TranscriptSpeaker(identifier: "speaker-1"), text: "unfinished thought", language: "en-US")
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            speaker: TranscriptSpeaker(identifier: "speaker-1"),
+            text: "unfinished thought",
+            language: "en-US"
+        )))
 
         viewModel.drainRecordingFrames()
-        XCTAssertEqual(viewModel.liveCaptionTurns.first?.chunkState, .draft)
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.chunkState == .draft
+        }
 
         viewModel.stopRecording()
 
@@ -368,10 +371,9 @@ final class MeetingAgentViewModelTests: XCTestCase {
         }
     }
 
-    func testDrainRecordingFramesRefreshesLiveCaptionTurnsFromStructuredTranscript() async throws {
+    func testActiveRecordingEmptyDrainDoesNotReplaySelectedTranscriptFile() async throws {
         let fixture = try ViewModelRecorderFixture()
         let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
-        var translationFactoryCallCount = 0
         let viewModel = MeetingAgentViewModel(
             store: fixture.store,
             recorder: fixture.recorder,
@@ -382,10 +384,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
                 whisperBinaryPath: nil,
                 whisperModelPath: nil
             ),
-            captionTranslationProviderFactory: { _ in
-                translationFactoryCallCount += 1
-                return nil
-            },
+            captionTranslationProviderFactory: { _ in nil },
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
@@ -398,13 +397,10 @@ final class MeetingAgentViewModelTests: XCTestCase {
 
         viewModel.drainRecordingFrames()
 
-        XCTAssertEqual(viewModel.liveCaptionTurns.map(\.sourceSegmentID), ["segment-1", "partial"])
-        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "Confirm launch owner.")
-        XCTAssertEqual(viewModel.liveCaptionTurns.last?.originalText, "partial")
-        XCTAssertEqual(viewModel.liveCaptionTurns.last?.isFinal, false)
-        XCTAssertEqual(viewModel.liveCaptionTurns.last?.translationHealth, .pending)
-        XCTAssertEqual(viewModel.liveCaptionTurns.first?.targetLocale, "zh-CN")
-        XCTAssertEqual(translationFactoryCallCount, 1)
+        XCTAssertTrue(viewModel.liveCaptionTurns.isEmpty)
+        let replayEvents = try readPerformanceEvents(from: XCTUnwrap(record.performanceEventsURL))
+            .filter { $0.event == "caption_turn_visible" && $0.metadata["path"] == "replay" }
+        XCTAssertTrue(replayEvents.isEmpty)
     }
 
     func testDrainRecordingFramesUsesRecorderTranscriptUpdatesForLiveCaptions() async throws {
@@ -1106,18 +1102,14 @@ final class MeetingAgentViewModelTests: XCTestCase {
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
-        let record = try XCTUnwrap(viewModel.meetings.first)
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(
-                id: "segment-1",
-                speaker: TranscriptSpeaker(identifier: "speaker-1", label: "Alex"),
-                text: "Alex is the launch owner.",
-                language: "en-US",
-                isFinal: true,
-                speechFinal: true
-            )
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            speaker: TranscriptSpeaker(identifier: "speaker-1", label: "Alex"),
+            text: "Alex is the launch owner.",
+            language: "en-US",
+            isFinal: true,
+            speechFinal: true
+        )))
 
         viewModel.drainRecordingFrames()
         try await Task.sleep(nanoseconds: 20_000_000)
@@ -1575,11 +1567,12 @@ final class MeetingAgentViewModelTests: XCTestCase {
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
-        let record = try XCTUnwrap(viewModel.meetings.first)
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(id: "segment-1", text: "Alex is the launch owner.", language: "en-US", isFinal: true)
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "Alex is the launch owner.",
+            language: "en-US",
+            isFinal: true
+        )))
 
         viewModel.drainRecordingFrames()
         try await Task.sleep(nanoseconds: 20_000_000)
@@ -1619,11 +1612,12 @@ final class MeetingAgentViewModelTests: XCTestCase {
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
-        let record = try XCTUnwrap(viewModel.meetings.first)
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(id: "segment-1", text: "開始しましょう。", language: "ja", isFinal: true)
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "開始しましょう。",
+            language: "ja",
+            isFinal: true
+        )))
 
         viewModel.drainRecordingFrames()
         try await Task.sleep(nanoseconds: 20_000_000)
@@ -1668,17 +1662,13 @@ final class MeetingAgentViewModelTests: XCTestCase {
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
-        let record = try XCTUnwrap(viewModel.meetings.first)
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(
-                id: "segment-1",
-                speaker: speaker,
-                text: "first",
-                language: "en-US",
-                isFinal: true
-            )
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            speaker: speaker,
+            text: "first",
+            language: "en-US",
+            isFinal: true
+        )))
 
         viewModel.drainRecordingFrames()
         try await waitFor {
@@ -1689,29 +1679,20 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句")
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
 
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(
-                id: "segment-1",
-                speaker: speaker,
-                text: "first",
-                language: "en-US",
-                isFinal: true
-            ),
-            TranscriptSegment(
-                id: "segment-2",
-                speaker: speaker,
-                text: "second",
-                language: "en-US",
-                isFinal: true,
-                speechFinal: true
-            )
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-2",
+            speaker: speaker,
+            text: "second",
+            language: "en-US",
+            isFinal: true,
+            speechFinal: true
+        )))
 
         viewModel.drainRecordingFrames()
 
-        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "first second")
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "first")
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.translatedText, "第一句")
-        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .pending)
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.translationHealth, .live)
 
         try await waitFor {
             viewModel.liveCaptionTurns.first?.translatedText == "第一句 第二句"
@@ -2267,11 +2248,12 @@ final class MeetingAgentViewModelTests: XCTestCase {
             processTargetsProvider: { [target] }
         )
         try await viewModel.startRecording(for: target)
-        let record = try XCTUnwrap(viewModel.meetings.first)
-        let writer = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL), structuredURL: XCTUnwrap(record.transcriptJSONURL))
-        try writer.replace(with: [
-            TranscriptSegment(id: "segment-1", text: "open caption", language: "en-US", isFinal: false)
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "open caption",
+            language: "en-US",
+            isFinal: false
+        )))
         viewModel.drainRecordingFrames()
         try await waitFor { provider.pendingRequestCount == 1 }
         provider.completeRequest(at: 0, targetText: "停止前草稿")
@@ -2339,11 +2321,16 @@ final class MeetingAgentViewModelTests: XCTestCase {
             expectedDecisions: [],
             keyTerms: []
         ))
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(id: "segment-1", text: "Alex is the launch owner.", language: "en-US", isFinal: true)
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "Alex is the launch owner.",
+            language: "en-US",
+            isFinal: true
+        )))
         viewModel.drainRecordingFrames()
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.sourceSegmentID == "segment-1"
+        }
 
         await viewModel.refreshMeetingProgress()
 
@@ -2391,11 +2378,16 @@ final class MeetingAgentViewModelTests: XCTestCase {
                 )
             )
         )
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(id: "segment-1", text: "We discussed hiring.", language: "en-US", isFinal: true)
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "We discussed hiring.",
+            language: "en-US",
+            isFinal: true
+        )))
         viewModel.drainRecordingFrames()
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.sourceSegmentID == "segment-1"
+        }
 
         await viewModel.refreshMeetingProgress()
 
@@ -2429,12 +2421,17 @@ final class MeetingAgentViewModelTests: XCTestCase {
         ))
         try await viewModel.startRecording(for: target)
         let record = try XCTUnwrap(viewModel.meetings.first)
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(id: "segment-1", text: "Alex is the launch owner.", language: "en-US", isFinal: true)
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "Alex is the launch owner.",
+            language: "en-US",
+            isFinal: true
+        )))
 
         viewModel.drainRecordingFrames()
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.sourceSegmentID == "segment-1"
+        }
         await viewModel.refreshMeetingProgress()
 
         XCTAssertEqual(viewModel.meetingProgressState?.status, .onTrack)
@@ -2467,11 +2464,16 @@ final class MeetingAgentViewModelTests: XCTestCase {
             expectedDecisions: [],
             keyTerms: []
         ))
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
-            TranscriptSegment(id: "segment-1", text: "Alex is the launch owner.", language: "en-US", isFinal: true)
-        ])
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "segment-1",
+            text: "Alex is the launch owner.",
+            language: "en-US",
+            isFinal: true
+        )))
         viewModel.drainRecordingFrames()
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.sourceSegmentID == "segment-1"
+        }
         await viewModel.refreshMeetingProgress()
         XCTAssertNotNil(viewModel.meetingProgressState)
 

--- a/docs/mistakes/2026-05-05T12-04-30Z.md
+++ b/docs/mistakes/2026-05-05T12-04-30Z.md
@@ -1,0 +1,13 @@
+# [134] Drive active caption tests through realtime updates
+
+**Date**: 2026-05-05
+**Category**: test-mistake
+
+### What went wrong
+Several active-recording view-model tests simulated live captions by writing directly to `transcript.json`, which depended on the file replay path that active recording must not use.
+
+### Correct approach
+Use the recorder's fake transcriber or transcript update sink to emit `TranscriptSegment` updates for active recording tests, and reserve `TranscriptFileWriter` replay setup for completed or idle meeting loading tests.
+
+### How to avoid
+When testing active recording captions, inject realtime transcript updates instead of mutating the selected meeting transcript file.


### PR DESCRIPTION
## Summary

Fixes #134

- Route active recording captions through a realtime-only session that does not expose replay APIs
- Stop empty active drain ticks from reading selected meeting transcript JSON or emitting replay visibility events
- Update active-recording tests to use recorder transcript updates instead of file-backed replay setup

## Changes

- `Sources/MeetingAgentCore/RealtimeCaptionSession.swift` - adds a realtime-only wrapper around live caption apply/flush behavior
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - separates active caption application from completed-meeting replay paths
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - adds active empty-drain replay regression and updates active tests to use fake transcriber updates
- `docs/mistakes/2026-05-05T12-04-30Z.md` - records the test-boundary lesson from this fix

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests` passed, 108 tests
- [x] Full verification: `make test` passed, 652 tests, coverage gate passed
- [x] E2E/integration: skipped; no E2E convention for this Swift Package issue
- [x] Code review: PASS, manual Swift review because available code-review skill targets TypeScript/Java
- [x] Manual verification: source search confirms replay calls remain only in selected/completed meeting replay helpers