### PR TITLE
feat: gate summaries on transcript refinement

### DIFF
--- a/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
+++ b/Sources/MeetingAgentCore/MeetingAgentViewModel.swift
@@ -627,6 +627,7 @@ public final class MeetingAgentViewModel: ObservableObject {
             return
         }
 
+        statusText = "Refining transcript"
         await refineStoppedTranscriptIfPossible(for: stoppedID)
         try await generateSummary(for: stoppedID, generatedAt: generatedAt)
     }
@@ -688,6 +689,7 @@ public final class MeetingAgentViewModel: ObservableObject {
         let consumptionView = session.transcript.consumptionView
         let progress = progressState(for: meeting)
         let provider = summaryProviderFactory(speechConfiguration)
+        statusText = "Generating summary"
         let summary = try await provider.generateSummary(
             input: MeetingSummaryInput(
                 meetingName: meeting.name,
@@ -697,6 +699,7 @@ public final class MeetingAgentViewModel: ObservableObject {
                 targetLanguage: speechConfiguration.localeIdentifier,
                 meetingGoal: summaryGoalContext(for: progress),
                 transcript: consumptionView,
+                transcriptSource: summaryTranscriptSource(for: meeting),
                 generatedAt: generatedAt
             )
         )
@@ -710,6 +713,24 @@ public final class MeetingAgentViewModel: ObservableObject {
         }
         statusText = summary.status == .succeeded ? "Summary generated" : "Summary failed"
         objectWillChange.send()
+    }
+
+    private func summaryTranscriptSource(for meeting: MeetingRecord) -> MeetingSummaryTranscriptSource {
+        guard let refinement = meeting.transcriptRefinement else {
+            return .live
+        }
+        switch refinement.status {
+        case .notStarted, .running:
+            return .live
+        case .refined:
+            return .refined
+        case .failed:
+            let reason = refinement.failureReason?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let reason, !reason.isEmpty {
+                return .fallback(reason: reason)
+            }
+            return .fallback(reason: "Transcript refinement failed")
+        }
     }
 
     private func summaryGoalContext(for progress: MeetingProgressState?) -> String? {

--- a/Sources/MeetingAgentCore/MeetingSummary.swift
+++ b/Sources/MeetingAgentCore/MeetingSummary.swift
@@ -287,6 +287,12 @@ enum MeetingSummaryTitleGenerator {
     }
 }
 
+public enum MeetingSummaryTranscriptSource: Equatable {
+    case live
+    case refined
+    case fallback(reason: String)
+}
+
 public struct MeetingSummaryInput: Equatable {
     public let meetingName: String
     public let startedAt: Date
@@ -295,6 +301,7 @@ public struct MeetingSummaryInput: Equatable {
     public let targetLanguage: String?
     public let meetingGoal: String?
     public let transcript: TranscriptConsumptionView
+    public let transcriptSource: MeetingSummaryTranscriptSource
     public let generatedAt: Date
 
     public init(
@@ -305,6 +312,7 @@ public struct MeetingSummaryInput: Equatable {
         targetLanguage: String? = nil,
         meetingGoal: String?,
         transcript: TranscriptConsumptionView,
+        transcriptSource: MeetingSummaryTranscriptSource = .live,
         generatedAt: Date = Date()
     ) {
         self.meetingName = meetingName
@@ -314,6 +322,7 @@ public struct MeetingSummaryInput: Equatable {
         self.targetLanguage = targetLanguage
         self.meetingGoal = meetingGoal
         self.transcript = transcript
+        self.transcriptSource = transcriptSource
         self.generatedAt = generatedAt
     }
 }

--- a/Sources/MeetingAgentCore/OpenRouterMeetingSummaryProvider.swift
+++ b/Sources/MeetingAgentCore/OpenRouterMeetingSummaryProvider.swift
@@ -25,6 +25,13 @@ public struct OpenRouterMeetingSummaryProvider: MeetingSummaryProvider {
 
     public func generateSummary(input: MeetingSummaryInput) async throws -> MeetingSummary {
         let sourceSegmentIDs = Self.sourceSegmentIDs(from: input.transcript)
+        guard !sourceSegmentIDs.isEmpty else {
+            return failedSummary(
+                input: input,
+                sourceSegmentIDs: sourceSegmentIDs,
+                reason: "No transcript is available for summary generation"
+            )
+        }
         switch configuration {
         case .unavailable(let reason):
             return failedSummary(input: input, sourceSegmentIDs: sourceSegmentIDs, reason: reason)
@@ -88,6 +95,7 @@ public struct OpenRouterMeetingSummaryProvider: MeetingSummaryProvider {
             "Meeting name: \(input.meetingName)",
             "Transcript language: \(input.language ?? "unknown")",
             "Summary target language: \(input.targetLanguage ?? input.language ?? "unknown")",
+            "Transcript source: \(transcriptSourceDescription(input.transcriptSource))",
             "Write every generated JSON string value in the summary target language."
         ]
         lines.append(contentsOf: qualityPromptLines(for: input.transcript.quality))
@@ -110,6 +118,21 @@ public struct OpenRouterMeetingSummaryProvider: MeetingSummaryProvider {
             lines.append("Transcript fallback reason: \(fallbackReason)")
         }
         return lines
+    }
+
+    private static func transcriptSourceDescription(_ source: MeetingSummaryTranscriptSource) -> String {
+        switch source {
+        case .live:
+            return "live"
+        case .refined:
+            return "refined"
+        case .fallback(let reason):
+            let trimmedReason = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmedReason.isEmpty {
+                return "fallback"
+            }
+            return "fallback (\(trimmedReason))"
+        }
     }
 
     private static func promptLines(for turn: TranscriptConsumptionTurn) -> [String] {

--- a/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift
@@ -3098,7 +3098,123 @@ final class MeetingAgentViewModelTests: XCTestCase {
         XCTAssertEqual(refiner.requests.count, 1)
         XCTAssertEqual(viewModel.selectedMeetingSessionState?.transcript.captionDocument.turns.map(\.id), ["refined-final"])
         XCTAssertEqual(summaryProvider.receivedInputs.first?.transcript.finalTurns.map(\.turnID), ["refined-final"])
+        XCTAssertEqual(summaryProvider.receivedInputs.first?.transcriptSource, .refined)
         XCTAssertEqual(viewModel.meetings.first?.transcriptRefinement?.status, .refined)
+    }
+
+    func testStopRecordingAndGenerateSummaryFallsBackToLiveTranscriptWhenRefinementFails() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let summaryProvider = CapturingSummaryProvider(providerName: "test-summary")
+        let refiner = FakePostMeetingTranscriptRefiner()
+        refiner.failureReason = "Deepgram batch unavailable"
+        let target = AudioCaptureTarget(processID: 42, displayName: "Google Meet", bundleIdentifier: "com.google.Chrome")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "en-US",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil
+            ),
+            postMeetingTranscriptRefiner: refiner,
+            summaryProviderFactory: { _ in summaryProvider },
+            processTargetsProvider: { [target] }
+        )
+
+        try await viewModel.startRecording(for: target)
+        fixture.transcriber.emit(.upsert(TranscriptSegment(
+            id: "live-final",
+            text: "We decided from the live transcript.",
+            language: "en-US",
+            sourceProvider: "deepgram-transcribe"
+        )))
+        try await waitFor { viewModel.selectedMeetingSessionState?.transcript.captionDocument.turns.map(\.id) == ["live-final"] }
+
+        try await viewModel.stopRecordingAndGenerateSummary(at: Date(timeIntervalSince1970: 200))
+
+        XCTAssertEqual(summaryProvider.receivedInputs.first?.transcript.finalTurns.map(\.turnID), ["live-final"])
+        XCTAssertEqual(summaryProvider.receivedInputs.first?.transcriptSource, .fallback(reason: "Deepgram batch unavailable"))
+        XCTAssertEqual(viewModel.meetings.first?.transcriptRefinement?.status, .failed)
+        XCTAssertEqual(viewModel.statusText, "Summary generated")
+    }
+
+    func testStopRecordingAndGenerateSummaryFailsClearlyWithoutTranscript() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let summaryProvider = CapturingSummaryProvider(providerName: "test-summary")
+        let refiner = FakePostMeetingTranscriptRefiner()
+        refiner.failureReason = "Deepgram batch unavailable"
+        let target = AudioCaptureTarget(processID: 42, displayName: "Google Meet", bundleIdentifier: "com.google.Chrome")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "en-US",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil
+            ),
+            postMeetingTranscriptRefiner: refiner,
+            summaryProviderFactory: { _ in summaryProvider },
+            processTargetsProvider: { [target] }
+        )
+
+        try await viewModel.startRecording(for: target)
+        try await viewModel.stopRecordingAndGenerateSummary(at: Date(timeIntervalSince1970: 200))
+
+        let summary = try MeetingSummaryWriter.read(from: XCTUnwrap(viewModel.meetings.first?.summaryJSONURL))
+        XCTAssertEqual(summary.status, .failed)
+        XCTAssertEqual(summary.failureReason, "No transcript is available for summary generation")
+        XCTAssertEqual(summaryProvider.receivedInputs.first?.transcript.finalTurns, [])
+        XCTAssertEqual(summaryProvider.receivedInputs.first?.transcriptSource, .fallback(reason: "Deepgram batch unavailable"))
+        XCTAssertEqual(viewModel.statusText, "Summary failed")
+    }
+
+    func testStopRecordingAndGenerateSummaryReportsRefinementAndSummaryStatusOrder() async throws {
+        let fixture = try ViewModelRecorderFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        var statusSnapshots: [String] = []
+        let summaryProvider = CapturingSummaryProvider(providerName: "test-summary")
+        let refiner = FakePostMeetingTranscriptRefiner()
+        refiner.document = summaryCaptionDocument([
+            TranscriptSegment(
+                id: "refined-final",
+                text: "We decided to launch with refined transcript.",
+                language: "en-US",
+                sourceProvider: "deepgram-batch-transcribe"
+            )
+        ])
+        let target = AudioCaptureTarget(processID: 42, displayName: "Google Meet", bundleIdentifier: "com.google.Chrome")
+        let viewModel = MeetingAgentViewModel(
+            store: fixture.store,
+            recorder: fixture.recorder,
+            speechConfiguration: SpeechTranscriptionConfiguration(
+                provider: .whisper,
+                localeIdentifier: "en-US",
+                whisperBinaryPath: nil,
+                whisperModelPath: nil,
+                transcriptionExecutionMode: .hosted,
+                hostedTranscriptionProviderID: "deepgram-transcribe",
+                deepgramAPIKey: "key"
+            ),
+            postMeetingTranscriptRefiner: refiner,
+            summaryProviderFactory: { _ in summaryProvider },
+            processTargetsProvider: { [target] }
+        )
+        refiner.onRefine = { statusSnapshots.append(viewModel.statusText) }
+        summaryProvider.onGenerate = { _ in statusSnapshots.append(viewModel.statusText) }
+
+        try await viewModel.startRecording(for: target)
+        try await viewModel.stopRecordingAndGenerateSummary(at: Date(timeIntervalSince1970: 200))
+        statusSnapshots.append(viewModel.statusText)
+
+        XCTAssertEqual(statusSnapshots, [
+            "Refining transcript",
+            "Generating summary",
+            "Summary generated"
+        ])
     }
 
     func testStopRecordingRefinementFailureKeepsLiveTranscript() async throws {
@@ -3451,6 +3567,8 @@ private final class ViewModelFakeTranscriberFactory {
 
 private final class FakePostMeetingTranscriptRefiner: PostMeetingTranscriptRefining {
     var document: CaptionDocument?
+    var failureReason = "fake failure"
+    var onRefine: (() -> Void)?
     private(set) var requests: [MeetingRecord] = []
 
     func refineTranscript(
@@ -3459,6 +3577,7 @@ private final class FakePostMeetingTranscriptRefiner: PostMeetingTranscriptRefin
         configuration: SpeechTranscriptionConfiguration
     ) async -> PostMeetingTranscriptRefinementResult {
         requests.append(record)
+        onRefine?()
         var updatedRecord = record
         if let document {
             updatedRecord.transcriptRefinement = TranscriptRefinementMetadata(
@@ -3474,7 +3593,7 @@ private final class FakePostMeetingTranscriptRefiner: PostMeetingTranscriptRefin
             providerID: configuration.batchTranscriptionProviderID,
             modelID: configuration.batchTranscriptionModelID,
             status: .failed,
-            failureReason: "fake failure",
+            failureReason: failureReason,
             durationSeconds: 0.1,
             updatedAt: Date(timeIntervalSince1970: 200)
         )
@@ -3484,6 +3603,7 @@ private final class FakePostMeetingTranscriptRefiner: PostMeetingTranscriptRefin
 
 private final class CapturingSummaryProvider: MeetingSummaryProvider {
     let providerName: String
+    var onGenerate: ((MeetingSummaryInput) -> Void)?
     private(set) var receivedInputs: [MeetingSummaryInput] = []
 
     init(providerName: String) {
@@ -3492,8 +3612,26 @@ private final class CapturingSummaryProvider: MeetingSummaryProvider {
 
     func generateSummary(input: MeetingSummaryInput) async throws -> MeetingSummary {
         receivedInputs.append(input)
+        onGenerate?(input)
         let usableTurns = input.transcript.finalTurns.filter {
             !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard !usableTurns.isEmpty else {
+            return MeetingSummary(
+                overview: "",
+                keyTopics: [],
+                decisions: [],
+                actionItems: [],
+                openQuestions: [],
+                risks: [],
+                followUps: [],
+                language: input.language,
+                sourceSegmentIDs: [],
+                generatedAt: input.generatedAt,
+                provider: providerName,
+                status: .failed,
+                failureReason: "No transcript is available for summary generation"
+            )
         }
         let decisions = usableTurns
             .filter { $0.text.lowercased().contains("decided") || $0.text.lowercased().contains("agreed") }

--- a/Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift
+++ b/Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift
@@ -2,6 +2,31 @@ import XCTest
 @testable import MeetingAgentCore
 
 final class MeetingSummaryProviderTests: XCTestCase {
+    func testSummaryInputRetainsTranscriptSourceMetadata() {
+        let fallbackInput = MeetingSummaryInput(
+            meetingName: "Launch Review",
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 200),
+            language: "en-US",
+            meetingGoal: nil,
+            transcript: Self.transcriptView(turns: []),
+            transcriptSource: .fallback(reason: "Deepgram batch unavailable"),
+            generatedAt: Date(timeIntervalSince1970: 300)
+        )
+        let defaultInput = MeetingSummaryInput(
+            meetingName: "Launch Review",
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 200),
+            language: "en-US",
+            meetingGoal: nil,
+            transcript: Self.transcriptView(turns: []),
+            generatedAt: Date(timeIntervalSince1970: 300)
+        )
+
+        XCTAssertEqual(fallbackInput.transcriptSource, .fallback(reason: "Deepgram batch unavailable"))
+        XCTAssertEqual(defaultInput.transcriptSource, .live)
+    }
+
     func testMarkdownRendererOmitsBlankSectionsAndRendersLists() {
         let summary = MeetingSummary(
             overview: " ",
@@ -135,6 +160,7 @@ final class MeetingSummaryProviderTests: XCTestCase {
         XCTAssertTrue(client.requests.first?.messages.first?.content.contains("tags") == true)
         XCTAssertTrue(client.requests.first?.messages.first?.content.contains("2-4") == true)
         XCTAssertTrue(client.requests.first?.messages.last?.content.contains("segment-1") == true)
+        XCTAssertTrue(client.requests.first?.messages.last?.content.contains("Transcript source: live") == true)
     }
 
     func testOpenRouterSummaryPromptUsesConsumptionTurnsWithSourceEvidence() async throws {

--- a/docs/superpowers/plans/2026-05-16-refined-transcript-summary-gate.md
+++ b/docs/superpowers/plans/2026-05-16-refined-transcript-summary-gate.md
@@ -1,0 +1,114 @@
+# Refined Transcript Summary Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ensure stop-and-generate summary waits for post-meeting transcript refinement, falls back clearly, and tells summary providers which transcript source they received.
+
+**Architecture:** Reuse the existing `PostMeetingTranscriptRefining` gate inside `MeetingAgentViewModel`. Add a narrow `MeetingSummaryTranscriptSource` value to `MeetingSummaryInput` so providers and tests can distinguish refined, live, and fallback transcript sources without changing persistence architecture.
+
+**Tech Stack:** Swift 5.9, SwiftUI ViewModel code, XCTest, existing `make test` coverage gate.
+
+---
+
+### Task 1: Summary Input Source Metadata
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingSummary.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that constructs `MeetingSummaryInput` with `.fallback(reason:)` and asserts the value is retained. Also construct a legacy-style input without the new argument and assert it defaults to `.live`.
+
+- [ ] **Step 2: Run focused test**
+
+Run: `swift test --filter MeetingSummaryProviderTests`
+Expected: FAIL because `transcriptSource` does not exist.
+
+- [ ] **Step 3: Implement metadata**
+
+Add:
+
+```swift
+public enum MeetingSummaryTranscriptSource: Equatable {
+    case live
+    case refined
+    case fallback(reason: String)
+}
+```
+
+Then add `public let transcriptSource: MeetingSummaryTranscriptSource` to `MeetingSummaryInput` with a default `.live` initializer argument.
+
+- [ ] **Step 4: Run focused test**
+
+Run: `swift test --filter MeetingSummaryProviderTests`
+Expected: PASS.
+
+### Task 2: ViewModel Refinement Gate Behavior
+
+**Files:**
+- Modify: `Sources/MeetingAgentCore/MeetingAgentViewModel.swift`
+- Test: `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift`
+
+- [ ] **Step 1: Add test helpers**
+
+Add a fake `PostMeetingTranscriptRefining` that records calls and returns configured success or failure results. Add a summary provider assertion hook that captures `MeetingSummaryInput.transcriptSource` and transcript turn text.
+
+- [ ] **Step 2: Add failing success test**
+
+Create a live transcript with text `Live wording`, configure the fake refiner to return a refined caption document with text `Refined wording`, call `stopRecordingAndGenerateSummary`, and assert the summary provider saw `Refined wording` with `.refined`.
+
+- [ ] **Step 3: Add failing fallback test**
+
+Configure the fake refiner to return a failed record with `failureReason = "Deepgram batch unavailable"` and no caption document. Assert the summary provider saw the live text with `.fallback(reason: "Deepgram batch unavailable")`.
+
+- [ ] **Step 4: Add failing empty transcript test**
+
+Stop and generate summary without live or refined turns. Assert the generated summary status is `.failed` and `statusText` is `Summary failed`.
+
+- [ ] **Step 5: Add failing status-ordering test**
+
+Configure a fake refiner and summary provider that capture status snapshots. Assert the observed sequence includes `Refining transcript`, `Generating summary`, and `Summary generated`.
+
+- [ ] **Step 6: Implement status and source derivation**
+
+Set `statusText = "Refining transcript"` before awaiting refinement in `stopRecordingAndGenerateSummary`. Set `statusText = "Generating summary"` before provider generation. Derive source from `MeetingRecord.transcriptRefinement` in a helper:
+
+```swift
+private func summaryTranscriptSource(for meeting: MeetingRecord) -> MeetingSummaryTranscriptSource
+```
+
+Return `.refined` for `.refined`, `.fallback(reason:)` for `.failed`, and `.live` otherwise.
+
+- [ ] **Step 7: Pass metadata to provider**
+
+Pass `transcriptSource: summaryTranscriptSource(for: meeting)` when constructing `MeetingSummaryInput`.
+
+- [ ] **Step 8: Run focused ViewModel tests**
+
+Run: `swift test --filter MeetingAgentViewModelTests`
+Expected: PASS.
+
+### Task 3: Full Verification And Commit
+
+**Files:**
+- Verify changed Swift files and docs.
+
+- [ ] **Step 1: Build**
+
+Run: `swift build --product MeetingAgentApp`
+Expected: PASS.
+
+- [ ] **Step 2: Required test entrypoint**
+
+Run: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/private/tmp/meeting-agent-issue-157-coverage make test`
+Expected: PASS.
+
+- [ ] **Step 3: Commit implementation**
+
+Stage only relevant files:
+
+```bash
+git add Sources/MeetingAgentCore/MeetingSummary.swift Sources/MeetingAgentCore/MeetingAgentViewModel.swift Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift docs/superpowers/specs/2026-05-16-refined-transcript-summary-gate-design.md docs/superpowers/plans/2026-05-16-refined-transcript-summary-gate.md
+git commit -m "feat: gate summaries on transcript refinement (#157)"
+```

--- a/docs/superpowers/specs/2026-05-16-refined-transcript-summary-gate-design.md
+++ b/docs/superpowers/specs/2026-05-16-refined-transcript-summary-gate-design.md
@@ -1,0 +1,73 @@
+# Refined Transcript Summary Gate Design
+
+## Context
+
+Issue #157 asks summary and knowledge generation to wait for post-meeting transcript refinement before consuming transcript text. The current `stopRecordingAndGenerateSummary` path stops recording, flushes the live caption document, invokes post-meeting refinement, and then calls `generateSummary`. The missing product contract is explicit: users and downstream providers cannot tell whether the summary came from the refined batch transcript or from the low-latency live transcript fallback.
+
+Issue #156 added `PostMeetingTranscriptRefining`, `TranscriptRefinementMetadata`, and refined caption document persistence. This design builds on that boundary and keeps summary generation consuming `MeetingSessionState` instead of direct transcript files.
+
+## Goals
+
+- Show a distinct `Refining transcript` status after recording stops and before summary generation.
+- Generate summaries from the refined `MeetingSessionState.transcript` when refinement succeeds.
+- Continue to generate summaries from the live transcript when refinement fails.
+- Preserve and expose the fallback reason so summary provider input can distinguish refined vs fallback transcript source.
+- Keep empty-transcript behavior explicit: no transcript turns should produce a failed summary, not an empty successful result.
+- Cover success, failure fallback, empty transcript, and status ordering with focused ViewModel tests.
+
+## Non-Goals
+
+- Do not add realtime translation, summary translation, or new caption persistence artifacts.
+- Do not change post-meeting refinement provider selection beyond the existing #156 configuration.
+- Do not make knowledge export automatically trigger refinement; this issue gates the stop-and-generate summary path and makes summary input metadata available for later knowledge consumers.
+
+## Selected Approach
+
+Use the existing refinement service as the gate in `stopRecordingAndGenerateSummary`, then pass transcript source metadata through `MeetingSummaryInput`.
+
+When summary generation starts, `MeetingAgentViewModel` derives a `MeetingSummaryTranscriptSource` from the selected or hydrated session:
+
+- `.refined` when the meeting's `TranscriptRefinementMetadata.status` is `.refined`.
+- `.fallback(reason:)` when metadata is `.failed`, preserving the failure reason.
+- `.live` when no refinement was attempted.
+
+`generateSummary` includes this source in `MeetingSummaryInput`. Providers can consume it immediately, while existing providers remain source-compatible because the field has a default.
+
+## Alternatives Considered
+
+1. Store the source only in `MeetingSummary`.
+   This makes persisted summaries self-describing, but it does not satisfy the provider-input requirement and risks wider Codable compatibility work.
+
+2. Add a dedicated summary-generation method for stopped recordings.
+   This would keep metadata local to one workflow, but it would duplicate summary input construction and make manual summary regeneration less consistent.
+
+3. Selected: add source metadata to `MeetingSummaryInput`.
+   This keeps the contract at the provider boundary and lets existing memory-first summary generation decide source from the current meeting record.
+
+## Data Flow
+
+1. `stopRecordingAndGenerateSummary` stops recording and persists the selected live caption document.
+2. The ViewModel sets `statusText` to `Refining transcript`.
+3. `PostMeetingTranscriptRefining.refineTranscript` runs.
+4. On success, `applyPostMeetingTranscriptRefinementResult` updates the selected session transcript to the refined caption document.
+5. On failure, the selected session transcript remains the persisted live fallback and the meeting record stores the failure reason.
+6. `generateSummary` sets `statusText` to `Generating summary`.
+7. `MeetingSummaryInput` carries `transcriptSource`.
+8. The summary provider generates a succeeded or failed summary from the memory-backed `TranscriptConsumptionView`.
+
+## Error Handling
+
+Refinement failures are non-fatal for summary generation if a live transcript exists. The fallback reason comes from `TranscriptRefinementMetadata.failureReason`, with a generic fallback only if metadata is incomplete.
+
+If the transcript consumption view has no turns, `generateSummary` still delegates to the existing summary provider path so provider-owned empty-input behavior is preserved. Tests assert this produces a failed summary rather than an empty success.
+
+## Testing
+
+Add focused `MeetingAgentViewModelTests` coverage:
+
+- refinement success replaces live turns before summary input is captured;
+- refinement failure leaves live turns in use and passes fallback source metadata;
+- no transcript after stop produces a failed summary;
+- status transitions include `Refining transcript`, `Generating summary`, and `Summary generated`.
+
+Existing provider tests get a small Codable/default-argument regression for `MeetingSummaryInput.transcriptSource` if needed.


### PR DESCRIPTION
## Summary

Fixes #157

- Waits for post-meeting transcript refinement before stop-and-generate summary proceeds.
- Falls back to live transcript when refinement fails and passes the fallback reason through summary input metadata.
- Adds explicit status transitions for refinement and summary generation, plus failed-summary handling for empty transcript input.

## Changes

- `Sources/MeetingAgentCore/MeetingAgentViewModel.swift` - adds the refinement status gate and derives refined/live/fallback summary transcript source metadata.
- `Sources/MeetingAgentCore/MeetingSummary.swift` - adds `MeetingSummaryTranscriptSource` to `MeetingSummaryInput`.
- `Sources/MeetingAgentCore/OpenRouterMeetingSummaryProvider.swift` - includes transcript source metadata in the summary prompt and fails clearly on empty transcript input.
- `Tests/MeetingAgentCoreTests/MeetingAgentViewModelTests.swift` - covers refined success, fallback, empty transcript failure, and status ordering.
- `Tests/MeetingAgentCoreTests/MeetingSummaryProviderTests.swift` - covers summary input source metadata and prompt inclusion.
- `docs/superpowers/specs/2026-05-16-refined-transcript-summary-gate-design.md` and `docs/superpowers/plans/2026-05-16-refined-transcript-summary-gate.md` - captured the approved design and plan.

## Test plan

- [x] Build: `swift build --product MeetingAgentApp` passed.
- [x] Unit tests: `swift test --filter MeetingSummaryProviderTests` passed.
- [x] Unit tests: `swift test --filter MeetingAgentViewModelTests` passed.
- [x] Required verification: `MEETING_AGENT_COVERAGE_SCRATCH_PATH=/private/tmp/meeting-agent-issue-157-coverage make test` passed: 731 tests, line coverage 95.30%, method coverage 94.11%.
- [x] E2E/integration: skipped; no E2E convention or UI automation surface needed for this ViewModel/provider-boundary change.
- [x] Code review: PASS via manual Swift review; plovr code-review skill only supports TypeScript/Java.

## Notes

`make test` initially failed inside the filesystem sandbox because SwiftPM invokes macOS `sandbox-exec`; the same command passed after approved escalation.