### PR TITLE
fix: preserve caption sections on transcript edit

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -1471,33 +1471,38 @@ public final class MeetingAgentViewModel: ObservableObject {
         var document = try transcriptRepository.loadCaptionDocument(for: record)
         var didUpdateSegment = false
         document.turns = document.turns.map { turn in
-            guard turn.id == normalizedSegmentID || turn.source.utteranceIDs.contains(normalizedSegmentID) else {
+            var updatedTurn = turn
+            var didUpdateSection = false
+            updatedTurn.sections = updatedTurn.sections.map { section in
+                guard section.utteranceIDs.contains(normalizedSegmentID) else {
+                    return section
+                }
+                didUpdateSection = true
+                var updatedSection = section
+                updatedSection.text = normalizedText
+                return updatedSection
+            }
+
+            if didUpdateSection {
+                didUpdateSegment = true
+                updatedTurn.updatedAt = Date()
+                return updatedTurn
+            }
+
+            guard turn.id == normalizedSegmentID else {
                 return turn
             }
+
             didUpdateSegment = true
-            var updatedTurn = turn
-            if updatedTurn.sections.isEmpty {
-                updatedTurn.sections = [
-                    CaptionSection(
-                        id: "\(turn.id)-section",
-                        text: normalizedText,
-                        utteranceIDs: turn.source.utteranceIDs,
-                        startTimeSeconds: turn.startTimeSeconds,
-                        endTimeSeconds: turn.endTimeSeconds
-                    )
-                ]
-            } else {
-                updatedTurn.sections = updatedTurn.sections.enumerated().map { index, section in
-                    guard index == 0 else {
-                        var clearedSection = section
-                        clearedSection.text = ""
-                        return clearedSection
-                    }
-                    var updatedSection = section
-                    updatedSection.text = normalizedText
-                    return updatedSection
-                }
-            }
+            updatedTurn.sections = [
+                CaptionSection(
+                    id: turn.sections.first?.id ?? "\(turn.id)-section",
+                    text: normalizedText,
+                    utteranceIDs: turn.source.utteranceIDs,
+                    startTimeSeconds: turn.startTimeSeconds,
+                    endTimeSeconds: turn.endTimeSeconds
+                )
+            ]
             updatedTurn.updatedAt = Date()
             return updatedTurn
         }

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -2110,6 +2110,61 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, "Transcript corrected; summary needs regeneration")
     }
 
+    func testUpdateTranscriptSegmentTextPreservesUnrelatedCaptionSections() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MeetingStore(baseDirectory: root)
+        let stored = try store.createMeeting(name: "Google Meet", startedAt: Date(timeIntervalSince1970: 100))
+        try FileTranscriptRepository().saveCaptionDocument(CaptionDocument(turns: [
+            CaptionTurn(
+                id: "turn-1",
+                speakerID: "speaker-1",
+                speakerLabel: "User A",
+                startTimeSeconds: 1,
+                endTimeSeconds: 6,
+                sections: [
+                    CaptionSection(
+                        id: "section-1",
+                        text: "First section should stay",
+                        utteranceIDs: ["utt-1"],
+                        startTimeSeconds: 1,
+                        endTimeSeconds: 3
+                    ),
+                    CaptionSection(
+                        id: "section-2",
+                        text: "Second section before edit",
+                        utteranceIDs: ["utt-2"],
+                        startTimeSeconds: 4,
+                        endTimeSeconds: 6
+                    )
+                ],
+                state: .final,
+                source: CaptionTurnSource(providerID: "test", utteranceIDs: ["utt-1", "utt-2"])
+            )
+        ]), for: stored.record)
+        let viewModel = MeetingAgentViewModel(store: store, processTargetsProvider: { [] })
+        try viewModel.loadMeetings()
+        viewModel.selectMeeting(stored.record.id)
+        viewModel.drainRecordingFrames()
+
+        try await viewModel.updateTranscriptSegmentText(
+            for: stored.record.id,
+            segmentID: "utt-2",
+            text: "Corrected second section"
+        )
+
+        let captionDocument = try FileTranscriptRepository().loadCaptionDocument(for: stored.record)
+        XCTAssertEqual(captionDocument.turns.first?.sections.map(\.text), [
+            "First section should stay",
+            "Corrected second section"
+        ])
+        XCTAssertEqual(
+            try String(contentsOf: XCTUnwrap(stored.record.transcriptURL), encoding: .utf8),
+            "User A:\nFirst section should stay\nCorrected second section\n"
+        )
+        XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "First section should stay\nCorrected second section")
+    }
+
     func testExportHelpersWriteSummaryDataAndReadinessReports() throws {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("meeting-vm-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: root) }

--- a/docs/mistakes/2026-05-15T03-47-10Z.md
+++ b/docs/mistakes/2026-05-15T03-47-10Z.md
@@ -1,0 +1,13 @@
+# [139] Isolate SwiftPM coverage scratch across worktrees
+
+**Date**: 2026-05-15
+**Category**: test-mistake
+
+### What went wrong
+The first full `make test` run completed XCTest successfully, but its coverage report failed because another sibling worktree was using the default `meeting-agent-swiftpm-coverage` scratch path at the same time.
+
+### Correct approach
+When another worktree may be running coverage, rerun the required verification with a worktree-specific `MEETING_AGENT_COVERAGE_SCRATCH_PATH`.
+
+### How to avoid
+Before concurrent SwiftPM coverage verification across worktrees, set a unique coverage scratch path for each run.


### PR DESCRIPTION
## Summary

Fixes #139

- Updates transcript corrections to edit matching caption sections by utterance ID before falling back to whole-turn replacement.
- Preserves unrelated readable sections so rendered transcript, live captions, export, summary, and knowledge consumers keep the correct text.
- Records the coverage scratch-path lesson learned while verifying this fix.

## Changes

- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - target section-level caption text updates and keep unrelated sections intact.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - adds a multi-section regression that verifies persisted caption sections, rendered transcript text, and live caption refresh.
- `docs/mistakes/2026-05-15T03-47-10Z.md` - documents isolated SwiftPM coverage scratch paths for concurrent worktrees.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed; `git diff --check` / `git show --check --format=short HEAD` passed.
- [x] Unit tests: focused regression failed before fix, then `swift test --filter MeetingAgentViewModelTests/testUpdateTranscriptSegmentTextPreservesUnrelatedCaptionSections` passed; existing edit test `swift test --filter MeetingAgentViewModelTests/testUpdateTranscriptSegmentTextRefreshesLiveCaptionsAndInvalidatesDownstreamArtifacts` passed.
- [x] E2E/integration: not added; behavior is covered at ViewModel/unit projection layer.
- [x] Full verification: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/private/tmp/meeting-agent-issue-139-coverage make test` passed with 891 tests and coverage gate.
- [x] Code review: PASS.
- [x] Manual verification: not applicable beyond persisted caption document, rendered transcript, and live caption assertions in the regression test.