### PR TITLE
feat: remove realtime transcript text persistence

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -750,7 +750,7 @@ private struct MeetingCommandCenterView: View {
             } label: {
                 Label("Export Transcript", systemImage: "doc.text")
             }
-            .disabled(isRecording || meeting.transcriptURL == nil)
+            .disabled(isRecording || meeting.transcriptJSONURL == nil)
 
             Button {
                 exportMeetingData()

--- a/Sources/MeetingAgentApp/TodayAgendaView.swift
+++ b/Sources/MeetingAgentApp/TodayAgendaView.swift
@@ -270,8 +270,8 @@ struct TodayAgendaView: View {
     }
 
     private func hasReadableTranscript(_ meeting: MeetingRecord) -> Bool {
-        guard let transcriptURL = meeting.transcriptURL else { return false }
-        return FileManager.default.isReadableFile(atPath: transcriptURL.path)
+        guard let transcriptJSONURL = meeting.transcriptJSONURL else { return false }
+        return FileManager.default.isReadableFile(atPath: transcriptJSONURL.path)
     }
 
     private func isCompleted(_ meeting: MeetingRecord) -> Bool {
@@ -477,14 +477,14 @@ private struct MeetingArtifactCard: View {
         if meeting.summaryURL != nil || meeting.summaryJSONURL != nil {
             return "Summary ready"
         }
-        if meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+        if meeting.transcriptJSONURL != nil {
             return "Transcript ready"
         }
         return "Artifacts pending"
     }
 
     private var artifactTint: Color {
-        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil || meeting.transcriptURL != nil || meeting.transcriptJSONURL != nil {
+        if meeting.summaryURL != nil || meeting.summaryJSONURL != nil || meeting.transcriptJSONURL != nil {
             return CommandCenterPalette.primary
         }
         return CommandCenterPalette.secondaryText

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -928,7 +928,7 @@ public final class MeetingAgentViewModel: ObservableObject {
     public func retryTranscription(for meetingID: UUID) async {
         guard let index = meetings.firstIndex(where: { $0.id == meetingID }) else { return }
         var record = meetings[index]
-        guard let audioURL = record.audioURL, let transcriptURL = record.transcriptURL else {
+        guard let audioURL = record.audioURL, let transcriptJSONURL = record.transcriptJSONURL else {
             record.transcriptionStatus = .failed
             record.transcriptionFailureReason = "No saved audio is available for transcription retry"
             meetings[index] = record
@@ -953,7 +953,18 @@ public final class MeetingAgentViewModel: ObservableObject {
         try? store.save(record)
 
         do {
-            let previousTranscript = try? String(contentsOf: transcriptURL, encoding: .utf8)
+            let providerTranscriptURL = transcriptJSONURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("provider-transcript.legacy")
+            defer {
+                try? FileManager.default.removeItem(at: providerTranscriptURL)
+                try? FileManager.default.removeItem(
+                    at: providerTranscriptURL.deletingPathExtension().appendingPathExtension("json")
+                )
+            }
+            let previousTranscript = try? TranscriptFormatter.render(
+                transcriptRepository.loadCaptionDocument(for: record).transcriptDocument.segments
+            )
             if speechConfiguration.usesDeepgram {
                 var retryConfiguration = speechConfiguration
                 retryConfiguration.localeIdentifier = retryLocaleIdentifier
@@ -962,7 +973,10 @@ public final class MeetingAgentViewModel: ObservableObject {
                     audio: AudioInput(wavURL: audioURL, localeIdentifier: retryLocaleIdentifier),
                     options: TranscriptionOptions(sourceLocale: retryLocaleIdentifier)
                 )
-                try FileBackedTranscriptUpdateSink(transcriptURL: transcriptURL).persist(.replaceAll(document.segments))
+                try transcriptRepository.saveCaptionDocument(
+                    Self.captionDocument(from: document.segments),
+                    for: record
+                )
             } else {
                 var retryConfiguration = speechConfiguration
                 retryConfiguration.localeIdentifier = retryLocaleIdentifier
@@ -972,11 +986,21 @@ public final class MeetingAgentViewModel: ObservableObject {
                 )
                 try await provider.transcribeExistingAudio(context: SpeechTranscriptionContext(
                     inputAudioURL: audioURL,
-                    transcriptURL: transcriptURL,
+                    transcriptURL: providerTranscriptURL,
                     localeIdentifier: retryLocaleIdentifier,
                     meetingID: record.id,
                     previousTranscript: previousTranscript
                 ))
+                if FileManager.default.fileExists(atPath: providerTranscriptURL.deletingPathExtension().appendingPathExtension("json").path) {
+                    let data = try Data(
+                        contentsOf: providerTranscriptURL.deletingPathExtension().appendingPathExtension("json")
+                    )
+                    let legacyDocument = try JSONDecoder.meetingAgent.decode(TranscriptDocument.self, from: data)
+                    try transcriptRepository.saveCaptionDocument(
+                        Self.captionDocument(from: legacyDocument.segments),
+                        for: record
+                    )
+                }
             }
             record.transcriptionStatus = .transcribed
             record.transcriptionFailureReason = nil
@@ -1457,7 +1481,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             )
         }
         document.updatedAt = Date()
-        try saveCaptionDocumentAndRenderedText(document, for: record)
+        try saveCaptionDocument(document, for: record)
     }
 
     private func updateCaptionSegmentText(
@@ -1512,15 +1536,45 @@ public final class MeetingAgentViewModel: ObservableObject {
             throw ProbeError.invalidArguments("Transcript segment not found")
         }
         document.updatedAt = Date()
-        try saveCaptionDocumentAndRenderedText(document, for: record)
+        try saveCaptionDocument(document, for: record)
     }
 
-    private func saveCaptionDocumentAndRenderedText(_ document: CaptionDocument, for record: MeetingRecord) throws {
+    private func saveCaptionDocument(_ document: CaptionDocument, for record: MeetingRecord) throws {
         try transcriptRepository.saveCaptionDocument(document, for: record)
-        if let transcriptURL = record.transcriptURL {
-            let transcript = TranscriptFormatter.render(document.transcriptDocument.segments)
-            try (transcript + "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func captionDocument(from segments: [TranscriptSegment]) -> CaptionDocument {
+        let turns = segments.map { segment in
+            CaptionTurn(
+                id: segment.id,
+                speakerID: segment.speakerID,
+                speakerLabel: segment.speakerLabel,
+                startTimeSeconds: segment.startTimeSeconds,
+                endTimeSeconds: segment.endTimeSeconds,
+                sections: [
+                    CaptionSection(
+                        id: "\(segment.id)-section",
+                        text: segment.text,
+                        utteranceIDs: [segment.id],
+                        startTimeSeconds: segment.startTimeSeconds,
+                        endTimeSeconds: segment.endTimeSeconds
+                    )
+                ],
+                state: segment.isFinal ? .final : .draft,
+                source: CaptionTurnSource(
+                    providerID: segment.sourceProvider,
+                    resultIDs: [segment.id],
+                    utteranceIDs: [segment.id]
+                ),
+                language: segment.language,
+                translatedText: segment.translatedText,
+                translationTargetLocale: segment.translationTargetLocale,
+                translationIsFinal: segment.translationIsFinal,
+                createdAt: segment.createdAt,
+                updatedAt: Date()
+            )
         }
+        return CaptionDocument(turns: turns)
     }
 
     private static func captionDocumentSignature(_ document: TranscriptDocument) -> String {

--- a/Sources/MeetingAgentCore/MeetingRecorder.swift
+++ b/Sources/MeetingAgentCore/MeetingRecorder.swift
@@ -270,7 +270,7 @@ public final class MeetingRecorder {
                 )
             }
 
-            if updatedRecord.transcriptURL != nil {
+            if updatedRecord.transcriptJSONURL != nil {
                 isStartingTranscriber = true
             }
             captureSession = session
@@ -282,10 +282,13 @@ public final class MeetingRecorder {
             throw error
         }
 
-        if let transcriptURL = updatedRecord.transcriptURL {
+        if let transcriptJSONURL = updatedRecord.transcriptJSONURL {
+            let providerTranscriptURL = transcriptJSONURL
+                .deletingLastPathComponent()
+                .appendingPathComponent("provider-transcript.legacy")
             do {
                 let updateSink = try RecordingTranscriptUpdateSink(
-                    transcriptURL: transcriptURL,
+                    transcriptJSONURL: transcriptJSONURL,
                     performanceEventLogger: performanceEventLogger,
                     onResults: { [weak self] results in
                         self?.emit(.transcriptUpdates(results))
@@ -294,7 +297,7 @@ public final class MeetingRecorder {
                 transcriptUpdateSink = updateSink
                 let startedTranscriber = try await transcriberFactory(
                     effectiveConfiguration,
-                    transcriptURL,
+                    providerTranscriptURL,
                     session.outputSampleRate,
                     session.outputChannelCount,
                     performanceEventLogger,
@@ -664,12 +667,12 @@ private final class RecordingTranscriptUpdateSink: TranscriptUpdateSink, SpeechR
     private let lock = NSLock()
 
     init(
-        transcriptURL: URL,
+        transcriptJSONURL: URL,
         performanceEventLogger: PerformanceEventLogger?,
         onResults: @escaping ([TranscriptSegmentAccumulationResult]) -> Void = { _ in }
     ) throws {
-        self.store = try RecordingTranscriptPersistenceStore(transcriptURL: transcriptURL)
-        self.transcriptDirectoryURL = transcriptURL.deletingLastPathComponent()
+        self.store = try RecordingTranscriptPersistenceStore(transcriptJSONURL: transcriptJSONURL)
+        self.transcriptDirectoryURL = transcriptJSONURL.deletingLastPathComponent()
         self.performanceEventLogger = performanceEventLogger
         self.onResults = onResults
     }

--- a/Sources/MeetingAgentCore/MeetingStore.swift
+++ b/Sources/MeetingAgentCore/MeetingStore.swift
@@ -46,7 +46,7 @@ public final class MeetingStore {
             startedAt: startedAt,
             endedAt: nil,
             audioURL: directory.appendingPathComponent("audio.wav"),
-            transcriptURL: directory.appendingPathComponent("transcript.txt"),
+            transcriptURL: nil,
             transcriptJSONURL: directory.appendingPathComponent("transcript.json"),
             meetingProgressJSONURL: directory.appendingPathComponent("meeting-progress.json"),
             summaryURL: directory.appendingPathComponent("summary.md"),

--- a/Sources/MeetingAgentCore/OpenAIRealtimeTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/OpenAIRealtimeTranscriptionProvider.swift
@@ -104,7 +104,7 @@ public struct OpenAIRealtimeTranscriptionProvider {
         let transport = transportFactory(url, apiKey)
         try await transport.connect()
         try await transport.send(try sessionUpdate(localeIdentifier: context.localeIdentifier))
-        let writer = try TranscriptFileWriter(url: context.transcriptURL)
+        let writer = context.transcriptUpdateSink == nil ? try TranscriptFileWriter(url: context.transcriptURL) : nil
         return OpenAIRealtimeTranscriptionTranscriber(
             transport: transport,
             writer: writer,
@@ -168,7 +168,7 @@ public struct OpenAIRealtimeTranscriptionProvider {
 
 final class OpenAIRealtimeTranscriptionTranscriber: AudioFrameTranscriber {
     private let transport: RealtimeTranscriptionWebSocketTransport
-    private let writer: TranscriptFileWriter
+    private let writer: TranscriptFileWriter?
     private let transcriptUpdateSink: TranscriptUpdateSink?
     private let localeIdentifier: String
     private var receiveTask: Task<Void, Never>?
@@ -176,7 +176,7 @@ final class OpenAIRealtimeTranscriptionTranscriber: AudioFrameTranscriber {
 
     init(
         transport: RealtimeTranscriptionWebSocketTransport,
-        writer: TranscriptFileWriter,
+        writer: TranscriptFileWriter?,
         transcriptUpdateSink: TranscriptUpdateSink? = nil,
         localeIdentifier: String
     ) {
@@ -202,16 +202,16 @@ final class OpenAIRealtimeTranscriptionTranscriber: AudioFrameTranscriber {
                             timingSource: .unavailable
                         )
                         transcriptUpdateSink?.receive(.upsert(segment))
-                        try writer.append(segment)
+                        try writer?.append(segment)
                         segmentIndex += 1
                     case .failed(let message):
                         transcriptUpdateSink?.receive(.replaceWithPlainText("OpenAI Realtime transcription failed: \(message)"))
-                        try writer.replace(with: "OpenAI Realtime transcription failed: \(message)")
+                        try writer?.replace(with: "OpenAI Realtime transcription failed: \(message)")
                     case .connected, .delta:
                         break
                     }
                 } catch {
-                    try? writer.replace(with: "OpenAI Realtime transcription failed: \(error)")
+                    try? writer?.replace(with: "OpenAI Realtime transcription failed: \(error)")
                 }
             }
         }
@@ -231,7 +231,7 @@ final class OpenAIRealtimeTranscriptionTranscriber: AudioFrameTranscriber {
         receiveTask?.cancel()
         Task { [transport, writer] in
             await transport.close()
-            try? writer.close()
+            try? writer?.close()
         }
     }
 

--- a/Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift
+++ b/Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 final class RecordingTranscriptPersistenceStore {
-    private let transcriptURL: URL
     private let structuredURL: URL
     private let eventLogURL: URL
     private let snapshotInterval: TimeInterval
@@ -11,20 +10,18 @@ final class RecordingTranscriptPersistenceStore {
     private var plainTextReplacement: String?
 
     init(
-        transcriptURL: URL,
+        transcriptJSONURL: URL,
         snapshotInterval: TimeInterval = 2,
         now: @escaping () -> Date = Date.init
     ) throws {
-        self.transcriptURL = transcriptURL
-        self.structuredURL = transcriptURL.deletingPathExtension().appendingPathExtension("json")
-        self.eventLogURL = transcriptURL
+        self.structuredURL = transcriptJSONURL
+        self.eventLogURL = transcriptJSONURL
             .deletingLastPathComponent()
             .appendingPathComponent("transcript-events.jsonl")
         self.snapshotInterval = snapshotInterval
         self.now = now
         self.lastSnapshotAt = now()
-        let initialDocument = try TranscriptFileWriter.readDocument(from: structuredURL)
-        FileManager.default.createFile(atPath: transcriptURL.path, contents: Data())
+        let initialDocument = try MeetingTranscriptStore.readDocument(from: structuredURL).transcriptDocument
         self.accumulator = TranscriptSegmentAccumulator(document: initialDocument)
         try replayEvents()
     }
@@ -46,12 +43,12 @@ final class RecordingTranscriptPersistenceStore {
 
     func flushSnapshot() throws {
         if let plainTextReplacement {
-            try writeSnapshot(CaptionDocument(), renderedText: plainTextReplacement)
+            _ = plainTextReplacement
+            try writeSnapshot(CaptionDocument())
         } else {
-            let labeledSegments = TranscriptFileWriter.assignSpeakerLabels(to: accumulator.currentDocument.segments)
+            let labeledSegments = Self.assignSpeakerLabels(to: accumulator.currentDocument.segments)
             try writeSnapshot(
-                Self.captionDocument(from: labeledSegments, updatedAt: now()),
-                renderedText: TranscriptFormatter.render(labeledSegments)
+                Self.captionDocument(from: labeledSegments, updatedAt: now())
             )
         }
         lastSnapshotAt = now()
@@ -133,10 +130,13 @@ final class RecordingTranscriptPersistenceStore {
         }
     }
 
-    private func writeSnapshot(_ document: CaptionDocument, renderedText: String) throws {
+    private func writeSnapshot(_ document: CaptionDocument) throws {
         let data = try JSONEncoder.meetingAgent.encode(document)
+        try FileManager.default.createDirectory(
+            at: structuredURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try data.write(to: structuredURL, options: .atomic)
-        try (renderedText + "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
     }
 
     private static func captionDocument(from segments: [TranscriptSegment], updatedAt: Date) -> CaptionDocument {
@@ -200,6 +200,43 @@ final class RecordingTranscriptPersistenceStore {
         }
         let locales = Set(segments.compactMap(\.language).filter { !$0.isEmpty })
         return CaptionProviderInfo(id: providerID, locale: locales.count == 1 ? locales.first : nil)
+    }
+
+    private static func assignSpeakerLabels(to segments: [TranscriptSegment]) -> [TranscriptSegment] {
+        var mapper = SpeakerLabelMapper(speakers: segments.map(\.speaker))
+        var generatedIDsBySpeaker: [TranscriptSpeaker: String] = [:]
+        var nextSpeakerIndex = 1
+        return segments.map { segment in
+            let speaker = segment.speaker
+            let label = mapper.label(for: speaker)
+            let speakerID: String
+            if let existingID = speaker.identifier {
+                speakerID = existingID
+            } else if let generatedID = generatedIDsBySpeaker[speaker] {
+                speakerID = generatedID
+            } else {
+                speakerID = "speaker-\(nextSpeakerIndex)"
+                generatedIDsBySpeaker[speaker] = speakerID
+                nextSpeakerIndex += 1
+            }
+            return TranscriptSegment(
+                id: segment.id,
+                speaker: TranscriptSpeaker(identifier: speakerID, label: segment.speakerLabel ?? label),
+                startTimeSeconds: segment.startTimeSeconds,
+                endTimeSeconds: segment.endTimeSeconds,
+                text: segment.text,
+                language: segment.language,
+                sourceProvider: segment.sourceProvider,
+                isFinal: segment.isFinal,
+                speechFinal: segment.speechFinal,
+                confidence: segment.confidence,
+                createdAt: segment.createdAt,
+                timingSource: segment.timingSource,
+                translatedText: segment.translatedText,
+                translationTargetLocale: segment.translationTargetLocale,
+                translationIsFinal: segment.translationIsFinal
+            )
+        }
     }
 
     private static var eventEncoder: JSONEncoder {

--- a/Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionProvider.swift
@@ -120,6 +120,15 @@ public struct LocalSpeechTranscriptionProvider: SpeechTranscriptionProvider {
             localeIdentifier: localeIdentifier
         )
     }
+
+    public func start(context: SpeechTranscriptionStreamContext) async throws -> AudioFrameTranscriber {
+        try await SystemSpeechTranscriber.start(
+            transcriptURL: context.transcriptURL,
+            localeIdentifier: context.localeIdentifier,
+            environment: .live,
+            transcriptUpdateSink: context.transcriptUpdateSink
+        )
+    }
 }
 
 public enum StreamingSpeechTranscriberFactory {

--- a/Sources/MeetingAgentCore/SystemSpeechTranscriber.swift
+++ b/Sources/MeetingAgentCore/SystemSpeechTranscriber.swift
@@ -175,14 +175,16 @@ final class SystemSpeechTranscriber: AudioFrameTranscriber {
         try await start(
             transcriptURL: transcriptURL,
             localeIdentifier: localeIdentifier,
-            environment: .live
+            environment: .live,
+            transcriptUpdateSink: nil
         )
     }
 
     static func start(
         transcriptURL: URL,
         localeIdentifier: String,
-        environment: SystemSpeechEnvironment
+        environment: SystemSpeechEnvironment,
+        transcriptUpdateSink: TranscriptUpdateSink? = nil
     ) async throws -> SystemSpeechTranscriber {
         try await requestAuthorization(authorizer: environment.authorizer)
 
@@ -194,7 +196,12 @@ final class SystemSpeechTranscriber: AudioFrameTranscriber {
         let request = environment.requestFactory()
         request.configureForDictation()
 
-        let writer = try environment.writerFactory(transcriptURL)
+        let writer: SystemSpeechWriting
+        if let transcriptUpdateSink {
+            writer = SystemSpeechUpdateSinkWriter(sink: transcriptUpdateSink)
+        } else {
+            writer = try environment.writerFactory(transcriptURL)
+        }
         let transcriber = SystemSpeechTranscriber(request: request, writer: writer)
         transcriber.task = recognizer.recognitionTask(with: request, localeIdentifier: localeIdentifier, writer: writer)
 
@@ -221,6 +228,22 @@ final class SystemSpeechTranscriber: AudioFrameTranscriber {
             throw ProbeError.speechRecognition("Speech recognition permission is \(status)")
         }
     }
+}
+
+private final class SystemSpeechUpdateSinkWriter: SystemSpeechWriting {
+    private let sink: TranscriptUpdateSink
+
+    init(sink: TranscriptUpdateSink) {
+        self.sink = sink
+    }
+
+    func replace(with segments: [TranscriptSegment]) throws {
+        for segment in segments {
+            sink.receive(.upsert(segment))
+        }
+    }
+
+    func close() throws {}
 }
 
 private extension SystemSpeechRecognizing {

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -286,7 +286,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertTrue(workspaceSource.contains("Label(\"Copy Summary\", systemImage: \"doc.on.clipboard\")"))
         XCTAssertTrue(workspaceSource.contains(".disabled(isRecording || meeting.summaryURL == nil)"))
         XCTAssertTrue(workspaceSource.contains("Label(\"Export Transcript\", systemImage: \"doc.text\")"))
-        XCTAssertTrue(workspaceSource.contains(".disabled(isRecording || meeting.transcriptURL == nil)"))
+        XCTAssertTrue(workspaceSource.contains(".disabled(isRecording || meeting.transcriptJSONURL == nil)"))
         XCTAssertTrue(workspaceSource.contains("Label(\"Export Meeting JSON\", systemImage: \"curlybraces\")"))
         XCTAssertTrue(workspaceSource.contains("Label(\"Export SRT\", systemImage: \"captions.bubble\")"))
         XCTAssertTrue(workspaceSource.contains("Label(\"Export VTT\", systemImage: \"captions.bubble\")"))

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -528,11 +528,10 @@ final class MeetingAgentViewModelTests: XCTestCase {
         )
         try await viewModel.startRecording(for: target)
         let record = try XCTUnwrap(viewModel.meetings.first)
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
+        try FileTranscriptRepository().saveCaptionDocument(summaryCaptionDocument([
             TranscriptSegment(id: "segment-1", text: "Confirm launch owner.", language: "en-US", isFinal: true),
             TranscriptSegment(id: "partial", text: "partial", language: "en-US", isFinal: false)
-        ])
+        ]), for: record)
 
         viewModel.drainRecordingFrames()
 
@@ -564,8 +563,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
         }
 
         let record = try XCTUnwrap(viewModel.meetings.first)
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
+        try FileTranscriptRepository().saveCaptionDocument(summaryCaptionDocument([
             TranscriptSegment(
                 id: "file-1",
                 text: "File replay should not replace active captions.",
@@ -573,7 +571,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
                 isFinal: true,
                 speechFinal: true
             )
-        ])
+        ]), for: record)
 
         viewModel.selectMeeting(record.id)
         await viewModel.waitForLiveCaptionReplayForTesting()
@@ -588,8 +586,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
     func testSelectingCompletedMeetingDuringActiveRecordingKeepsActiveRealtimeCaptions() async throws {
         let fixture = try ViewModelRecorderFixture()
         let completed = try fixture.store.createMeeting(name: "Completed Meeting", startedAt: Date(timeIntervalSince1970: 0)).record
-        let completedWriter = try TranscriptFileWriter(url: XCTUnwrap(completed.transcriptURL))
-        try completedWriter.replace(with: [
+        try FileTranscriptRepository().saveCaptionDocument(summaryCaptionDocument([
             TranscriptSegment(
                 id: "completed-1",
                 text: "Completed meeting replay should stay inactive.",
@@ -597,7 +594,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
                 isFinal: true,
                 speechFinal: true
             )
-        ])
+        ]), for: completed)
         let target = AudioCaptureTarget(processID: 10, displayName: "zoom.us", bundleIdentifier: "us.zoom.xos")
         let viewModel = MeetingAgentViewModel(
             store: fixture.store,
@@ -2067,9 +2064,11 @@ final class MeetingAgentViewModelTests: XCTestCase {
             label: "Allan"
         )
 
-        let document = try TranscriptFileWriter.readDocument(from: XCTUnwrap(stored.record.transcriptJSONURL))
-        XCTAssertEqual(document.segments.first?.speakerLabel, "Allan")
-        XCTAssertEqual(try String(contentsOf: XCTUnwrap(stored.record.transcriptURL), encoding: .utf8), "Allan:\nHello\n")
+        let document = try FileTranscriptRepository().loadCaptionDocument(for: stored.record)
+        XCTAssertEqual(document.turns.first?.speakerLabel, "Allan")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: try XCTUnwrap(stored.record.transcriptJSONURL).deletingLastPathComponent().appendingPathComponent("transcript.txt").path
+        ))
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.speaker.label, "Allan")
         XCTAssertEqual(viewModel.statusText, "Speaker label updated")
     }
@@ -2142,9 +2141,11 @@ final class MeetingAgentViewModelTests: XCTestCase {
             text: "Corrected text"
         )
 
-        let document = try TranscriptFileWriter.readDocument(from: XCTUnwrap(stored.transcriptJSONURL))
-        XCTAssertEqual(document.segments.first?.text, "Corrected text")
-        XCTAssertEqual(try String(contentsOf: XCTUnwrap(stored.transcriptURL), encoding: .utf8), "User A:\nCorrected text\n")
+        let document = try FileTranscriptRepository().loadCaptionDocument(for: stored)
+        XCTAssertEqual(document.turns.first?.text, "Corrected text")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: try XCTUnwrap(stored.transcriptJSONURL).deletingLastPathComponent().appendingPathComponent("transcript.txt").path
+        ))
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "Corrected text")
         XCTAssertFalse(FileManager.default.fileExists(atPath: try XCTUnwrap(stored.summaryJSONURL).path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: try XCTUnwrap(stored.summaryMarkdownURL).path))
@@ -2202,10 +2203,9 @@ final class MeetingAgentViewModelTests: XCTestCase {
             "First section should stay",
             "Corrected second section"
         ])
-        XCTAssertEqual(
-            try String(contentsOf: XCTUnwrap(stored.record.transcriptURL), encoding: .utf8),
-            "User A:\nFirst section should stay\nCorrected second section\n"
-        )
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: try XCTUnwrap(stored.record.transcriptJSONURL).deletingLastPathComponent().appendingPathComponent("transcript.txt").path
+        ))
         XCTAssertEqual(viewModel.liveCaptionTurns.first?.originalText, "First section should stay\nCorrected second section")
     }
 
@@ -2734,11 +2734,9 @@ final class MeetingAgentViewModelTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
         let store = MeetingStore(baseDirectory: root)
         let record = try store.createMeeting(name: "Demo", startedAt: Date()).record
-        let transcriptWriter = try TranscriptFileWriter(url: XCTUnwrap(record.transcriptURL))
-        try transcriptWriter.replace(with: [
+        try FileTranscriptRepository().saveCaptionDocument(summaryCaptionDocument([
             TranscriptSegment(text: "old", language: "en-US", sourceProvider: "test")
-        ])
-        try transcriptWriter.close()
+        ]), for: record)
         try MeetingSummaryWriter.write(MeetingSummary(
             overview: "old summary",
             keyTopics: [],
@@ -2996,7 +2994,9 @@ final class MeetingAgentViewModelTests: XCTestCase {
         let store = MeetingStore(baseDirectory: root)
         let stored = try store.createMeeting(name: "Google Meet", startedAt: Date(timeIntervalSince1970: 100)).record
         FileManager.default.createFile(atPath: stored.audioURL!.path, contents: Data([0x52, 0x49, 0x46, 0x46]))
-        try "previous transcript".write(to: stored.transcriptURL!, atomically: true, encoding: .utf8)
+        try FileTranscriptRepository().saveCaptionDocument(summaryCaptionDocument([
+            TranscriptSegment(text: "previous transcript", language: "en-US", sourceProvider: "test")
+        ]), for: stored)
         let viewModel = MeetingAgentViewModel(
             store: store,
             speechConfiguration: SpeechTranscriptionConfiguration(

--- a/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift
@@ -464,17 +464,17 @@ final class MeetingRecorderTests: XCTestCase {
 
         _ = fixture.recorder.drainTranscriptUpdates()
 
-        XCTAssertEqual(try String(contentsOf: XCTUnwrap(record.transcriptURL), encoding: .utf8), "")
-        XCTAssertEqual(
-            try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL)).segments,
-            []
-        )
+        XCTAssertNil(record.transcriptURL)
+        XCTAssertTrue(try MeetingTranscriptStore.readDocument(from: XCTUnwrap(record.transcriptJSONURL)).turns.isEmpty)
 
         _ = try fixture.recorder.stopRecording(at: Date(timeIntervalSince1970: 200))
 
-        let document = try TranscriptFileWriter.readDocument(from: XCTUnwrap(record.transcriptJSONURL))
-        XCTAssertEqual(document.segments.map(\.text), ["persist me"])
-        XCTAssertEqual(try String(contentsOf: XCTUnwrap(record.transcriptURL), encoding: .utf8), "User A:\npersist me\n")
+        let document = try MeetingTranscriptStore.readDocument(from: XCTUnwrap(record.transcriptJSONURL))
+        XCTAssertEqual(document.turns.map(\.text), ["persist me"])
+        let transcriptTextURL = try XCTUnwrap(record.transcriptJSONURL)
+            .deletingLastPathComponent()
+            .appendingPathComponent("transcript.txt")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: transcriptTextURL.path))
         XCTAssertEqual(try transcriptEventLogLineCount(for: record), 1)
     }
 
@@ -772,7 +772,7 @@ private func performanceEvents(at url: URL) throws -> [PerformanceEvent] {
 }
 
 private func transcriptEventLogLineCount(for record: MeetingRecord) throws -> Int {
-    let eventLogURL = try XCTUnwrap(record.transcriptURL)
+    let eventLogURL = try XCTUnwrap(record.transcriptJSONURL)
         .deletingLastPathComponent()
         .appendingPathComponent("transcript-events.jsonl")
     return try String(contentsOf: eventLogURL, encoding: .utf8)

--- a/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingStoreTests.swift
@@ -16,7 +16,7 @@ final class MeetingStoreTests: XCTestCase {
 
         XCTAssertEqual(created.record.name, "Google Chrome")
         XCTAssertEqual(created.record.audioURL?.lastPathComponent, "audio.wav")
-        XCTAssertEqual(created.record.transcriptURL?.lastPathComponent, "transcript.txt")
+        XCTAssertNil(created.record.transcriptURL)
         XCTAssertEqual(created.record.transcriptJSONURL?.lastPathComponent, "transcript.json")
         XCTAssertEqual(created.record.summaryURL?.lastPathComponent, "summary.md")
         XCTAssertEqual(created.record.summaryJSONURL?.lastPathComponent, "summary.json")

--- a/Tests/MeetingAgentCoreTests/OpenAIRealtimeTranscriptionProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/OpenAIRealtimeTranscriptionProviderTests.swift
@@ -27,7 +27,7 @@ final class OpenAIRealtimeTranscriptionProviderTests: XCTestCase {
         XCTAssertNil(event)
     }
 
-    func testProviderStartsSessionSendsConfigurationAndWritesCompletedSegments() async throws {
+    func testProviderStartsSessionSendsConfigurationAndPublishesCompletedSegmentsWithoutTranscriptFile() async throws {
         let transport = FakeRealtimeTranscriptionTransport()
         let updateSink = RecordingOpenAITranscriptUpdateSink()
         let transcriptURL = temporaryURL("transcript.txt")
@@ -55,11 +55,10 @@ final class OpenAIRealtimeTranscriptionProviderTests: XCTestCase {
         transcriber.finish()
         try await Task.sleep(nanoseconds: 50_000_000)
 
-        let document = try TranscriptFileWriter.readDocument(
-            from: transcriptURL.deletingPathExtension().appendingPathExtension("json")
-        )
-        XCTAssertEqual(document.segments.map(\.text), ["Hello world"])
-        XCTAssertEqual(document.segments.first?.sourceProvider, "openai-realtime-transcribe")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: transcriptURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: transcriptURL.deletingPathExtension().appendingPathExtension("json").path
+        ))
         XCTAssertEqual(updateSink.updates.count, 1)
         guard case .upsert(let updatedSegment) = updateSink.updates.first else {
             return XCTFail("Expected upsert update")

--- a/Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift
+++ b/Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift
@@ -5,7 +5,7 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
     func testUpsertAppendsEventWithoutImmediateTextSnapshot() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -13,15 +13,15 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "hello", isFinal: false)))
 
         XCTAssertEqual(store.currentDocument.segments.map(\.id), ["segment-1"])
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "")
-        XCTAssertEqual(try TranscriptFileWriter.readDocument(from: fixture.structuredURL), TranscriptDocument())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
+        XCTAssertTrue(try MeetingTranscriptStore.readDocument(from: fixture.structuredURL).turns.isEmpty)
         XCTAssertEqual(try fixture.eventLogLineCount(), 1)
     }
 
-    func testDebouncedSnapshotWritesCompleteArtifacts() throws {
+    func testDebouncedSnapshotWritesCaptionDocumentOnly() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 2,
             now: fixture.now
         )
@@ -30,15 +30,15 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         fixture.currentDate = Date(timeIntervalSince1970: 3)
         try store.apply(.upsert(TranscriptSegment(id: "segment-2", text: "world", isFinal: true)))
 
-        let document = try TranscriptFileWriter.readDocument(from: fixture.structuredURL)
-        XCTAssertEqual(document.segments.map(\.id), ["segment-1", "segment-2"])
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nhello world\n")
+        let document = try MeetingTranscriptStore.readDocument(from: fixture.structuredURL)
+        XCTAssertEqual(document.turns.map(\.id), ["segment-1", "segment-2"])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
     }
 
     func testSnapshotWritesCaptionDocumentForRepositoryHydration() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -69,7 +69,7 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
     func testDraftTranslationPatchDoesNotSnapshotBeforeDebounce() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -83,14 +83,14 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         ))
 
         XCTAssertEqual(store.currentDocument.segments.first?.translatedText, "确认负责人。")
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
         XCTAssertEqual(try fixture.eventLogLineCount(), 2)
     }
 
     func testFinalTranslationPatchForcesSnapshot() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -103,21 +103,18 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
             isFinal: true
         ))
 
-        let document = try TranscriptFileWriter.readDocument(from: fixture.structuredURL)
-        XCTAssertEqual(document.segments.first?.translatedText, "确认负责人。")
-        XCTAssertEqual(document.segments.first?.translationIsFinal, true)
         let captionDocument = try FileTranscriptRepository().loadCaptionDocument(for: fixture.record)
         XCTAssertEqual(captionDocument.turns.first?.translatedText, "确认负责人。")
         XCTAssertEqual(captionDocument.turns.first?.translationTargetLocale, "zh-CN")
         XCTAssertEqual(captionDocument.turns.first?.translationIsFinal, true)
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nConfirm owner.\n")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
         XCTAssertEqual(try fixture.eventLogLineCount(), 2)
     }
 
     func testCloseFlushesFinalSnapshot() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -125,21 +122,26 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "hello", isFinal: true)))
         try store.close()
 
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nhello\n")
         XCTAssertEqual(
-            try TranscriptFileWriter.readDocument(from: fixture.structuredURL).segments.map(\.id),
+            try MeetingTranscriptStore.readDocument(from: fixture.structuredURL).turns.map(\.id),
             ["segment-1"]
         )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
     }
 
     func testRecoversFromSnapshotPlusEventLog() throws {
         let fixture = try StoreFixture()
-        try TranscriptFileWriter(url: fixture.transcriptURL).replace(with: [
-            TranscriptSegment(id: "snapshot-segment", text: "from snapshot", isFinal: true)
-        ])
+        try FileTranscriptRepository().saveCaptionDocument(CaptionDocument(turns: [
+            CaptionTurn(
+                id: "snapshot-segment",
+                sections: [CaptionSection(id: "snapshot-segment-section", text: "from snapshot")],
+                state: .final,
+                source: CaptionTurnSource(providerID: "legacy")
+            )
+        ]), for: fixture.record)
         var currentDate = Date(timeIntervalSince1970: 0)
         let firstStore = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: { currentDate }
         )
@@ -147,7 +149,7 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
 
         currentDate = Date(timeIntervalSince1970: 1)
         let recovered = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: { currentDate }
         )
@@ -155,15 +157,16 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         XCTAssertEqual(recovered.currentDocument.segments.map(\.id), ["snapshot-segment", "event-segment"])
         try recovered.flushSnapshot()
         XCTAssertEqual(
-            try TranscriptFileWriter.readDocument(from: fixture.structuredURL).segments.map(\.id),
+            try MeetingTranscriptStore.readDocument(from: fixture.structuredURL).turns.map(\.id),
             ["snapshot-segment", "event-segment"]
         )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
     }
 
-    func testReplaceWithPlainTextForcesSnapshotAndClearsStructuredDocument() throws {
+    func testReplaceWithPlainTextForcesEmptyCaptionSnapshotWithoutTextArtifact() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -171,15 +174,14 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         try store.apply(.upsert(TranscriptSegment(id: "segment-1", text: "hello", isFinal: true)))
         try store.apply(.replaceWithPlainText("Speech recognition unavailable"))
 
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "Speech recognition unavailable\n")
-        XCTAssertTrue(try TranscriptFileWriter.readDocument(from: fixture.structuredURL).segments.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
         XCTAssertTrue(try FileTranscriptRepository().loadCaptionDocument(for: fixture.record).turns.isEmpty)
     }
 
     func testReplaceAllForcesSnapshotAndCanBeReplayed() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -189,9 +191,9 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
             TranscriptSegment(id: "segment-2", text: "second", isFinal: true)
         ]))
 
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "User A:\nfirst second\n")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
         let recovered = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -201,7 +203,7 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
     func testRecoveryReplaysTranslationPatchAndPlainTextReplacement() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -214,7 +216,7 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
             isFinal: true
         ))
         let recoveredTranslation = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -223,21 +225,21 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
 
         try store.apply(.replaceWithPlainText("Speech recognition unavailable"))
         let recoveredPlainText = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
         try recoveredPlainText.flushSnapshot()
 
         XCTAssertTrue(recoveredPlainText.currentDocument.segments.isEmpty)
