### PR TITLE
fix: persist recording snapshots as caption documents

### DIFF
--- a/Sources/MeetingAgentCore/CaptionDocument.swift
+++ b/Sources/MeetingAgentCore/CaptionDocument.swift
@@ -87,6 +87,10 @@ public struct CaptionTurn: Codable, Equatable, Identifiable, Sendable {
     public var sections: [CaptionSection]
     public var state: CaptionTurnState
     public var source: CaptionTurnSource
+    public var language: String?
+    public var translatedText: String?
+    public var translationTargetLocale: String?
+    public var translationIsFinal: Bool?
     public let createdAt: Date
     public var updatedAt: Date
 
@@ -109,11 +113,15 @@ public struct CaptionTurn: Codable, Equatable, Identifiable, Sendable {
             startTimeSeconds: startTimeSeconds,
             endTimeSeconds: endTimeSeconds,
             text: text,
+            language: language,
             sourceProvider: source.providerID.isEmpty ? "unknown" : source.providerID,
             isFinal: state == .final,
             speechFinal: state == .final,
             createdAt: createdAt,
-            timingSource: startTimeSeconds == nil && endTimeSeconds == nil ? .unavailable : .precise
+            timingSource: startTimeSeconds == nil && endTimeSeconds == nil ? .unavailable : .precise,
+            translatedText: translatedText,
+            translationTargetLocale: translationTargetLocale,
+            translationIsFinal: translationIsFinal
         )
     }
 
