### PR TITLE
feat: clean caption-only configuration surface

### DIFF
--- a/Sources/MeetingAgentApp/MainWindowView.swift
+++ b/Sources/MeetingAgentApp/MainWindowView.swift
@@ -66,7 +66,6 @@ struct MainWindowView: View {
             case .settings:
                 SettingsView(
                     configuration: viewModel.speechConfiguration,
-                    profiles: BilingualPipelineFactory.builtInProfiles,
                     localeIdentifiers: MeetingAgentViewModel.supportedLocaleIdentifiers,
                     isRecording: viewModel.isRecording,
                     status: viewModel.speechConfigurationStatus,
@@ -423,7 +422,7 @@ private struct MeetingDetailView: View {
                 MeetingCommandCenterView(
                     meeting: meeting,
                     backToMeetings: backToMeetings,
-                    pipelineDisplayName: pipelineDisplayName(for: speechConfiguration),
+                    pipelineDisplayName: transcriptionChainDisplayName(for: speechConfiguration),
                     transcriptionLinkText: transcriptionLinkText(for: speechConfiguration),
                     transcriptionModelText: transcriptionModelText(for: speechConfiguration),
                     preflightText: preflightText,
@@ -468,10 +467,14 @@ private struct MeetingDetailView: View {
         }
     }
 
-    private func pipelineDisplayName(for configuration: SpeechTranscriptionConfiguration) -> String {
-        BilingualPipelineFactory.builtInProfiles
-            .first { $0.id == configuration.bilingualPipelineProfileID }?
-            .displayName ?? configuration.bilingualPipelineProfileID
+    private func transcriptionChainDisplayName(for configuration: SpeechTranscriptionConfiguration) -> String {
+        if configuration.usesDeepgram {
+            return "Deepgram Transcription"
+        }
+        if configuration.transcriptionExecutionMode == .hosted {
+            return "Hosted Transcription"
+        }
+        return "Local Transcription"
     }
 
     private func transcriptionLinkText(for configuration: SpeechTranscriptionConfiguration) -> String {
@@ -483,7 +486,7 @@ private struct MeetingDetailView: View {
 
     private func transcriptionModelText(for configuration: SpeechTranscriptionConfiguration) -> String {
         if configuration.usesDeepgram {
-            return modelDisplayName(configuration.deepgramModelID, in: BilingualPipelineFactory.hostedTranscriptionModelOptions)
+            return modelDisplayName(configuration.deepgramModelID, in: SpeechProviderCatalog.hostedTranscriptionModelOptions)
         }
         if configuration.hostedTranscriptionProviderID == SpeechTranscriptionConfiguration.defaultOpenAIRealtimeTranscriptionProviderID {
             return openAIRealtimeTranscriptionModelDisplayName(configuration.hostedTranscriptionModelID)
@@ -491,7 +494,7 @@ private struct MeetingDetailView: View {
         if configuration.transcriptionExecutionMode == .hosted {
             return modelDisplayName(
                 configuration.hostedTranscriptionModelID,
-                in: BilingualPipelineFactory.hostedTranscriptionModelOptions
+                in: SpeechProviderCatalog.hostedTranscriptionModelOptions
             )
         }
         if configuration.localTranscriptionProviderID == SpeechTranscriptionConfiguration.defaultLocalTranscriptionProviderID {
@@ -519,10 +522,10 @@ private struct MeetingDetailView: View {
     }
 
     private func providerDisplayName(_ providerID: String) -> String {
-        BilingualPipelineFactory.builtInRegistry.descriptor(id: providerID)?.displayName ?? providerID
+        SpeechProviderCatalog.builtInRegistry.descriptor(id: providerID)?.displayName ?? providerID
     }
 
-    private func modelDisplayName(_ modelID: String, in options: [BilingualPipelineFactory.ModelOption]) -> String {
+    private func modelDisplayName(_ modelID: String, in options: [SpeechProviderCatalog.ModelOption]) -> String {
         options.first { $0.id == modelID }?.displayName ?? modelID
     }
 
@@ -1361,7 +1364,7 @@ private struct UnifiedTranscriptView: View {
                 LazyVStack(alignment: .leading, spacing: 20) {
                     let groups = LiveCaptionSpeakerGroup.groups(from: turns)
                     ForEach(groups) { group in
-                        BilingualTranscriptGroup(
+                        CaptionTranscriptGroup(
                             group: group,
                             editSpeaker: group.speaker.identifier == nil ? nil : {
                                 if let firstTurn = group.turns.first {
@@ -1402,7 +1405,7 @@ private struct UnifiedTranscriptView: View {
 
 }
 
-private struct BilingualTranscriptGroup: View {
+private struct CaptionTranscriptGroup: View {
     let group: LiveCaptionSpeakerGroup
     var editSpeaker: (() -> Void)? = nil
 
@@ -1410,7 +1413,7 @@ private struct BilingualTranscriptGroup: View {
         VStack(alignment: .leading, spacing: 6) {
             speakerLabel
             ForEach(group.turns) { turn in
-                BilingualTranscriptBlock(
+                CaptionTranscriptBlock(
                     turn: turn
                 )
                 .id(turn.id)
@@ -1463,7 +1466,7 @@ private struct BilingualTranscriptGroup: View {
     }
 }
 
-private struct BilingualTranscriptBlock: View {
+private struct CaptionTranscriptBlock: View {
     let turn: LiveCaptionTurn
 
     var body: some View {

--- a/Sources/MeetingAgentApp/SettingsView.swift
+++ b/Sources/MeetingAgentApp/SettingsView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct SettingsView: View {
     let configuration: SpeechTranscriptionConfiguration
-    let profiles: [BilingualPipelineProfile]
     let localeIdentifiers: [String]
     let isRecording: Bool
     let status: SpeechConfigurationValidationStatus
@@ -14,7 +13,6 @@ struct SettingsView: View {
 
     init(
         configuration: SpeechTranscriptionConfiguration,
-        profiles: [BilingualPipelineProfile],
         localeIdentifiers: [String],
         isRecording: Bool,
         status: SpeechConfigurationValidationStatus,
@@ -22,7 +20,6 @@ struct SettingsView: View {
         save: @escaping (SpeechTranscriptionConfiguration) -> Void
     ) {
         self.configuration = configuration
-        self.profiles = profiles
         self.localeIdentifiers = localeIdentifiers
         self.isRecording = isRecording
         self.status = status
@@ -76,7 +73,7 @@ struct SettingsView: View {
                             }
                         } else {
                             Picker("Hosted Transcription Model", selection: $draft.hostedTranscriptionModelID) {
-                                ForEach(BilingualPipelineFactory.hostedTranscriptionModelOptions.filter { $0.id != "nova-3" }) { model in
+                                ForEach(SpeechProviderCatalog.hostedTranscriptionModelOptions.filter { $0.id != "nova-3" }) { model in
                                     Text(model.displayName).tag(model.id)
                                 }
                             }
@@ -89,7 +86,7 @@ struct SettingsView: View {
                         SecureField("OpenRouter API Key", text: openRouterAPIKeyBinding)
 
                         Picker("Hosted Summary Model", selection: $draft.hostedSummaryModelID) {
-                            ForEach(BilingualPipelineFactory.hostedSummaryModelOptions) { model in
+                            ForEach(SpeechProviderCatalog.hostedSummaryModelOptions) { model in
                                 Text(model.displayName).tag(model.id)
                             }
                         }
@@ -206,10 +203,10 @@ struct SettingsView: View {
             draft.deepgramModelID = SpeechTranscriptionConfiguration.defaultDeepgramModelID
             return
         }
-        if BilingualPipelineFactory.hostedTranscriptionModelOptions.contains(where: { $0.id == draft.hostedTranscriptionModelID }) {
+        if SpeechProviderCatalog.hostedTranscriptionModelOptions.contains(where: { $0.id == draft.hostedTranscriptionModelID }) {
             return
         }
-        draft.hostedTranscriptionModelID = BilingualPipelineFactory.hostedTranscriptionModelOptions.first?.id
+        draft.hostedTranscriptionModelID = SpeechProviderCatalog.hostedTranscriptionModelOptions.first?.id
             ?? SpeechTranscriptionConfiguration.defaultHostedTranscriptionModelID
     }
 

--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -241,20 +241,12 @@ public final class MeetingAgentViewModel: ObservableObject {
         speechConfiguration = SpeechTranscriptionConfiguration(
             provider: configuration.provider,
             localeIdentifier: configuration.localeIdentifier,
-            bilingualPipelineProfileID: Self.derivedBilingualPipelineProfileID(
-                transcriptionExecutionMode: configuration.transcriptionExecutionMode,
-                translationExecutionMode: configuration.translationExecutionMode
-            ),
             whisperBinaryPath: configuration.whisperBinaryPath,
             whisperModelPath: configuration.whisperModelPath,
             transcriptionExecutionMode: configuration.transcriptionExecutionMode,
-            translationExecutionMode: configuration.translationExecutionMode,
             localTranscriptionProviderID: configuration.localTranscriptionProviderID,
-            localTranslationProviderID: configuration.localTranslationProviderID,
             hostedTranscriptionProviderID: configuration.hostedTranscriptionProviderID,
-            hostedTranslationProviderID: configuration.hostedTranslationProviderID,
             hostedTranscriptionModelID: configuration.hostedTranscriptionModelID,
-            hostedTranslationModelID: configuration.hostedTranslationModelID,
             hostedSummaryModelID: configuration.hostedSummaryModelID,
             openRouterAPIKey: configuration.openRouterAPIKey,
             openAIRealtimeAPIKey: configuration.openAIRealtimeAPIKey,
@@ -1189,20 +1181,6 @@ public final class MeetingAgentViewModel: ObservableObject {
             sourceGoals = []
         }
         return sourceGoals.compactMap(normalizedMeetingGoal)
-    }
-
-    private static func derivedBilingualPipelineProfileID(
-        transcriptionExecutionMode: ProviderExecutionMode,
-        translationExecutionMode: ProviderExecutionMode
-    ) -> String {
-        switch (transcriptionExecutionMode, translationExecutionMode) {
-        case (.hosted, .hosted):
-            return "hosted-transcribe-hosted-translation"
-        case (.local, .local):
-            return "local-whisper-local-translation"
-        default:
-            return "local-whisper-hosted-translation"
-        }
     }
 
     nonisolated static func summaryProvider(

--- a/Sources/MeetingAgentCore/SpeechProviderCatalog.swift
+++ b/Sources/MeetingAgentCore/SpeechProviderCatalog.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum SpeechProviderCatalog {
+    public struct ModelOption: Codable, Equatable, Identifiable {
+        public var id: String
+        public var displayName: String
+
+        public init(id: String, displayName: String) {
+            self.id = id
+            self.displayName = displayName
+        }
+    }
+
+    public static let builtInRegistry = ProviderRegistry(descriptors: builtInProviderDescriptors)
+
+    public static let hostedTranscriptionModelOptions: [ModelOption] = [
+        ModelOption(id: "google/gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
+        ModelOption(id: "openai/gpt-4o-mini-transcribe", displayName: "GPT-4o Mini Transcribe"),
+        ModelOption(id: "nova-3", displayName: "Deepgram Nova 3")
+    ]
+
+    public static let hostedSummaryModelOptions: [ModelOption] = [
+        ModelOption(id: "openai/gpt-4.1-mini", displayName: "GPT-4.1 Mini"),
+        ModelOption(id: "google/gemini-2.5-flash", displayName: "Gemini 2.5 Flash")
+    ]
+
+    public static let builtInProviderDescriptors: [ProviderDescriptor] = [
+        ProviderDescriptor(id: "whisper-local", displayName: "Whisper Local", capability: .audioTranscription, executionMode: .local, supportedSourceLocales: ["*"], supportedTargetLocales: [], requiresNetwork: false, requiresAPIKey: false),
+        ProviderDescriptor(id: "macos-speech-local", displayName: "macOS Speech", capability: .audioTranscription, executionMode: .local, supportedSourceLocales: ["*"], supportedTargetLocales: [], requiresNetwork: false, requiresAPIKey: false),
+        ProviderDescriptor(id: "openrouter-transcribe", displayName: "OpenRouter Transcribe", capability: .audioTranscription, executionMode: .hosted, supportedSourceLocales: ["*"], supportedTargetLocales: [], requiresNetwork: true, requiresAPIKey: true),
+        ProviderDescriptor(id: "deepgram-transcribe", displayName: "Deepgram Transcribe", capability: .audioTranscription, executionMode: .hosted, supportedSourceLocales: ["*"], supportedTargetLocales: [], requiresNetwork: true, requiresAPIKey: true),
+        ProviderDescriptor(id: "openai-realtime-transcribe", displayName: "OpenAI Realtime Transcription", capability: .audioTranscription, executionMode: .hosted, supportedSourceLocales: ["*"], supportedTargetLocales: [], requiresNetwork: true, requiresAPIKey: true)
+    ]
+}

--- a/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
+++ b/Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift
@@ -21,16 +21,21 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
 
     public var provider: SpeechProvider
     public var localeIdentifier: String
+    // Legacy migration-only fields kept so older user defaults decode safely.
     public var bilingualPipelineProfileID: String
     public var whisperBinaryPath: String?
     public var whisperModelPath: String?
     public var transcriptionExecutionMode: ProviderExecutionMode
+    // Legacy migration-only fields kept out of active UI and new persisted settings.
     public var translationExecutionMode: ProviderExecutionMode
     public var localTranscriptionProviderID: String
+    // Legacy migration-only fields kept out of active UI and new persisted settings.
     public var localTranslationProviderID: String
     public var hostedTranscriptionProviderID: String
+    // Legacy migration-only fields kept out of active UI and new persisted settings.
     public var hostedTranslationProviderID: String
     public var hostedTranscriptionModelID: String
+    // Legacy migration-only fields kept out of active UI and new persisted settings.
     public var hostedTranslationModelID: String
     public var hostedSummaryModelID: String
     public var openRouterAPIKey: String?
@@ -178,17 +183,12 @@ public struct SpeechTranscriptionConfiguration: Codable, Equatable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(provider, forKey: .provider)
         try container.encode(localeIdentifier, forKey: .localeIdentifier)
-        try container.encode(bilingualPipelineProfileID, forKey: .bilingualPipelineProfileID)
         try container.encodeIfPresent(whisperBinaryPath, forKey: .whisperBinaryPath)
         try container.encodeIfPresent(whisperModelPath, forKey: .whisperModelPath)
         try container.encode(transcriptionExecutionMode, forKey: .transcriptionExecutionMode)
-        try container.encode(translationExecutionMode, forKey: .translationExecutionMode)
         try container.encode(localTranscriptionProviderID, forKey: .localTranscriptionProviderID)
-        try container.encode(localTranslationProviderID, forKey: .localTranslationProviderID)
         try container.encode(hostedTranscriptionProviderID, forKey: .hostedTranscriptionProviderID)
-        try container.encode(hostedTranslationProviderID, forKey: .hostedTranslationProviderID)
         try container.encode(hostedTranscriptionModelID, forKey: .hostedTranscriptionModelID)
-        try container.encode(hostedTranslationModelID, forKey: .hostedTranslationModelID)
         try container.encode(hostedSummaryModelID, forKey: .hostedSummaryModelID)
         try container.encodeIfPresent(openRouterAPIKey, forKey: .openRouterAPIKey)
         try container.encodeIfPresent(openAIRealtimeAPIKey, forKey: .openAIRealtimeAPIKey)

--- a/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
+++ b/Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift
@@ -402,6 +402,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
 
         XCTAssertTrue(source.contains("@State private var destination: MainWindowDestination = .today"))
         XCTAssertTrue(source.contains("SettingsView("))
+        XCTAssertFalse(source.contains("profiles: BilingualPipelineFactory.builtInProfiles"))
         XCTAssertFalse(source.contains("\"Whisper Binary Path\""))
         XCTAssertFalse(source.contains("\"Whisper Model Path\""))
         XCTAssertFalse(source.contains("\"STT Locale\""))
@@ -539,7 +540,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         let source = try String(contentsOf: sourceURL)
 
         XCTAssertTrue(source.contains("UnifiedTranscriptView("))
-        XCTAssertTrue(source.contains("BilingualTranscriptBlock("))
+        XCTAssertTrue(source.contains("CaptionTranscriptBlock("))
         XCTAssertTrue(source.contains("ScrollViewReader"))
         XCTAssertTrue(source.contains("LazyVStack"))
         XCTAssertTrue(source.contains("Text(turn.originalText)"))
@@ -551,7 +552,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         guard let unifiedRange = source.range(of: "private struct UnifiedTranscriptView") else {
             return XCTFail("UnifiedTranscriptView is missing")
         }
-        guard let groupRange = source.range(of: "private struct BilingualTranscriptGroup", range: unifiedRange.upperBound..<source.endIndex) else {
+        guard let groupRange = source.range(of: "private struct CaptionTranscriptGroup", range: unifiedRange.upperBound..<source.endIndex) else {
             return XCTFail("UnifiedTranscriptView boundary is missing")
         }
         let unifiedSource = source[unifiedRange.lowerBound..<groupRange.lowerBound]
@@ -576,14 +577,14 @@ final class MainWindowViewLayoutTests: XCTestCase {
 
         XCTAssertTrue(source.contains("LiveCaptionSpeakerGroup.groups(from: turns)"))
         XCTAssertTrue(source.contains("ForEach(group.turns)"))
-        XCTAssertTrue(source.contains("BilingualTranscriptBlock"))
+        XCTAssertTrue(source.contains("CaptionTranscriptBlock"))
     }
 
     func testTranscriptBlocksRenderOriginalTextOnly() throws {
         let source = try String(contentsOfFile: "Sources/MeetingAgentApp/MainWindowView.swift")
 
-        guard let blockRange = source.range(of: "private struct BilingualTranscriptBlock") else {
-            return XCTFail("BilingualTranscriptBlock is missing")
+        guard let blockRange = source.range(of: "private struct CaptionTranscriptBlock") else {
+            return XCTFail("CaptionTranscriptBlock is missing")
         }
         let blockSource = source[blockRange.lowerBound..<source.endIndex]
 
@@ -602,7 +603,7 @@ final class MainWindowViewLayoutTests: XCTestCase {
         XCTAssertFalse(source.contains(".id(group.turns.last?.id ?? group.id)"))
     }
 
-    func testBilingualTranscriptBlockDoesNotReserveBlankEditControlSpace() throws {
+    func testCaptionTranscriptBlockDoesNotReserveBlankEditControlSpace() throws {
         let source = try String(contentsOfFile: "Sources/MeetingAgentApp/MainWindowView.swift")
 
         XCTAssertTrue(source.contains("transcriptText\n            .frame(maxWidth: .infinity, alignment: .leading)"))

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -2820,7 +2820,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statusText, "Summary generated")
     }
 
-    func testSaveSpeechConfigurationPersistsBilingualSettings() throws {
+    func testSaveSpeechConfigurationPersistsCaptionOnlySettings() throws {
         let suiteName = "meeting-vm-settings-save-\(UUID().uuidString)"
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
@@ -2851,7 +2851,11 @@ final class MeetingAgentViewModelTests: XCTestCase {
         viewModel.saveSpeechConfiguration(configuration)
 
         var expectedConfiguration = configuration
-        expectedConfiguration.bilingualPipelineProfileID = "hosted-transcribe-hosted-translation"
+        expectedConfiguration.bilingualPipelineProfileID = SpeechTranscriptionConfiguration.defaultBilingualPipelineProfileID
+        expectedConfiguration.translationExecutionMode = .hosted
+        expectedConfiguration.localTranslationProviderID = SpeechTranscriptionConfiguration.defaultLocalTranslationProviderID
+        expectedConfiguration.hostedTranslationProviderID = SpeechTranscriptionConfiguration.defaultHostedTranslationProviderID
+        expectedConfiguration.hostedTranslationModelID = SpeechTranscriptionConfiguration.defaultHostedTranslationModelID
         XCTAssertEqual(viewModel.speechConfiguration, expectedConfiguration)
         XCTAssertEqual(try configurationStore.load(), expectedConfiguration)
         XCTAssertEqual(viewModel.statusText, "Settings saved")
@@ -2878,7 +2882,7 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.primaryChainPreflightSummary, "Primary chain ready")
     }
 
-    func testSaveSpeechConfigurationDerivesPipelineProfileFromStepModes() throws {
+    func testSaveSpeechConfigurationDropsLegacyPipelineProfileFromActiveSettings() throws {
         let suiteName = "meeting-vm-derived-profile-\(UUID().uuidString)"
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
@@ -2899,11 +2903,17 @@ final class MeetingAgentViewModelTests: XCTestCase {
 
         viewModel.saveSpeechConfiguration(staleProfileConfiguration)
 
-        XCTAssertEqual(viewModel.speechConfiguration.bilingualPipelineProfileID, "hosted-transcribe-hosted-translation")
-        XCTAssertEqual(try configurationStore.load().bilingualPipelineProfileID, "hosted-transcribe-hosted-translation")
+        XCTAssertEqual(
+            viewModel.speechConfiguration.bilingualPipelineProfileID,
+            SpeechTranscriptionConfiguration.defaultBilingualPipelineProfileID
+        )
+        XCTAssertEqual(
+            try configurationStore.load().bilingualPipelineProfileID,
+            SpeechTranscriptionConfiguration.defaultBilingualPipelineProfileID
+        )
     }
 
-    func testSaveSpeechConfigurationDerivesLocalAndMixedProfilesAndValidationStatus() throws {
+    func testSaveSpeechConfigurationKeepsLegacyProfileOutOfValidationStatus() throws {
         let suiteName = "meeting-vm-derived-profile-more-\(UUID().uuidString)"
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
@@ -2922,7 +2932,10 @@ final class MeetingAgentViewModelTests: XCTestCase {
             transcriptionExecutionMode: .local,
             translationExecutionMode: .local
         ))
-        XCTAssertEqual(viewModel.speechConfiguration.bilingualPipelineProfileID, "local-whisper-local-translation")
+        XCTAssertEqual(
+            viewModel.speechConfiguration.bilingualPipelineProfileID,
+            SpeechTranscriptionConfiguration.defaultBilingualPipelineProfileID
+        )
         XCTAssertEqual(viewModel.speechConfigurationStatus, .available)
 
         viewModel.saveSpeechConfiguration(SpeechTranscriptionConfiguration(
@@ -2934,7 +2947,10 @@ final class MeetingAgentViewModelTests: XCTestCase {
             transcriptionExecutionMode: .local,
             translationExecutionMode: .hosted
         ))
-        XCTAssertEqual(viewModel.speechConfiguration.bilingualPipelineProfileID, "local-whisper-hosted-translation")
+        XCTAssertEqual(
+            viewModel.speechConfiguration.bilingualPipelineProfileID,
+            SpeechTranscriptionConfiguration.defaultBilingualPipelineProfileID
+        )
     }
 
     func testSupportedLocaleIdentifiersIncludeInitialSettingsChoices() {

--- a/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
+++ b/Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift
@@ -9,9 +9,9 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.localTranscriptionProviderID, "whisper-local")
         XCTAssertEqual(configuration.hostedTranscriptionProviderID, "deepgram-transcribe")
         XCTAssertEqual(configuration.hostedSummaryModelID, "openai/gpt-4.1-mini")
-        XCTAssertEqual(BilingualPipelineFactory.hostedSummaryModelOptions.first?.id, "openai/gpt-4.1-mini")
+        XCTAssertEqual(SpeechProviderCatalog.hostedSummaryModelOptions.first?.id, "openai/gpt-4.1-mini")
         XCTAssertEqual(configuration.deepgramModelID, "nova-3")
-        XCTAssertFalse(BilingualPipelineFactory.builtInProviderDescriptors.contains {
+        XCTAssertFalse(SpeechProviderCatalog.builtInProviderDescriptors.contains {
             $0.capability == .textTranslation || $0.capability == .speechTranslation || $0.capability == .bilingualSubtitle
         })
     }
@@ -238,7 +238,7 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration.validationStatus(fileManager: .default), .available)
     }
 
-    func testConfigurationRoundTripsStepLevelProviderAndModelSettings() throws {
+    func testConfigurationPersistsActiveProviderAndModelSettingsOnly() throws {
         let suiteName = "meeting-agent-tests-\(UUID().uuidString)"
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { userDefaults.removePersistentDomain(forName: suiteName) }
@@ -271,8 +271,18 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
             JSONSerialization.jsonObject(with: persistedData) as? [String: Any]
         )
         XCTAssertNil(persistedObject["targetLocaleIdentifier"])
+        XCTAssertNil(persistedObject["bilingualPipelineProfileID"])
+        XCTAssertNil(persistedObject["translationExecutionMode"])
+        XCTAssertNil(persistedObject["localTranslationProviderID"])
+        XCTAssertNil(persistedObject["hostedTranslationProviderID"])
+        XCTAssertNil(persistedObject["hostedTranslationModelID"])
 
         var expected = configuration
+        expected.bilingualPipelineProfileID = SpeechTranscriptionConfiguration.defaultBilingualPipelineProfileID
+        expected.translationExecutionMode = .hosted
+        expected.localTranslationProviderID = SpeechTranscriptionConfiguration.defaultLocalTranslationProviderID
+        expected.hostedTranslationProviderID = SpeechTranscriptionConfiguration.defaultHostedTranslationProviderID
+        expected.hostedTranslationModelID = SpeechTranscriptionConfiguration.defaultHostedTranslationModelID
         expected.openAIRealtimeAPIKey = "realtime-key"
         expected.deepgramAPIKey = "deepgram-key"
         expected.deepgramModelID = "nova-2"
@@ -293,7 +303,12 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
           "whisperBinaryPath": "/opt/homebrew/bin/whisper-cli",
           "whisperModelPath": "/Users/allan/models/ggml-medium.bin",
           "transcriptionExecutionMode": "local",
-          "translationExecutionMode": "hosted"
+          "translationExecutionMode": "local",
+          "localTranslationProviderID": "legacy-local-translation",
+          "hostedTranscriptionProviderID": "openrouter-transcribe",
+          "hostedTranslationProviderID": "legacy-hosted-translation",
+          "hostedTranscriptionModelID": "google/gemini-2.5-flash",
+          "hostedTranslationModelID": "legacy-translation-model"
         }
         """
         userDefaults.set(Data(legacyConfiguration.utf8), forKey: "SpeechTranscriptionConfiguration")
@@ -301,6 +316,11 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         let loaded = try store.load()
 
         XCTAssertEqual(loaded.localeIdentifier, "zh-CN")
+        XCTAssertEqual(loaded.bilingualPipelineProfileID, "local-whisper-hosted-translation")
+        XCTAssertEqual(loaded.translationExecutionMode, .local)
+        XCTAssertEqual(loaded.localTranslationProviderID, "legacy-local-translation")
+        XCTAssertEqual(loaded.hostedTranslationProviderID, "legacy-hosted-translation")
+        XCTAssertEqual(loaded.hostedTranslationModelID, "legacy-translation-model")
         try store.save(loaded)
         let persistedData = try XCTUnwrap(userDefaults.data(forKey: "SpeechTranscriptionConfiguration"))
         let persistedObject = try XCTUnwrap(
@@ -308,6 +328,11 @@ final class SpeechTranscriptionConfigurationTests: XCTestCase {
         )
         XCTAssertEqual(persistedObject["localeIdentifier"] as? String, "zh-CN")
         XCTAssertNil(persistedObject["targetLocaleIdentifier"])
+        XCTAssertNil(persistedObject["bilingualPipelineProfileID"])
+        XCTAssertNil(persistedObject["translationExecutionMode"])
+        XCTAssertNil(persistedObject["localTranslationProviderID"])
+        XCTAssertNil(persistedObject["hostedTranslationProviderID"])
+        XCTAssertNil(persistedObject["hostedTranslationModelID"])
     }
 
     func testConfigurationStorePersistsAPIKeys() throws {

--- a/docs/superpowers/plans/2026-05-15-caption-only-configuration.md
+++ b/docs/superpowers/plans/2026-05-15-caption-only-configuration.md
@@ -1,0 +1,66 @@
+# Caption-Only Configuration Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove translation and bilingual concepts from the active caption-only settings and transcript UI surface while preserving legacy config decoding.
+
+**Architecture:** Treat old bilingual and translation settings as migration-only decode inputs. Keep active configuration, settings UI, and transcript rendering named around transcription, summary, and captions. Leave legacy translation artifacts untouched.
+
+**Tech Stack:** Swift 5.9, SwiftUI, XCTest, Swift Package Manager, repository `make test` coverage gate.
+
+---
+
+### Task 1: Make legacy translation configuration decode-only
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift`
+- Test: `Tests/MeetingAgentCoreTests/SpeechTranscriptionConfigurationTests.swift`
+
+- [ ] Add tests that decode JSON containing `bilingualPipelineProfileID`, `translationExecutionMode`, `localTranslationProviderID`, `hostedTranslationProviderID`, and `hostedTranslationModelID`.
+- [ ] Add tests that encoding `SpeechTranscriptionConfiguration.default` omits those legacy keys.
+- [ ] Replace first-class translation config properties with decode-only coding keys and legacy compatibility comments.
+- [ ] Run `swift test --filter SpeechTranscriptionConfigurationTests`.
+
+### Task 2: Save only active caption-era settings
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] Update settings save tests to assert transcription, summary, and credentials persist.
+- [ ] Remove derived bilingual profile logic from `saveSpeechConfiguration`.
+- [ ] Delete the now-unused derived profile helper.
+- [ ] Run `swift test --filter MeetingAgentViewModelTests/testSaveSpeechConfiguration`.
+
+### Task 3: Remove bilingual profile settings dependency
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/SettingsView.swift`
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] Remove the `profiles` property and initializer argument from `SettingsView`.
+- [ ] Stop passing `BilingualPipelineFactory.builtInProfiles` when constructing `SettingsView`.
+- [ ] Replace the meeting header pipeline display helper with a transcription-chain display helper.
+- [ ] Update layout tests to assert settings no longer receives built-in bilingual profiles.
+
+### Task 4: Rename caption-only transcript UI types
+
+**Files:**
+- Modify: `Sources/MeetingAgentApp/MainWindowView.swift`
+- Test: `Tests/MeetingAgentCoreTests/MainWindowViewLayoutTests.swift`
+
+- [ ] Rename `BilingualTranscriptGroup` to `CaptionTranscriptGroup`.
+- [ ] Rename `BilingualTranscriptBlock` to `CaptionTranscriptBlock`.
+- [ ] Update source-layout tests that reference those private view names.
+- [ ] Run `swift test --filter MainWindowViewLayoutTests`.
+
+### Task 5: Verify and commit
+
+**Files:**
+- All modified source, test, and plan/spec files.
+
+- [ ] Run `swift build --product MeetingAgentApp`.
+- [ ] Run required `make test`, using a worktree-specific `MEETING_AGENT_COVERAGE_SCRATCH_PATH` if the shared coverage scratch is busy.
+- [ ] Review `git diff --check` and `git status --short`.
+- [ ] Commit relevant files with `feat: clean caption-only configuration surface (#146)`.

--- a/docs/superpowers/specs/2026-05-15-caption-only-configuration-design.md
+++ b/docs/superpowers/specs/2026-05-15-caption-only-configuration-design.md
@@ -1,0 +1,34 @@
+# Caption-Only Configuration Cleanup Design
+
+## Context
+
+Issue #146 asks the active app surface to stop presenting realtime captions as a bilingual or translation pipeline. Active recording is caption-only, while old translation models and artifacts may remain for legacy data compatibility.
+
+## Requirements
+
+- Settings must expose only speech, transcription, summary model, and provider credentials.
+- `MainWindowView` must not depend on bilingual profiles to render settings.
+- Visible transcript UI implementation names should match caption-only behavior.
+- Old user defaults containing translation or bilingual keys must still decode safely.
+- New configuration saves should avoid writing legacy translation and bilingual keys.
+
+## Non-Requirements
+
+- Do not delete historical translation model types, stores, fixtures, or old tests that still protect legacy data.
+- Do not remove transcript segment translation fields used by old artifacts.
+- Do not introduce a realtime translation path.
+
+## Approach
+
+Keep legacy keys as decode-only migration inputs in `SpeechTranscriptionConfiguration`. Store them in a small legacy compatibility container so old defaults can be read, but encode only current caption-era fields. `MeetingAgentViewModel.saveSpeechConfiguration` should preserve current transcription and summary settings while dropping derived bilingual profile behavior.
+
+`SettingsView` should remove the `profiles` input and stop accepting `BilingualPipelineProfile`. It can still use transcription and summary model option constants until the larger factory is renamed in a future cleanup, but the settings entry point should no longer be driven by bilingual profiles.
+
+`MainWindowView` should pass settings without profiles and rename private transcript rendering views from `BilingualTranscriptGroup` / `BilingualTranscriptBlock` to `CaptionTranscriptGroup` / `CaptionTranscriptBlock`. Its meeting header should describe the active transcription chain directly rather than looking up a bilingual profile display name.
+
+## Test Plan
+
+- Add/adjust configuration tests so legacy bilingual/translation keys decode without throwing.
+- Assert newly encoded configuration JSON omits legacy bilingual and translation keys.
+- Update view-model settings tests so save behavior preserves transcription and summary fields while dropping legacy profile derivation.
+- Update source-layout tests to expect caption-only UI type names and no `BilingualPipelineFactory.builtInProfiles` settings dependency.


### PR DESCRIPTION
## Summary

Fixes #146

- Remove bilingual profile wiring from active settings and meeting detail display.
- Persist active transcription and summary configuration without writing legacy translation keys.
- Rename transcript UI implementation views around caption-only behavior.

## Changes

- Sources/MeetingAgentCore/SpeechProviderCatalog.swift - adds caption-era provider/model catalog for current app surfaces.
- Sources/MeetingAgentCore/SpeechTranscriptionConfiguration.swift - keeps old bilingual/translation keys decode-only and omits them from new persisted config.
- Sources/MeetingAgentCore/MeetingAgentViewModel.swift - drops derived bilingual profile handling during settings save.
- Sources/MeetingAgentApp/SettingsView.swift - removes profile input and uses speech provider options.
- Sources/MeetingAgentApp/MainWindowView.swift - removes bilingual profile display dependency and renames caption transcript views.
- Tests/MeetingAgentCoreTests/* - updates regression/source-layout coverage for caption-only configuration.

## Test plan

- [x] Build/lint: swift build --product MeetingAgentApp passed; git diff --check passed.
- [x] Unit tests: swift test --filter SpeechTranscriptionConfigurationTests, swift test --filter MeetingAgentViewModelTests/testSaveSpeechConfiguration, swift test --filter MainWindowViewLayoutTests passed.
- [x] Full verification: MEETING_AGENT_COVERAGE_SCRATCH_PATH=/private/tmp/meeting-agent-issue-146-coverage make test passed, 790 tests, coverage gate passed.
- [x] E2E/integration: skipped; no E2E convention for this settings/config surface.
- [x] Code review: PASS via Swift manual diff review after code-review skill fallback.
- [x] Manual verification: source search confirms app settings/detail no longer reference BilingualPipelineFactory/Profile/Transcript names.