-        XCTAssertEqual(try String(contentsOf: fixture.transcriptURL, encoding: .utf8), "Speech recognition unavailable\n")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
         XCTAssertTrue(try FileTranscriptRepository().loadCaptionDocument(for: fixture.record).turns.isEmpty)
     }
 
     func testTranslationPatchRejectsBlankInputs() throws {
         let fixture = try StoreFixture()
         let store = try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         )
@@ -268,7 +270,7 @@ final class RecordingTranscriptPersistenceStoreTests: XCTestCase {
         try #"{"type":"upsert"}"#.write(to: fixture.eventLogURL, atomically: true, encoding: .utf8)
 
         XCTAssertThrowsError(try RecordingTranscriptPersistenceStore(
-            transcriptURL: fixture.transcriptURL,
+            transcriptJSONURL: fixture.structuredURL,
             snapshotInterval: 10,
             now: fixture.now
         ))
@@ -298,7 +300,7 @@ private final class StoreFixture {
             startedAt: currentDate,
             endedAt: nil,
             audioURL: directory.appendingPathComponent("audio.wav"),
-            transcriptURL: transcriptURL,
+            transcriptURL: nil,
             transcriptJSONURL: structuredURL
         )
     }

--- a/Tests/MeetingAgentCoreTests/SystemSpeechTranscriberTests.swift
+++ b/Tests/MeetingAgentCoreTests/SystemSpeechTranscriberTests.swift
@@ -105,6 +105,30 @@ final class SystemSpeechTranscriberTests: XCTestCase {
         XCTAssertEqual(fixture.task.finishCallCount, 1)
     }
 