@@ -126,6 +134,10 @@ public struct CaptionTurn: Codable, Equatable, Identifiable, Sendable {
         sections: [CaptionSection],
         state: CaptionTurnState,
         source: CaptionTurnSource,
+        language: String? = nil,
+        translatedText: String? = nil,
+        translationTargetLocale: String? = nil,
+        translationIsFinal: Bool? = nil,
         createdAt: Date = Date(),
         updatedAt: Date = Date()
     ) {
@@ -137,6 +149,10 @@ public struct CaptionTurn: Codable, Equatable, Identifiable, Sendable {
         self.sections = sections
         self.state = state
         self.source = source
+        self.language = language.nilIfBlank
+        self.translatedText = translatedText.nilIfBlank
+        self.translationTargetLocale = translationTargetLocale.nilIfBlank
+        self.translationIsFinal = translationIsFinal
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }

--- a/Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift
+++ b/Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift
@@ -2,8 +2,8 @@ import Foundation
 
 final class RecordingTranscriptPersistenceStore {
     private let transcriptURL: URL
+    private let structuredURL: URL
     private let eventLogURL: URL
-    private let writer: TranscriptFileWriter
     private let snapshotInterval: TimeInterval
     private let now: () -> Date
     private var accumulator: TranscriptSegmentAccumulator
@@ -16,15 +16,15 @@ final class RecordingTranscriptPersistenceStore {
         now: @escaping () -> Date = Date.init
     ) throws {
         self.transcriptURL = transcriptURL
+        self.structuredURL = transcriptURL.deletingPathExtension().appendingPathExtension("json")
         self.eventLogURL = transcriptURL
             .deletingLastPathComponent()
             .appendingPathComponent("transcript-events.jsonl")
         self.snapshotInterval = snapshotInterval
         self.now = now
         self.lastSnapshotAt = now()
-        let structuredURL = transcriptURL.deletingPathExtension().appendingPathExtension("json")
         let initialDocument = try TranscriptFileWriter.readDocument(from: structuredURL)
-        self.writer = try TranscriptFileWriter(url: transcriptURL, structuredURL: structuredURL)
+        FileManager.default.createFile(atPath: transcriptURL.path, contents: Data())
         self.accumulator = TranscriptSegmentAccumulator(document: initialDocument)
         try replayEvents()
     }
@@ -46,16 +46,19 @@ final class RecordingTranscriptPersistenceStore {
 
     func flushSnapshot() throws {
         if let plainTextReplacement {
-            try writer.replace(with: plainTextReplacement)
+            try writeSnapshot(CaptionDocument(), renderedText: plainTextReplacement)
         } else {
-            try writer.replace(with: accumulator.currentDocument.segments)
+            let labeledSegments = TranscriptFileWriter.assignSpeakerLabels(to: accumulator.currentDocument.segments)
+            try writeSnapshot(
+                Self.captionDocument(from: labeledSegments, updatedAt: now()),
+                renderedText: TranscriptFormatter.render(labeledSegments)
+            )
         }
         lastSnapshotAt = now()
     }
 
     func close() throws {
         try flushSnapshot()
-        try writer.close()
     }
 
     private func replayEvents() throws {
@@ -128,6 +131,75 @@ final class RecordingTranscriptPersistenceStore {
         case .upsert, .replaceAll, .replaceWithPlainText:
             return
         }
+    }
+
+    private func writeSnapshot(_ document: CaptionDocument, renderedText: String) throws {
+        let data = try JSONEncoder.meetingAgent.encode(document)
+        try data.write(to: structuredURL, options: .atomic)
+        try (renderedText + "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func captionDocument(from segments: [TranscriptSegment], updatedAt: Date) -> CaptionDocument {
+        let speakers = captionSpeakers(from: segments)
+        let turns = segments.map { segment in
+            CaptionTurn(
+                id: segment.id,
+                speakerID: segment.speakerID,
+                speakerLabel: segment.speakerLabel,
+                startTimeSeconds: segment.startTimeSeconds,
+                endTimeSeconds: segment.endTimeSeconds,
+                sections: [
+                    CaptionSection(
+                        id: "\(segment.id)-section",
+                        text: segment.text,
+                        utteranceIDs: [segment.id],
+                        startTimeSeconds: segment.startTimeSeconds,
+                        endTimeSeconds: segment.endTimeSeconds
+                    )
+                ],
+                state: segment.isFinal ? .final : .draft,
+                source: CaptionTurnSource(
+                    providerID: segment.sourceProvider,
+                    resultIDs: [segment.id],
+                    utteranceIDs: [segment.id]
+                ),
+                language: segment.language,
+                translatedText: segment.translatedText,
+                translationTargetLocale: segment.translationTargetLocale,
+                translationIsFinal: segment.translationIsFinal,
+                createdAt: segment.createdAt,
+                updatedAt: updatedAt
+            )
+        }
+        let provider = captionProvider(from: segments)
+        return CaptionDocument(
+            speakers: speakers,
+            turns: turns,
+            provider: provider,
+            createdAt: segments.map(\.createdAt).min() ?? updatedAt,
+            updatedAt: updatedAt,
+            finalizedAt: turns.isEmpty || turns.contains(where: { $0.state != .final }) ? nil : updatedAt
+        )
+    }
+
+    private static func captionSpeakers(from segments: [TranscriptSegment]) -> [CaptionSpeaker] {
+        var speakers: [CaptionSpeaker] = []
+        var seen = Set<String>()
+        for segment in segments {
+            guard let speakerID = segment.speakerID, !seen.contains(speakerID) else { continue }
+            speakers.append(CaptionSpeaker(id: speakerID, label: segment.speakerLabel))
+            seen.insert(speakerID)
+        }
+        return speakers
+    }
+
+    private static func captionProvider(from segments: [TranscriptSegment]) -> CaptionProviderInfo? {
+        let providerIDs = Set(segments.map(\.sourceProvider).filter { !$0.isEmpty && $0 != "unknown" })
+        guard providerIDs.count == 1, let providerID = providerIDs.first else {
+            return nil
+        }
+        let locales = Set(segments.compactMap(\.language).filter { !$0.isEmpty })
+        return CaptionProviderInfo(id: providerID, locale: locales.count == 1 ? locales.first : nil)
     }
 
     private static var eventEncoder: JSONEncoder {

--- a/Tests/MeetingAgentCoreTests/CaptionDocumentTests.swift
+++ b/Tests/MeetingAgentCoreTests/CaptionDocumentTests.swift
@@ -105,6 +105,10 @@ final class CaptionDocumentTests: XCTestCase {
             ],
             state: .final,
             source: CaptionTurnSource(providerID: "deepgram", streamID: "stream-1", resultIDs: ["r1"], utteranceIDs: ["utt-1", "utt-2"]),
+            language: "zh-CN",
+            translatedText: "First sentence. Second sentence.",
+            translationTargetLocale: "en-US",
+            translationIsFinal: true,
             createdAt: Date(timeIntervalSince1970: 1_777_000_000),
             updatedAt: Date(timeIntervalSince1970: 1_777_000_001)
         )
@@ -115,8 +119,12 @@ final class CaptionDocumentTests: XCTestCase {
         XCTAssertEqual(segment.speakerID, "speaker-1")
         XCTAssertEqual(segment.speakerLabel, "Alice")
         XCTAssertEqual(segment.text, "第一句。\n第二句。")
+        XCTAssertEqual(segment.language, "zh-CN")
         XCTAssertEqual(segment.sourceProvider, "deepgram")
         XCTAssertTrue(segment.isFinal)
         XCTAssertEqual(segment.timingSource, .precise)
+        XCTAssertEqual(segment.translatedText, "First sentence. Second sentence.")
+        XCTAssertEqual(segment.translationTargetLocale, "en-US")
+        XCTAssertEqual(segment.translationIsFinal, true)
     }
 }

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -759,7 +759,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
             isFinal: false
         )))
         if let transcriptJSONURL = viewModel.selectedMeeting?.transcriptJSONURL {
-            try FileManager.default.removeItem(at: transcriptJSONURL)
+            try? FileManager.default.removeItem(at: transcriptJSONURL)
         }
         viewModel.drainRecordingFrames()
 

