### PR TITLE
feat: enforce memory-only meeting consumption

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -625,15 +625,8 @@ public final class MeetingAgentViewModel: ObservableObject {
             throw ProbeError.invalidArguments("Meeting has no summary output URL")
         }
 
-        let consumptionView: TranscriptConsumptionView
-        if let selectedMeetingSessionState,
-           selectedMeetingSessionState.meetingID == meetingID,
-           !selectedMeetingSessionState.transcript.consumptionView.finalTurns.isEmpty {
-            consumptionView = selectedMeetingSessionState.transcript.consumptionView
-        } else {
-            let transcript = try transcriptRepository.loadCaptionDocument(for: meeting)
-            consumptionView = TranscriptConsumptionView.project(meetingID: meeting.id, document: transcript)
-        }
+        let session = try sessionState(for: meeting)
+        let consumptionView = session.transcript.consumptionView
         let progress = progressState(for: meeting)
         let provider = summaryProviderFactory(speechConfiguration)
         let summary = try await provider.generateSummary(
@@ -790,21 +783,15 @@ public final class MeetingAgentViewModel: ObservableObject {
 
     public func exportTranscript(for meetingID: UUID, to destinationURL: URL) throws {
         try export("Transcript", for: meetingID) { record in
-            if let session = selectedSession(for: record.id) {
-                try exportService.exportTranscript(for: record, session: session, to: destinationURL)
-            } else {
-                try exportService.exportTranscript(for: record, to: destinationURL)
-            }
+            let session = try sessionState(for: record)
+            try exportService.exportTranscript(for: record, session: session, to: destinationURL)
         }
     }
 
     public func exportSummary(for meetingID: UUID, to destinationURL: URL) throws {
         try export("Summary", for: meetingID) { record in
-            if let session = selectedSession(for: record.id) {
-                try exportService.exportSummary(session.summary.summary, to: destinationURL)
-            } else {
-                try exportService.exportSummary(for: record, to: destinationURL)
-            }
+            let session = try sessionState(for: record)
+            try exportService.exportSummary(session.summary.summary, to: destinationURL)
         }
     }
 
@@ -820,32 +807,22 @@ public final class MeetingAgentViewModel: ObservableObject {
         to destinationURL: URL
     ) throws {
         try export(format == .srt ? "SRT subtitles" : "VTT subtitles", for: meetingID) { record in
-            if let session = selectedSession(for: record.id) {
-                try exportService.exportSubtitles(for: record, session: session, format: format, to: destinationURL)
-            } else {
-                try exportService.exportSubtitles(for: record, format: format, to: destinationURL)
-            }
+            let session = try sessionState(for: record)
+            try exportService.exportSubtitles(for: record, session: session, format: format, to: destinationURL)
         }
     }
 
     public func exportReadinessReport(for meetingID: UUID, to destinationURL: URL) throws {
         try export("Readiness report", for: meetingID) { record in
-            if let session = selectedSession(for: record.id) {
-                try exportService.exportReadinessReport(for: record, session: session, to: destinationURL)
-            } else {
-                try exportService.exportReadinessReport(for: record, to: destinationURL)
-            }
+            let session = try sessionState(for: record)
+            try exportService.exportReadinessReport(for: record, session: session, to: destinationURL)
         }
     }
 
     public func exportKnowledgePackage(for meetingID: UUID, to destinationURL: URL) throws {
         try export("Knowledge package", for: meetingID) { record in
-            if let session = selectedSession(for: record.id) {
-                try exportService.exportKnowledgePackage(for: record, session: session, to: destinationURL)
-            } else {
-                let summary = try? summaryRepository.loadSummary(for: record)
-                try exportService.exportKnowledgePackage(for: record, summary: summary, to: destinationURL)
-            }
+            let session = try sessionState(for: record)
+            try exportService.exportKnowledgePackage(for: record, session: session, to: destinationURL)
         }
     }
 
@@ -857,11 +834,8 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
         do {
             let summary: String
-            if let session = selectedSession(for: record.id) {
-                summary = try exportService.summaryText(summary: session.summary.summary)
-            } else {
-                summary = try exportService.summaryText(for: record)
-            }
+            let session = try sessionState(for: record)
+            summary = try exportService.summaryText(summary: session.summary.summary)
             statusText = "Summary copied"
             return summary
         } catch {
@@ -877,6 +851,30 @@ public final class MeetingAgentViewModel: ObservableObject {
             return nil
         }
         return selectedMeetingSessionState
+    }
+
+    private func sessionState(for record: MeetingRecord) throws -> MeetingSessionState {
+        if let session = selectedSession(for: record.id) {
+            return session
+        }
+
+        let captionDocument = try transcriptRepository.loadCaptionDocument(for: record)
+        var session = MeetingSessionState(
+            meetingID: record.id,
+            transcript: TranscriptState(
+                meetingID: record.id,
+                captionDocument: captionDocument,
+                source: record.id == activeMeetingID ? .activeRecording : .hydratedFromPersistence
+            ),
+            summary: .missing
+        )
+        if let summary = try summaryRepository.loadSummary(for: record) {
+            session.summary = .loaded(summary)
+        }
+        if selectedMeetingID == record.id {
+            selectedMeetingSessionState = session
+        }
+        return session
     }
 
     private func activeSessionState(for record: MeetingRecord, document: CaptionDocument) -> MeetingSessionState {
@@ -1122,8 +1120,13 @@ public final class MeetingAgentViewModel: ObservableObject {
                 meeting: selectedMeeting,
                 session: selectedMeetingSessionState
             )
+        } else if let session = try? sessionState(for: selectedMeeting) {
+            selectedMeetingArtifactSnapshot = MeetingArtifactSnapshot.make(
+                meeting: selectedMeeting,
+                session: session
+            )
         } else {
-            selectedMeetingArtifactSnapshot = MeetingArtifactSnapshot.load(for: selectedMeeting)
+            selectedMeetingArtifactSnapshot = nil
         }
     }
 
@@ -1426,20 +1429,12 @@ public final class MeetingAgentViewModel: ObservableObject {
     }
 
     private func selectedTranscriptDocument() -> TranscriptDocument? {
-        if let selectedMeetingSessionState,
-           selectedMeetingSessionState.meetingID == selectedMeetingID {
-            let document = selectedMeetingSessionState.transcript.captionDocument.transcriptDocument
-            return document.segments.isEmpty ? nil : document
-        }
         guard let meeting = selectedMeeting,
-              meeting.transcriptJSONURL != nil
+              let session = try? sessionState(for: meeting)
         else {
             return nil
         }
-        guard let captionDocument = try? transcriptRepository.loadCaptionDocument(for: meeting) else {
-            return nil
-        }
-        let document = captionDocument.transcriptDocument
+        let document = session.transcript.captionDocument.transcriptDocument
         return document.segments.isEmpty ? nil : document
     }
 

--- a/Sources/MeetingAgentCore/MeetingArtifactSnapshot.swift
+++ b/Sources/MeetingAgentCore/MeetingArtifactSnapshot.swift
@@ -24,24 +24,6 @@ public struct MeetingArtifactSnapshot: Equatable {
         self.transcriptLatencyText = transcriptLatencyText
     }
 
-    public static func load(for meeting: MeetingRecord) -> MeetingArtifactSnapshot {
-        let captionDocument = try? FileTranscriptRepository().loadCaptionDocument(for: meeting)
-        let document = captionDocument?.transcriptDocument
-        let transcriptText = document.flatMap(renderedTranscript(from:))
-            ?? "Transcript will appear here while recording."
-        let summary = try? FileSummaryRepository().loadSummary(for: meeting)
-        let providers = Array(Set(document?.segments.map(\.sourceProvider) ?? [])).sorted()
-
-        return MeetingArtifactSnapshot(
-            meetingID: meeting.id,
-            transcriptText: transcriptText,
-            transcriptSegments: document?.segments ?? [],
-            summary: summary,
-            actualTranscriptionSourceText: providers.isEmpty ? meeting.transcriptionProviderID : providers.joined(separator: ", "),
-            transcriptLatencyText: Self.transcriptLatencyText(for: meeting)
-        )
-    }
-
     public static func make(meeting: MeetingRecord, session: MeetingSessionState) -> MeetingArtifactSnapshot {
         let document = session.transcript.captionDocument.transcriptDocument
         let transcriptText = renderedTranscript(from: document)

--- a/Sources/MeetingAgentCore/MeetingExportService.swift
+++ b/Sources/MeetingAgentCore/MeetingExportService.swift
@@ -18,23 +18,9 @@ public enum SubtitleExportFormat: Equatable {
 
 public struct MeetingExportService {
     private let fileManager: FileManager
-    private let transcriptRepository: any TranscriptRepository
 
-    public init(
-        fileManager: FileManager = .default,
-        transcriptRepository: any TranscriptRepository = FileTranscriptRepository()
-    ) {
+    public init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
-        self.transcriptRepository = transcriptRepository
-    }
-
-    public func exportTranscript(for record: MeetingRecord, to destinationURL: URL) throws {
-        let document = try transcriptDocument(for: record)
-        let transcript = TranscriptFormatter.render(document.segments)
-        guard !transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw MeetingExportError.missingArtifact("transcript")
-        }
-        try write(transcript, to: destinationURL)
     }
 
     public func exportTranscript(for record: MeetingRecord, session: MeetingSessionState, to destinationURL: URL) throws {
@@ -44,10 +30,6 @@ public struct MeetingExportService {
             throw MeetingExportError.missingArtifact("transcript")
         }
         try write(transcript, to: destinationURL)
-    }
-
-    public func exportSummary(for record: MeetingRecord, to destinationURL: URL) throws {
-        try write(try summaryText(for: record), to: destinationURL)
     }
 
     public func exportSummary(_ summary: MeetingSummary?, to destinationURL: URL) throws {
@@ -62,24 +44,6 @@ public struct MeetingExportService {
 
     public func exportSubtitles(
         for record: MeetingRecord,
-        format: SubtitleExportFormat,
-        to destinationURL: URL
-    ) throws {
-        let document = try transcriptDocument(for: record)
-        let cues = subtitleCues(from: document.segments)
-        guard !cues.isEmpty else {
-            throw MeetingExportError.missingArtifact("timed transcript")
-        }
-        switch format {
-        case .srt:
-            try write(renderSRT(cues), to: destinationURL)
-        case .vtt:
-            try write(renderVTT(cues), to: destinationURL)
-        }
-    }
-
-    public func exportSubtitles(
-        for record: MeetingRecord,
         session: MeetingSessionState,
         format: SubtitleExportFormat,
         to destinationURL: URL
@@ -88,43 +52,8 @@ public struct MeetingExportService {
         try exportSubtitles(segments: document.segments, format: format, to: destinationURL)
     }
 
-    public func exportReadinessReport(for record: MeetingRecord, to destinationURL: URL) throws {
-        try write(readinessReport(for: record), to: destinationURL)
-    }
-
     public func exportReadinessReport(for record: MeetingRecord, session: MeetingSessionState, to destinationURL: URL) throws {
         try write(readinessReport(for: record, session: session), to: destinationURL)
-    }
-
-    public func exportKnowledgePackage(
-        for record: MeetingRecord,
-        summary: MeetingSummary?,
-        knowledge: MeetingKnowledge? = nil,
-        to destinationURL: URL
-    ) throws {
-        let document = try transcriptDocument(for: record)
-        let resolvedKnowledge: MeetingKnowledge
-        if let knowledge {
-            resolvedKnowledge = knowledge
-        } else if let summary {
-            resolvedKnowledge = MeetingKnowledgeExtractor.fromSummary(summary, segments: document.segments)
-        } else {
-            resolvedKnowledge = MeetingKnowledge(failureReason: "Knowledge extraction was not available.")
-        }
-        let package = MeetingKnowledgePackage(
-            record: record,
-            summary: summary,
-            segments: document.segments,
-            knowledge: resolvedKnowledge
-        )
-
-        try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
-        try MeetingKnowledgePackageMarkdownRenderer.renderMeeting(package)
-            .write(to: destinationURL.appendingPathComponent("meeting.md"), atomically: true, encoding: .utf8)
-        try MeetingKnowledgePackageMarkdownRenderer.renderTranscript(package)
-            .write(to: destinationURL.appendingPathComponent("transcript.md"), atomically: true, encoding: .utf8)
-        try MeetingKnowledgePackageMarkdownRenderer.renderKnowledge(package)
-            .write(to: destinationURL.appendingPathComponent("knowledge.md"), atomically: true, encoding: .utf8)
     }
 
     public func exportKnowledgePackage(
@@ -143,101 +72,19 @@ public struct MeetingExportService {
         } else {
             resolvedKnowledge = MeetingKnowledge(failureReason: "Knowledge extraction was not available.")
         }
-        let package = MeetingKnowledgePackage(
-            record: record,
-            summary: summary,
-            segments: document.segments,
-            knowledge: resolvedKnowledge
+        try exportKnowledgePackage(
+            package: MeetingKnowledgePackage(
+                record: record,
+                summary: summary,
+                segments: document.segments,
+                knowledge: resolvedKnowledge
+            ),
+            to: destinationURL
         )
-
-        try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
-        try MeetingKnowledgePackageMarkdownRenderer.renderMeeting(package)
-            .write(to: destinationURL.appendingPathComponent("meeting.md"), atomically: true, encoding: .utf8)
-        try MeetingKnowledgePackageMarkdownRenderer.renderTranscript(package)
-            .write(to: destinationURL.appendingPathComponent("transcript.md"), atomically: true, encoding: .utf8)
-        try MeetingKnowledgePackageMarkdownRenderer.renderKnowledge(package)
-            .write(to: destinationURL.appendingPathComponent("knowledge.md"), atomically: true, encoding: .utf8)
-    }
-
-    public func summaryText(for record: MeetingRecord) throws -> String {
-        guard let summaryURL = record.summaryURL,
-              fileManager.fileExists(atPath: summaryURL.path)
-        else {
-            throw MeetingExportError.missingArtifact("summary")
-        }
-
-        let summary = try String(contentsOf: summaryURL, encoding: .utf8)
-        guard !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw MeetingExportError.missingArtifact("summary")
-        }
-        return summary
     }
 
     public func summaryText(summary: MeetingSummary?) throws -> String {
         try renderedSummaryText(summary)
-    }
-
-    private func readinessReport(for record: MeetingRecord) -> String {
-        let transcript = (try? transcriptDocument(for: record))
-            .map { TranscriptFormatter.render($0.segments) }
-        let diagnostics = diagnostics(for: record)
-        let summaryAvailable = record.summaryURL.map { fileManager.fileExists(atPath: $0.path) } ?? false
-
-        var lines: [String] = [
-            "# Meeting Readiness Report",
-            "",
-            "## Meeting",
-            "",
-            "- Name: \(record.name)",
-            "- ID: \(record.id.uuidString)",
-            "- Started: \(format(record.startedAt))",
-            "- Ended: \(record.endedAt.map(format) ?? "Not ended")",
-            "- STT provider: \(record.transcriptionProviderID)",
-            "- Language: \(record.speechLocaleIdentifier)",
-            "- Transcription: \(transcriptionLabel(for: record.transcriptionStatus))",
-            "- Failure reason: \(record.transcriptionFailureReason ?? "None")",
-            "",
-            "## Artifacts",
-            "",
-            "- Audio: \(artifactPath(record.audioURL))",
-            "- Transcript: \(artifactPath(record.transcriptURL))",
-            "- Structured transcript: \(artifactPath(record.transcriptJSONURL))",
-            "- Summary: \(summaryAvailable ? artifactPath(record.summaryURL) : "Not generated")",
-            "- Diagnostics: \(artifactPath(record.diagnosticsURL))",
-            "",
-            "## Capture Diagnostics",
-            ""
-        ]
-
-        if let diagnostics {
-            lines.append(contentsOf: [
-                "- Status: \(diagnostics.status.rawValue)",
-                "- Frames captured: \(diagnostics.framesCaptured)",
-                "- Duration seconds: \(format(diagnostics.durationSeconds))",
-                "- Average level: \(format(diagnostics.averageLevel))",
-                "- Peak level: \(format(diagnostics.peakLevel))",
-                "- Silent duration seconds: \(format(diagnostics.silentDurationSeconds))",
-                "- Dropped frames: \(diagnostics.droppedFrameCount)",
-                "- Startup replay frames: \(diagnostics.startupReplayFrameCount)",
-                "- Startup replay duration seconds: \(format(diagnostics.startupReplayDurationSeconds))",
-                "- Startup replay dropped frames: \(diagnostics.startupReplayDroppedFrameCount)",
-                ""
-            ])
-        } else {
-            lines.append(contentsOf: [
-                "No diagnostics artifact is available.",
-                ""
-            ])
-        }
-
-        lines.append(contentsOf: [
-            "## Transcript Excerpt",
-            "",
-            transcriptExcerpt(from: transcript),
-            ""
-        ])
-
-        return lines.joined(separator: "\n")
     }
 
     private func readinessReport(for record: MeetingRecord, session: MeetingSessionState) -> String {
@@ -313,17 +160,18 @@ public struct MeetingExportService {
         return try? JSONDecoder.meetingAgent.decode(CaptureDiagnostics.self, from: data)
     }
 
-    private func transcriptDocument(for record: MeetingRecord) throws -> TranscriptDocument {
-        guard let transcriptJSONURL = record.transcriptJSONURL,
-              fileManager.fileExists(atPath: transcriptJSONURL.path)
-        else {
-            throw MeetingExportError.missingArtifact("structured transcript")
-        }
-        return try transcriptRepository.loadCaptionDocument(for: record).transcriptDocument
-    }
-
     private func transcriptDocument(for session: MeetingSessionState) -> TranscriptDocument {
         session.transcript.captionDocument.transcriptDocument
+    }
+
+    private func exportKnowledgePackage(package: MeetingKnowledgePackage, to destinationURL: URL) throws {
+        try fileManager.createDirectory(at: destinationURL, withIntermediateDirectories: true)
+        try MeetingKnowledgePackageMarkdownRenderer.renderMeeting(package)
+            .write(to: destinationURL.appendingPathComponent("meeting.md"), atomically: true, encoding: .utf8)
+        try MeetingKnowledgePackageMarkdownRenderer.renderTranscript(package)
+            .write(to: destinationURL.appendingPathComponent("transcript.md"), atomically: true, encoding: .utf8)
+        try MeetingKnowledgePackageMarkdownRenderer.renderKnowledge(package)
+            .write(to: destinationURL.appendingPathComponent("knowledge.md"), atomically: true, encoding: .utf8)
     }
 
     private func exportSubtitles(segments: [TranscriptSegment], format: SubtitleExportFormat, to destinationURL: URL) throws {

--- a/Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift
@@ -5,13 +5,13 @@ final class MeetingExportServiceTests: XCTestCase {
     func testExportsRenderedStructuredTranscript() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
-        try fixture.writeStructuredTranscript([
+        let session = fixture.session(segments: [
             TranscriptSegment(speaker: TranscriptSpeaker(identifier: "a", label: "Allan"), text: "Hello"),
             TranscriptSegment(speaker: TranscriptSpeaker(identifier: "a", label: "Allan"), text: "Next step")
         ])
         let destination = fixture.root.appendingPathComponent("transcript-export.txt")
 
-        try MeetingExportService().exportTranscript(for: fixture.record, to: destination)
+        try MeetingExportService().exportTranscript(for: fixture.record, session: session, to: destination)
 
         XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "Allan:\nHello Next step")
     }
@@ -19,12 +19,12 @@ final class MeetingExportServiceTests: XCTestCase {
     func testExportsSummaryMarkdownWhenPresent() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
-        try "# Summary\n\n- Decision made\n".write(to: fixture.record.summaryURL!, atomically: true, encoding: .utf8)
+        let summary = fixture.summary(overview: "Decision made")
         let destination = fixture.root.appendingPathComponent("summary-export.md")
 
-        try MeetingExportService().exportSummary(for: fixture.record, to: destination)
+        try MeetingExportService().exportSummary(summary, to: destination)
 
-        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), "# Summary\n\n- Decision made\n")
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), MeetingSummaryMarkdownRenderer.render(summary))
     }
 
     func testSummaryExportFailsWhenSummaryMissing() throws {
@@ -32,7 +32,7 @@ final class MeetingExportServiceTests: XCTestCase {
         defer { fixture.cleanup() }
 
         XCTAssertThrowsError(try MeetingExportService().exportSummary(
-            for: fixture.record,
+            nil,
             to: fixture.root.appendingPathComponent("summary-export.md")
         )) { error in
             XCTAssertEqual(error as? MeetingExportError, .missingArtifact("summary"))
@@ -55,7 +55,7 @@ final class MeetingExportServiceTests: XCTestCase {
     func testExportsStructuredTranscriptAsSRT() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
-        try fixture.writeStructuredTranscript([
+        let session = fixture.session(segments: [
             TranscriptSegment(
                 speaker: TranscriptSpeaker(identifier: "a", label: "Allan"),
                 startTimeSeconds: 1.25,
@@ -73,7 +73,7 @@ final class MeetingExportServiceTests: XCTestCase {
         ])
         let destination = fixture.root.appendingPathComponent("captions.srt")
 
-        try MeetingExportService().exportSubtitles(for: fixture.record, format: .srt, to: destination)
+        try MeetingExportService().exportSubtitles(for: fixture.record, session: session, format: .srt, to: destination)
 
         XCTAssertEqual(
             try String(contentsOf: destination, encoding: .utf8),
@@ -93,13 +93,13 @@ final class MeetingExportServiceTests: XCTestCase {
     func testExportsStructuredTranscriptAsVTTWithApproximateFallbackTiming() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
-        try fixture.writeStructuredTranscript([
+        let session = fixture.session(segments: [
             TranscriptSegment(speaker: TranscriptSpeaker(identifier: "a", label: "Allan"), text: "First line."),
             TranscriptSegment(speaker: TranscriptSpeaker(identifier: "a", label: "Allan"), text: "Second line.")
         ])
         let destination = fixture.root.appendingPathComponent("captions.vtt")
 
-        try MeetingExportService().exportSubtitles(for: fixture.record, format: .vtt, to: destination)
+        try MeetingExportService().exportSubtitles(for: fixture.record, session: session, format: .vtt, to: destination)
 
         XCTAssertEqual(
             try String(contentsOf: destination, encoding: .utf8),
@@ -119,20 +119,22 @@ final class MeetingExportServiceTests: XCTestCase {
     func testSubtitleExportFailsWhenStructuredTranscriptMissing() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
+        let session = fixture.session(segments: [])
 
         XCTAssertThrowsError(try MeetingExportService().exportSubtitles(
             for: fixture.record,
+            session: session,
             format: .srt,
             to: fixture.root.appendingPathComponent("captions.srt")
         )) { error in
-            XCTAssertEqual(error as? MeetingExportError, .missingArtifact("structured transcript"))
+            XCTAssertEqual(error as? MeetingExportError, .missingArtifact("timed transcript"))
         }
     }
 
     func testExportsReadinessMarkdownReport() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
-        try fixture.writeStructuredTranscript([
+        let session = fixture.session(segments: [
             TranscriptSegment(text: "Structured transcript text for validation.")
         ])
         try CaptureDiagnostics(
@@ -153,7 +155,7 @@ final class MeetingExportServiceTests: XCTestCase {
         ).write(to: fixture.record.diagnosticsURL!)
         let destination = fixture.root.appendingPathComponent("readiness.md")
 
-        try MeetingExportService().exportReadinessReport(for: fixture.record, to: destination)
+        try MeetingExportService().exportReadinessReport(for: fixture.record, session: session, to: destination)
 
         let markdown = try String(contentsOf: destination, encoding: .utf8)
         XCTAssertTrue(markdown.contains("# Meeting Readiness Report"))
@@ -167,7 +169,7 @@ final class MeetingExportServiceTests: XCTestCase {
     func testExportsKnowledgePackageMarkdownFiles() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
-        try fixture.writeStructuredTranscript([
+        let segments = [
             TranscriptSegment(
                 id: "segment-1",
                 speaker: TranscriptSpeaker(identifier: "a", label: "Alice"),
@@ -180,7 +182,7 @@ final class MeetingExportServiceTests: XCTestCase {
                 startTimeSeconds: 48,
                 text: "I will confirm legal timing."
             )
-        ])
+        ]
         let summary = MeetingSummary(
             overview: "The team agreed to a Tokyo-only pilot.",
             keyTopics: ["Japan GTM"],
@@ -211,9 +213,10 @@ final class MeetingExportServiceTests: XCTestCase {
             status: .succeeded,
             failureReason: nil
         )
+        let session = fixture.session(segments: segments, summary: summary)
         let destination = fixture.root.appendingPathComponent("knowledge-package", isDirectory: true)
 
-        try MeetingExportService().exportKnowledgePackage(for: fixture.record, summary: summary, to: destination)
+        try MeetingExportService().exportKnowledgePackage(for: fixture.record, session: session, to: destination)
 
         let files = try FileManager.default.contentsOfDirectory(atPath: destination.path).sorted()
         XCTAssertEqual(files, ["knowledge.md", "meeting.md", "transcript.md"])
@@ -226,30 +229,33 @@ final class MeetingExportServiceTests: XCTestCase {
         XCTAssertTrue(knowledge.contains("[[transcript#t-00-00-12|Alice 00:00:12]]"))
     }
 
-    func testKnowledgePackageExportFailsWhenStructuredTranscriptMissing() throws {
+    func testKnowledgePackageExportUsesEmptySessionTranscriptWhenNoSegmentsExist() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
 
-        XCTAssertThrowsError(try MeetingExportService().exportKnowledgePackage(
+        let session = fixture.session(segments: [])
+        let destination = fixture.root.appendingPathComponent("knowledge-package", isDirectory: true)
+        try MeetingExportService().exportKnowledgePackage(
             for: fixture.record,
-            summary: nil,
-            to: fixture.root.appendingPathComponent("knowledge-package", isDirectory: true)
-        )) { error in
-            XCTAssertEqual(error as? MeetingExportError, .missingArtifact("structured transcript"))
-        }
+            session: session,
+            to: destination
+        )
+
+        let transcript = try String(contentsOf: destination.appendingPathComponent("transcript.md"), encoding: .utf8)
+        XCTAssertTrue(transcript.contains("Transcript is not available."))
     }
 
     func testExportsKnowledgePackageWithFailureNote() throws {
         let fixture = try MeetingExportFixture()
         defer { fixture.cleanup() }
-        try fixture.writeStructuredTranscript([
+        let session = fixture.session(segments: [
             TranscriptSegment(id: "segment-1", text: "Transcript exists.")
         ])
         let destination = fixture.root.appendingPathComponent("knowledge-package", isDirectory: true)
 
         try MeetingExportService().exportKnowledgePackage(
             for: fixture.record,
-            summary: nil,
+            session: session,
             knowledge: MeetingKnowledge(failureReason: "OpenRouter API key is not configured"),
             to: destination
         )
@@ -288,7 +294,37 @@ private struct MeetingExportFixture {
         try? FileManager.default.removeItem(at: root)
     }
 
-    func writeStructuredTranscript(_ segments: [TranscriptSegment]) throws {
+    func session(segments: [TranscriptSegment], summary: MeetingSummary? = nil) -> MeetingSessionState {
+        MeetingSessionState(
+            meetingID: record.id,
+            transcript: TranscriptState(
+                meetingID: record.id,
+                captionDocument: captionDocument(from: segments),
+                source: .hydratedFromPersistence
+            ),
+            summary: summary.map(SummaryState.loaded) ?? .missing
+        )
+    }
+
+    func summary(overview: String) -> MeetingSummary {
+        MeetingSummary(
+            overview: overview,
+            keyTopics: [],
+            decisions: [],
+            actionItems: [],
+            openQuestions: [],
+            risks: [],
+            followUps: [],
+            language: "en-US",
+            sourceSegmentIDs: [],
+            generatedAt: Date(timeIntervalSince1970: 1_777_000_700),
+            provider: "test",
+            status: .succeeded,
+            failureReason: nil
+        )
+    }
+
+    private func captionDocument(from segments: [TranscriptSegment]) -> CaptionDocument {
         let turns = segments.map { segment in
             CaptionTurn(
                 id: segment.id,
@@ -314,13 +350,12 @@ private struct MeetingExportFixture {
                 updatedAt: segment.createdAt
             )
         }
-        let data = try JSONEncoder.meetingAgent.encode(CaptionDocument(
+        return CaptionDocument(
             turns: turns,
             provider: CaptionProviderInfo(
                 id: segments.first?.sourceProvider ?? "test",
                 locale: segments.compactMap(\.language).first
             )
-        ))
-        try data.write(to: record.transcriptJSONURL!, options: .atomic)
+        )
     }
 }

--- a/Tests/MeetingAgentCoreTests/TranscriptConsumptionArchitectureTests.swift
+++ b/Tests/MeetingAgentCoreTests/TranscriptConsumptionArchitectureTests.swift
@@ -4,16 +4,18 @@ final class TranscriptConsumptionArchitectureTests: XCTestCase {
     func testProductConsumersDoNotReadTranscriptOrSummaryFilesDirectly() throws {
         let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
         let productFiles = [
-            "Sources/MeetingAgentCore/MeetingAgentViewModel.swift",
             "Sources/MeetingAgentCore/MeetingArtifactSnapshot.swift",
-            "Sources/MeetingAgentCore/MeetingExportService.swift",
-            "Sources/MeetingAgentCore/MeetingStore.swift"
+            "Sources/MeetingAgentCore/MeetingExportService.swift"
         ]
 
         for path in productFiles {
             let source = try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
             XCTAssertFalse(source.contains("TranscriptFileWriter.readDocument"), path)
             XCTAssertFalse(source.contains("MeetingSummaryWriter.read"), path)
+            XCTAssertFalse(source.contains("FileTranscriptRepository()"), path)
+            XCTAssertFalse(source.contains("FileSummaryRepository()"), path)
+            XCTAssertFalse(source.contains("loadCaptionDocument(for:"), path)
+            XCTAssertFalse(source.contains("loadSummary(for:"), path)
         }
 
         let exportSource = try String(
@@ -21,6 +23,41 @@ final class TranscriptConsumptionArchitectureTests: XCTestCase {
             encoding: .utf8
         )
         XCTAssertFalse(exportSource.contains("TranscriptFileWriter.readDocument(from:"), "MeetingExportService.swift")
+        XCTAssertFalse(exportSource.contains("TranscriptRepository"), "MeetingExportService.swift")
+        XCTAssertFalse(exportSource.contains("SummaryRepository"), "MeetingExportService.swift")
+
+        let viewModelSource = try String(
+            contentsOf: root.appendingPathComponent("Sources/MeetingAgentCore/MeetingAgentViewModel.swift"),
+            encoding: .utf8
+        )
+        XCTAssertFalse(viewModelSource.contains("exportService.exportTranscript(for: record, to:"), "MeetingAgentViewModel.swift")
+        XCTAssertFalse(viewModelSource.contains("exportService.exportSummary(for: record, to:"), "MeetingAgentViewModel.swift")
+        XCTAssertFalse(viewModelSource.contains("exportService.exportSubtitles(for: record, format:"), "MeetingAgentViewModel.swift")
+        XCTAssertFalse(viewModelSource.contains("exportService.exportKnowledgePackage(for: record, summary:"), "MeetingAgentViewModel.swift")
+        XCTAssertFalse(viewModelSource.contains("exportService.summaryText(for: record)"), "MeetingAgentViewModel.swift")
+    }
+
+    func testRepositoryConsumptionIsLimitedToHydrationBoundaries() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let allowedFiles: Set<String> = [
+            "Sources/MeetingAgentCore/MeetingDataRepositories.swift",
+            "Sources/MeetingAgentCore/MeetingStore.swift",
+            "Sources/MeetingAgentCore/MeetingAgentViewModel.swift"
+        ]
+        let sourceRoot = root.appendingPathComponent("Sources/MeetingAgentCore", isDirectory: true)
+        let fileURLs = try FileManager.default.contentsOfDirectory(
+            at: sourceRoot,
+            includingPropertiesForKeys: nil
+        )
+        for fileURL in fileURLs where fileURL.pathExtension == "swift" {
+            let relativePath = "Sources/MeetingAgentCore/\(fileURL.lastPathComponent)"
+            guard !allowedFiles.contains(relativePath) else { continue }
+            let source = try String(contentsOf: fileURL, encoding: .utf8)
+            XCTAssertFalse(source.contains("FileTranscriptRepository"), relativePath)
+            XCTAssertFalse(source.contains("FileSummaryRepository"), relativePath)
+            XCTAssertFalse(source.contains("loadCaptionDocument(for:"), relativePath)
+            XCTAssertFalse(source.contains("loadSummary(for:"), relativePath)
+        }
     }
 
     func testRealtimeRecordingPersistenceDoesNotUseLegacyTranscriptFileBridge() throws {

--- a/docs/mistakes/2026-05-15T04-55-41Z.md
+++ b/docs/mistakes/2026-05-15T04-55-41Z.md
@@ -1,0 +1,13 @@
+# [145] Preserve provider-owned empty transcript handling
+
+**Date**: 2026-05-15
+**Category**: logic-error
+
+### What went wrong
+The first memory-only summary implementation rejected hydrated sessions with no final transcript turns before calling the summary provider, changing an existing empty-transcript path that should produce a failed summary state.
+
+### Correct approach
+Hydrate the session into memory, then pass the resulting `TranscriptConsumptionView` through the existing summary provider so provider-level empty-input semantics remain intact.
+
+### How to avoid
+When replacing file fallback reads with hydrated memory, preserve downstream validation ownership instead of adding new early guards.


### PR DESCRIPTION
## Summary

Fixes #145

- Routes summary generation, exports, clipboard text, and artifact snapshots through hydrated MeetingSessionState/read models.
- Removes record-only transcript/summary file-reading APIs from MeetingExportService and MeetingArtifactSnapshot.
- Adds architecture tests that keep repository construction and transcript/summary loading out of product consumers.

## Changes

- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - hydrates sessions before product consumption and removes downstream file fallback calls.
- `Sources/MeetingAgentCore/MeetingArtifactSnapshot.swift` - constructs snapshots only from session memory.
- `Sources/MeetingAgentCore/MeetingExportService.swift` - exports from session/summary inputs without repository dependencies.
- `Tests/MeetingAgentCoreTests/MeetingExportServiceTests.swift` - updates export tests to use in-memory session fixtures.
- `Tests/MeetingAgentCoreTests/TranscriptConsumptionArchitectureTests.swift` - adds architecture guards for direct repository/file consumption.

## Test plan

- [x] Build: `swift build --product MeetingAgentApp` passed.
- [x] Unit tests: `swift test --filter TranscriptConsumptionArchitectureTests`, `swift test --filter MeetingExportServiceTests`, and `swift test --filter MeetingAgentViewModelTests` passed.
- [x] Full verification: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/private/tmp/meeting-agent-issue-145-coverage make test` passed, 791 tests, line 95.45%, method 94.62%.
- [x] Code review: PASS.
- [x] E2E/integration: skipped; no app E2E convention for this backend architecture boundary.