+    func testStartWithTranscriptUpdateSinkPublishesUpdatesWithoutCreatingWriter() async throws {
+        let fixture = SystemSpeechFixture(status: .authorized)
+        let updateSink = RecordingSystemSpeechUpdateSink()
+        let transcriber = try await SystemSpeechTranscriber.start(
+            transcriptURL: URL(fileURLWithPath: "/tmp/transcript.txt"),
+            localeIdentifier: "en-US",
+            environment: fixture.environment(),
+            transcriptUpdateSink: updateSink
+        )
+
+        fixture.recognizer.send(.result(text: "Hello caption", isFinal: true))
+
+        XCTAssertTrue(fixture.writer.replacedSegments.isEmpty)
+        XCTAssertEqual(updateSink.updates.count, 1)
+        guard case .upsert(let segment) = updateSink.updates.first else {
+            return XCTFail("Expected upsert update")
+        }
+        XCTAssertEqual(segment.text, "Hello caption")
+        XCTAssertEqual(segment.sourceProvider, "local")
+        XCTAssertTrue(segment.isFinal)
+
+        transcriber.finish()
+    }
+
     func testAppendConvertsAudioFrameAndForwardsBuffer() async throws {
         let fixture = SystemSpeechFixture(status: .authorized)
         let transcriber = try await SystemSpeechTranscriber.start(
@@ -236,6 +260,14 @@ private final class FakeSystemSpeechWriter: SystemSpeechWriting {
 
     func close() throws {
         closeCallCount += 1
+    }
+}
+
+private final class RecordingSystemSpeechUpdateSink: TranscriptUpdateSink {
+    var updates: [TranscriptSegmentUpdate] = []
+
+    func receive(_ update: TranscriptSegmentUpdate) {
+        updates.append(update)
     }
 }
 

--- a/Tests/MeetingAgentCoreTests/TranscriptConsumptionArchitectureTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptConsumptionArchitectureTests.swift
@@ -22,4 +22,19 @@ final class TranscriptConsumptionArchitectureTests: XCTestCase {
         )
         XCTAssertFalse(exportSource.contains("TranscriptFileWriter.readDocument(from:"), "MeetingExportService.swift")
     }
+
+    func testRealtimeRecordingPersistenceDoesNotUseLegacyTranscriptFileBridge() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let realtimeFiles = [
+            "Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift",
+            "Sources/MeetingAgentCore/MeetingRecorder.swift"
+        ]
+
+        for path in realtimeFiles {
+            let source = try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+            XCTAssertFalse(source.contains("TranscriptFileWriter"), path)
+            XCTAssertFalse(source.contains("FileBackedTranscriptUpdateSink"), path)
+            XCTAssertFalse(source.contains("transcript.txt"), path)
+        }
+    }
 }