--- a/Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift
@@ -35,6 +35,37 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nhello world\n")
     }
 
+    func testSnapshotWritesCaptionDocumentForRepositoryHydration() throws {
+        let fixture = try StoreFixture()
+        let store = try RecordingTranscriptPersistenceStore(
+            transcriptURL: fixture.transcriptURL,
+            snapshotInterval: 10,
+            now: fixture.now
+        )
+
+        try store.apply(.upsert(TranscriptSegment(
+            id: "segment-1",
+            speaker: TranscriptSpeaker(identifier: "speaker-0", label: "Alice"),
+            startTimeSeconds: 1,
+            endTimeSeconds: 2,
+            text: "hello",
+            language: "en-US",
+            sourceProvider: "whisper",
+            isFinal: true,
+            createdAt: Date(timeIntervalSince1970: 1_777_000_000),
+            timingSource: .precise
+        )), forceSnapshot: true)
+
+        let document = try FileTranscriptRepository().loadCaptionDocument(for: fixture.record)
+
+        XCTAssertEqual(document.turns.map(\.id), ["segment-1"])
+        XCTAssertEqual(document.turns.first?.speakerID, "speaker-0")
+        XCTAssertEqual(document.turns.first?.speakerLabel, "Alice")
+        XCTAssertEqual(document.turns.first?.text, "hello")
+        XCTAssertEqual(document.turns.first?.state, .final)
+        XCTAssertEqual(document.turns.first?.source.providerID, "whisper")
+    }
+
     func testDraftTranslationPatchDoesNotSnapshotBeforeDebounce() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
@@ -75,6 +106,10 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         let document = try TranscriptFileWriter.readDocument(from: fixture.structuredURL)
         XCTAssertEqual(document.segments.first?.translatedText, "确认负责人。")
         XCTAssertEqual(document.segments.first?.translationIsFinal, true)
+        let captionDocument = try FileTranscriptRepository().loadCaptionDocument(for: fixture.record)
+        XCTAssertEqual(captionDocument.turns.first?.translatedText, "确认负责人。")
+        XCTAssertEqual(captionDocument.turns.first?.translationTargetLocale, "zh-CN")
+        XCTAssertEqual(captionDocument.turns.first?.translationIsFinal, true)
         XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nConfirm owner.\n")
         XCTAssertEqual(try fixture.eventLogLineCount(), 2)
     }
@@ -137,7 +172,8 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         try store.apply(.replaceWithPlainText("Speech recognition unavailable"))
 
         XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "Speech recognition unavailable\n")
