### PR TITLE
fix: preserve live transcript timing on stop

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -51,6 +51,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     private var realtimeSpeakerIdentificationRuntime: RealtimeSpeakerIdentificationRuntime?
     private var speakerIdentityMap: [String: SpeakerIdentityResolution] = [:]
     private var activeCaptionDocumentSignature: String?
+    private var activeTranscriptDocument: TranscriptDocument?
     private var selectedMeetingReplaySignature: SelectedMeetingReplaySignature?
     private var selectedMeetingReplayFileSignature: SelectedMeetingTranscriptFileSignature?
     private var recentlyStoppedLiveMeetingID: UUID?
@@ -1238,6 +1239,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         liveCaptionReplayTask = nil
         liveCaptionReplaySequence += 1
         activeCaptionDocumentSignature = nil
+        activeTranscriptDocument = nil
         selectedMeetingReplaySignature = nil
         selectedMeetingReplayFileSignature = nil
         resetDraftCaptionInputThrottleState(reason: "pipeline_reset")
@@ -1580,6 +1582,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             realtimeCaptionSessionUsesCaptionTranslationProvider = true
         }
         activeCaptionDocumentSignature = Self.captionDocumentSignature(latest.document)
+        activeTranscriptDocument = latest.document
         var latestSnapshot: LiveCaptionPipelineSnapshot?
         for result in results {
             guard isCurrentActiveCaptionApply(context) else { return }
@@ -1896,6 +1899,10 @@ public final class MeetingAgentViewModel: ObservableObject {
         let providerID = record.transcriptionProviderID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? speechConfiguration.provider.rawValue
             : record.transcriptionProviderID
+        var sourceSegmentsByID: [String: TranscriptSegment] = [:]
+        for segment in activeTranscriptDocument?.segments ?? [] {
+            sourceSegmentsByID[segment.id] = segment
+        }
         let speakers = Dictionary(grouping: turns, by: { $0.speaker.identifier ?? $0.speaker.label ?? "unknown" })
             .map { key, turns in
                 CaptionSpeaker(
@@ -1906,15 +1913,20 @@ public final class MeetingAgentViewModel: ObservableObject {
             }
             .sorted { $0.id < $1.id }
         let captionTurns = turns.map { turn in
-            CaptionTurn(
+            let timing = timing(for: turn.sourceSegmentIDs, sourceSegmentsByID: sourceSegmentsByID)
+            return CaptionTurn(
                 id: turn.id,
                 speakerID: turn.speaker.identifier,
                 speakerLabel: turn.speaker.label,
+                startTimeSeconds: timing.start,
+                endTimeSeconds: timing.end,
                 sections: [
                     CaptionSection(
                         id: "\(turn.id)-section",
                         text: turn.originalText,
-                        utteranceIDs: turn.sourceSegmentIDs
+                        utteranceIDs: turn.sourceSegmentIDs,
+                        startTimeSeconds: timing.start,
+                        endTimeSeconds: timing.end
                     )
                 ],
                 state: turn.isFinal ? .final : .draft,
@@ -1935,6 +1947,32 @@ public final class MeetingAgentViewModel: ObservableObject {
                 locale: speechConfiguration.localeIdentifier
             )
         )
+    }
+
+    private func timing(
+        for sourceSegmentIDs: [String],
+        sourceSegmentsByID: [String: TranscriptSegment]
+    ) -> (start: Double?, end: Double?) {
+        var start: Double?
+        var end: Double?
+        for sourceSegmentID in sourceSegmentIDs {
+            guard let segment = sourceSegmentsByID[sourceSegmentID] else { continue }
+            if let segmentStart = segment.startTimeSeconds {
+                if let currentStart = start {
+                    start = min(currentStart, segmentStart)
+                } else {
+                    start = segmentStart
+                }
+            }
+            if let segmentEnd = segment.endTimeSeconds {
+                if let currentEnd = end {
+                    end = max(currentEnd, segmentEnd)
+                } else {
+                    end = segmentEnd
+                }
+            }
+        }
+        return (start, end)
     }
 
     private func startRealtimeSpeakerIdentificationRuntime() {

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -1011,6 +1011,50 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.sourceSegmentID, "stop-replay")
     }
 
+    func testStopRecordingPersistsLiveCaptionTiming() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            processTargetsProvider: { [target] }
+        )
+        try await viewModel.startRecording(for: target)
+
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "timed-final",
+            speaker: TranscriptSpeaker(identifier: "speaker-1", label: "Alex"),
+            startTimeSeconds: 12.5,
+            endTimeSeconds: 15.25,
+            text: "We decided to launch on Monday.",
+            language: "en-US",
+            sourceProvider: "deepgram-transcribe",
+            isFinal: true,
+            speechFinal: true
+        )))
+        viewModel.drainRecordingFrames()
+        try await waitFor {
+            viewModel.liveCaptionTurns.first?.sourceSegmentID == "timed-final"
+        }
+
+        let record = try XCTUnwrap(viewModel.selectedMeeting)
+        viewModel.stopRecording(at: Date(timeIntervalSince1970: 200))
+
+        let document = try MeetingTranscriptStore.readDocument(from: XCTUnwrap(record.transcriptJSONURL))
+        let turn = try XCTUnwrap(document.turns.first)
+        XCTAssertEqual(turn.startTimeSeconds, 12.5)
+        XCTAssertEqual(turn.endTimeSeconds, 15.25)
+        XCTAssertEqual(turn.sections.first?.startTimeSeconds, 12.5)
+        XCTAssertEqual(turn.sections.first?.endTimeSeconds, 15.25)
+        XCTAssertEqual(viewModel.selectedMeetingSessionState?.transcript.captionDocument.turns.first?.startTimeSeconds, 12.5)
+
+        let srtURL = fixture.root.appendingPathComponent("timed-export.srt")
+        try viewModel.exportSubtitles(for: record.id, format: .srt, to: srtURL)
+        let srt = try String(contentsOf: srtURL, encoding: .utf8)
+        XCTAssertTrue(srt.contains("00:00:12,500 --> 00:00:15,250"))
+    }
+
     func testDraftCaptionInputThrottleLogsCoalescingTelemetry() async throws {
         let fixture = try ViewModelRecorderFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }

--- a/docs/mistakes/2026-05-15T03-46-51Z.md
+++ b/docs/mistakes/2026-05-15T03-46-51Z.md
@@ -1,0 +1,13 @@
+# [138] Avoid closure-heavy timing helpers in coverage-gated Swift
+
+**Date**: 2026-05-15
+**Category**: test-mistake
+
+### What went wrong
+The first timing-preservation fix used compact `Dictionary` construction and optional `map` fallback closures in `MeetingAgentViewModel`. Behavior tests passed, but Swift coverage counted the tiny closures as methods and dropped method coverage below the required gate.
+
+### Correct approach
+Use explicit loops and branches for small helper logic in coverage-enforced Swift files, especially in core ViewModel code where method coverage is already near the threshold.
+
+### How to avoid
+Before running full coverage, scan new core Swift helpers for compact closure expressions and rewrite trivial fallback logic as explicit branches.


### PR DESCRIPTION
## Summary

Fixes #138

- Preserve source transcript timing when active live captions are persisted on stop.
- Keep stopped-meeting SRT/VTT and summary consumers on the original segment timestamps instead of synthetic fallback cues.

## Changes

- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - stores the latest active `TranscriptDocument` and derives persisted `CaptionTurn` / `CaptionSection` timing from source segment IDs.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - adds an active stop regression covering transcript.json timing and SRT export timing.
- `docs/mistakes/2026-05-15T03-46-51Z.md` - records the coverage lesson from this fix.

## Test plan

- [x] Build: `swift build --product MeetingAgentApp` passed
- [x] Focused regression: `swift test --filter MeetingAgentViewModelTests/testStopRecordingPersistsLiveCaptionTiming` failed before fix, passed after fix
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests` passed 100 tests
- [x] Full verification: `make test` passed 891 tests and coverage gate
- [x] Code review: PASS
- [x] E2E/integration: skipped; no app-level E2E convention for this active-recording persistence path