--- a/docs/mistakes/2026-05-15T04-35-04Z.md
+++ b/docs/mistakes/2026-05-15T04-35-04Z.md
@@ -1,0 +1,13 @@
+# [144] Keep SwiftPM focused verification serial
+
+**Date**: 2026-05-15
+**Category**: test-mistake
+
+### What went wrong
+While verifying the caption-only persistence change, two `swift test --filter ...` commands were launched in parallel in the same worktree, causing SwiftPM to wait on the shared `.build` directory.
+
+### Correct approach
+Run SwiftPM focused tests and coverage commands one at a time in a worktree, even when the commands look independent.
+
+### How to avoid
+Before starting any SwiftPM command, check that no other SwiftPM command is already running in the same worktree.

--- a/docs/superpowers/plans/2026-05-15-caption-only-transcript-persistence.md
+++ b/docs/superpowers/plans/2026-05-15-caption-only-transcript-persistence.md
@@ -1,0 +1,138 @@
+# Caption-Only Transcript Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove redundant `transcript.txt` persistence from new realtime meeting flows while preserving on-demand text export from `CaptionDocument`.
+
+**Architecture:** New meetings store only `transcript.json` for transcript state. Active recording and retry paths save `CaptionDocument` snapshots directly; UI and exports render text from that document when needed. `TranscriptFileWriter` remains for legacy isolated tests but leaves the realtime persistence boundary.
+
+**Tech Stack:** Swift 5.9, SwiftPM, XCTest, existing `CaptionDocument`, `MeetingTranscriptStore`, `TranscriptRepository`, `make test`.
+
+---
+
+### Task 1: Stop Creating New `transcript.txt` Metadata
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingStore.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingStoreTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Update the create-meeting test to expect `record.transcriptURL == nil` and `record.transcriptJSONURL?.lastPathComponent == "transcript.json"`.
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter MeetingStoreTests`
+Expected: failure because `MeetingStore.createMeeting` still sets `transcriptURL`.
+
+- [ ] **Step 3: Implement**
+
+In `MeetingStore.createMeeting`, set `transcriptURL: nil` and keep `transcriptJSONURL`.
+
+- [ ] **Step 4: Verify**
+
+Run: `swift test --filter MeetingStoreTests`
+Expected: pass.
+
+### Task 2: Make Active Segment Persistence Caption-Only
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift`
+- Modify: `Sources/MeetingAgentCore/MeetingRecorder.swift`
+- Modify: `Tests/MeetingAgentCoreTests/RecordingTranscriptPersistenceStoreTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingRecorderTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Change `RecordingTranscriptPersistenceStoreTests` so fixtures pass a `transcriptJSONURL` or directory, and assert `transcript.txt` is not created after upsert, forced snapshot, close, replaceAll, and plain-text failure updates.
+
+- [ ] **Step 2: Run focused tests**
+
+Run: `swift test --filter RecordingTranscriptPersistenceStoreTests`
+Expected: failure from old initializer/signature and text-file assertions.
+
+- [ ] **Step 3: Implement caption-only store**
+
+Update `RecordingTranscriptPersistenceStore` to accept `transcriptJSONURL`. Initialize from `MeetingTranscriptStore.readDocument(from:)`, convert that caption document to a `TranscriptDocument` for the accumulator, replay existing events, and write only encoded `CaptionDocument` snapshots to `transcriptJSONURL`.
+
+- [ ] **Step 4: Update recorder sink**
+
+Change `RecordingTranscriptUpdateSink` to initialize from `transcriptJSONURL` or the meeting directory instead of `transcriptURL`. The active recorder should start transcription when `transcriptJSONURL != nil`, while still passing a scratch URL to provider APIs that still require one.
+
+- [ ] **Step 5: Verify**
+
+Run: `swift test --filter RecordingTranscriptPersistenceStoreTests`
+Run: `swift test --filter MeetingRecorderTests`
+Expected: pass.
+
+### Task 3: Remove Retry and Edit Writes to Rendered Text
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Modify: `Sources/MeetingAgentCore/WhisperTranscriptionProvider.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+- Modify: `Tests/MeetingAgentCoreTests/WhisperTranscriptionProviderTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Add or update tests so retry transcription succeeds when `record.transcriptURL == nil` and only `transcriptJSONURL` exists. Update edit tests to assert no `transcript.txt` is created after speaker or segment edits.
+
+- [ ] **Step 2: Run focused tests**
+
+Run: `swift test --filter MeetingAgentViewModelTests`
+Expected: failure where retry and edit paths still require or write `transcriptURL`.
+
+- [ ] **Step 3: Implement retry**
+
+In retry flow, require `audioURL` and `transcriptJSONURL`. For Deepgram retry, save `document.captionDocument` through `transcriptRepository`. For provider retry paths that return segment updates, route final segments into a caption document and save it without `FileBackedTranscriptUpdateSink`.
+
+- [ ] **Step 4: Implement edit persistence**
+
+Rename `saveCaptionDocumentAndRenderedText` to `saveCaptionDocument` and remove the `transcriptURL` write.
+
+- [ ] **Step 5: Verify**
+
+Run: `swift test --filter MeetingAgentViewModelTests`
+Run: `swift test --filter WhisperTranscriptionProviderTests`
+Expected: pass or only unrelated pre-existing failures.
+
+### Task 4: Update UI Readiness and Export Conditions
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Modify: `Sources/MeetingAgentApp/TodayAgendaView.swift`
+- Modify: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] **Step 1: Write failing source/layout tests**
+
+Update tests that guard transcript export/readiness to assert source does not disable export solely on `meeting.transcriptURL == nil`.
+
+- [ ] **Step 2: Implement UI checks**
+
+Change export transcript enablement and agenda readiness to use `transcriptJSONURL` or existing artifact snapshot state.
+
+- [ ] **Step 3: Verify**
+
+Run: `swift test --filter MainWindowViewLayoutTests`
+Expected: pass.
+
+### Task 5: Architecture Guard and Full Verification
+
+**Files:**
+- Modify: `Tests/MeetingAgentCoreTests/TranscriptConsumptionArchitectureTests.swift`
+- Possibly modify: `Tests/MeetingAgentCoreTests/TranscriptSegmentAccumulatorTests.swift`
+
+- [ ] **Step 1: Add architecture guard**
+
+Add a source-level regression that active realtime files do not contain `TranscriptFileWriter.readDocument`, `FileBackedTranscriptUpdateSink`, or direct `transcript.txt` writes in `RecordingTranscriptPersistenceStore` / `MeetingRecorder`.
+
+- [ ] **Step 2: Run focused guards**
+
+Run: `swift test --filter TranscriptConsumptionArchitectureTests`
+Expected: pass after implementation.
+
+- [ ] **Step 3: Run required verification**
+
+Run: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/tmp/meeting-agent-issue-144-coverage make test`
+Expected: pass with coverage gate.
+