-        XCTAssertEqual(try TranscriptFileWriter.readDocument(from: fixture.structuredURL), TranscriptDocument())
+        XCTAssertTrue(try TranscriptFileWriter.readDocument(from: fixture.structuredURL).segments.isEmpty)
+        XCTAssertTrue(try FileTranscriptRepository().loadCaptionDocument(for: fixture.record).turns.isEmpty)
     }
 
     func testReplaceAllForcesSnapshotAndCanBeReplayed() throws {
@@ -193,8 +229,9 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         )
         try recoveredPlainText.flushSnapshot()
 
-        XCTAssertEqual(recoveredPlainText.currentDocument, TranscriptDocument())
+        XCTAssertTrue(recoveredPlainText.currentDocument.segments.isEmpty)
         XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "Speech recognition unavailable\n")
+        XCTAssertTrue(try FileTranscriptRepository().loadCaptionDocument(for: fixture.record).turns.isEmpty)
     }
 
     func testTranslationPatchRejectsBlankInputs() throws {
@@ -243,6 +280,7 @@ private final class StoreFixture {
     let transcriptURL: URL
     let structuredURL: URL
     let eventLogURL: URL
+    let record: MeetingRecord
     var currentDate = Date(timeIntervalSince1970: 0)
 
     init() throws {
@@ -254,6 +292,15 @@ private final class StoreFixture {
         transcriptURL = directory.appendingPathComponent("transcript.txt")
         structuredURL = directory.appendingPathComponent("transcript.json")
         eventLogURL = directory.appendingPathComponent("transcript-events.jsonl")
+        record = MeetingRecord(
+            id: UUID(),
+            name: "Fixture",
+            startedAt: currentDate,
+            endedAt: nil,
+            audioURL: directory.appendingPathComponent("audio.wav"),
+            transcriptURL: transcriptURL,
+            transcriptJSONURL: structuredURL
+        )
     }
 
     deinit {

--- a/docs/mistakes/2026-05-15T03-48-28Z.md
+++ b/docs/mistakes/2026-05-15T03-48-28Z.md
@@ -1,0 +1,13 @@
+# [137] Refresh origin before choosing a non-default base
+
+**Date**: 2026-05-15
+**Category**: wrong-assumption
+
+### What went wrong
+Issue evidence mentioned files that were not present in the stale local `origin/main`, so the first investigation treated a local topic branch as the likely target base.
+
+### Correct approach
+Fetch the remote default branch and verify its current tree before deciding that an issue targets a non-default branch.
+
+### How to avoid
+For issue fixes, refresh `origin/main` first, then compare issue evidence against the updated remote tree before switching bases.


### PR DESCRIPTION
## Summary

Fixes #137

- Writes non-speech-event recording transcript snapshots as CaptionDocument JSON so FileTranscriptRepository can hydrate them.
- Preserves legacy transcript projection fields, including language and translation cache metadata, for export/retry consumers.
- Keeps active recording caption tests independent of transcript file reloads when no draft snapshot exists yet.

## Changes

- `Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift` - replaces TranscriptFileWriter snapshot writes with explicit CaptionDocument snapshot writes.
- `Sources/MeetingAgentCore/CaptionDocument.swift` - carries language and translation cache metadata through legacy TranscriptSegment projection.
- `Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift` - covers repository hydration, plain-text clearing, and final translation snapshot metadata.
- `Tests/MeetingAgentCoreTests/CaptionDocumentTests.swift` - covers projection of the added metadata fields.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - keeps active caption test valid when transcript.json has not been created yet.

## Test plan

- [x] Build/lint: `swift build --product MeetingAgentApp` passed
- [x] Unit tests: `swift test --filter RecordingTranscriptPersistenceStoreTests` passed
- [x] Unit tests: `swift test --filter CaptionDocumentTests` passed
- [x] Unit tests: `swift test --filter MeetingDataRepositoriesTests` passed
- [x] Unit tests: `swift test --filter TranscriptFileWriterTests` passed
- [x] Regression: `swift test --filter MeetingAgentViewModelTests/testActiveRecordingCaptionDoesNotRequireTranscriptFileReload` passed
- [x] Full verification: `scripts/check-unit-coverage.sh` passed, 891 tests, line 95.89%, method 94.19%
- [x] Code review: PASS_WITH_WARNINGS, code-review skill is TS/Java-focused so Swift diff was reviewed manually