--- a/docs/superpowers/specs/2026-05-15-caption-only-transcript-persistence-design.md
+++ b/docs/superpowers/specs/2026-05-15-caption-only-transcript-persistence-design.md
@@ -1,0 +1,52 @@
+# Caption-Only Transcript Persistence Design
+
+## Issue
+
+GitHub issue #144 asks whether realtime caption persistence should keep the old `TranscriptFileWriter` bridge. The approved decision is to remove the redundant legacy transcript artifact from new realtime meetings.
+
+## User Intent
+
+New recordings should treat `CaptionDocument` in `transcript.json` as the only persisted realtime subtitle source of truth. The app may still export a transcript text file on demand, but it must not maintain `transcript.txt` as a parallel cache for active recording, retry, or edit flows.
+
+## Requirements
+
+- New meetings do not receive a `transcriptURL` pointing at `transcript.txt`.
+- Active recording writes realtime captions through a caption-first store boundary.
+- Stopping or finalizing a recording cannot overwrite a populated `CaptionDocument` with an empty legacy transcript document.
+- Retry transcription writes a new `CaptionDocument` snapshot, not a legacy rendered transcript.
+- UI readiness and export affordances use `transcriptJSONURL` or in-memory transcript state instead of `transcriptURL`.
+- Text transcript export remains available by rendering `CaptionDocument` at export time.
+
+## Non-Requirements
+
+- Do not delete the `TranscriptFileWriter` type in this issue. It still supports older tests and isolated non-realtime compatibility code.
+- Do not migrate existing user metadata files in place. Existing decoded `transcriptURL` values may remain for old meetings, but new writes should not depend on them.
+- Do not remove subtitle export, summary generation, meeting export, or knowledge package flows.
+
+## Considered Approaches
+
+1. Keep `transcript.txt` as a documented backup bridge.
+   - Lowest code churn, but preserves the ambiguity the issue is trying to remove.
+2. Remove legacy rendered text from active recording only.
+   - Improves the main path, but retry and edit flows would still maintain the redundant artifact.
+3. Remove new-meeting `transcript.txt` persistence across active recording, retry, edits, and UI readiness.
+   - Best matches the approved product direction. Export can still render a text file when the user asks for one.
+
+## Selected Approach
+
+Use approach 3. `transcript.json` remains the meeting transcript repository artifact. `transcript.txt` is no longer created for new meetings and no longer updated by active recording, retry, or edit flows. Any remaining `TranscriptFileWriter` usage must be outside the new realtime persistence boundary.
+
+## Architecture
+
+`MeetingStore` creates new records with `transcriptURL == nil` and `transcriptJSONURL == <meeting>/transcript.json`. `MeetingRecorder` creates a recording update sink from the transcript JSON location. Segment-style provider updates are reduced into a `CaptionDocument` and saved through the same JSON file. Speech event providers continue using `MeetingTranscriptStore`.
+
+Retry transcription converts provider segments into a `CaptionDocument` and saves that document through `TranscriptRepository`. UI actions that previously checked `transcriptURL` now check for `transcriptJSONURL` or hydrated transcript state. Exported transcript text is generated on demand from `CaptionDocument`.
+
+## Testing
+
+- `MeetingStoreTests` proves new meetings no longer include `transcriptURL`.
+- `RecordingTranscriptPersistenceStoreTests` proves segment updates persist `CaptionDocument` only and do not create `transcript.txt`.
+- `MeetingRecorderTests` proves stop/finalize preserves the caption document without a text transcript URL.
+- `MeetingAgentViewModelTests` proves retry and transcript edits update `CaptionDocument` without writing rendered text.
+- App layout/source tests prove export and agenda readiness no longer depend on `transcriptURL`.
+


### PR DESCRIPTION
## Summary

Fixes #144

- Makes new realtime meetings persist captions through `transcript.json` only, without maintaining `transcript.txt`.
- Routes active recording, retry, local speech, and OpenAI realtime updates through caption/update sinks instead of legacy file writers when a sink exists.
- Updates UI readiness and export enablement to use caption JSON while preserving on-demand transcript export.

## Changes

- `Sources/MeetingAgentCore/RecordingTranscriptPersistenceStore.swift` - writes `CaptionDocument` snapshots only.
- `Sources/MeetingAgentCore/MeetingStore.swift` - stops assigning `transcriptURL` for new meetings.
- `Sources/MeetingAgentCore/MeetingRecorder.swift` - initializes active transcript persistence from `transcriptJSONURL`.
- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - retries and edits save caption JSON without rendered text artifacts.
- `Sources/MeetingAgentCore/SystemSpeechTranscriber.swift` / `OpenAIRealtimeTranscriptionProvider.swift` - avoid legacy writer creation when update sinks are present.
- `Sources/MeetingAgentApp` - checks transcript JSON for transcript readiness/export availability.
- Tests - cover caption-only persistence, stop/finalize behavior, retry/edit behavior, UI guards, and architecture boundary.

## Test plan

- [x] Build/lint: SwiftPM build through `make test` succeeded
- [x] Unit tests: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/tmp/meeting-agent-issue-144-coverage make test` passed, 895 tests, line 95.13%, method 94.07%
- [x] E2E/integration: not added; persistence boundary is covered by focused unit and architecture tests
- [x] Code review: PASS (manual Swift review; plovr code-review skill is TS/Java-specific)
- [x] Manual verification: source search/architecture guard confirms active recording persistence files do not use `TranscriptFileWriter`, `FileBackedTranscriptUpdateSink`, or `transcript.txt`